### PR TITLE
Remove third party prefetch and preconnect

### DIFF
--- a/harness/blank.html
+++ b/harness/blank.html
@@ -17,12 +17,9 @@
 <link rel="dns-prefetch" href="//j.ophan.co.uk"/>
 <link rel="dns-prefetch" href="//ophan.theguardian.com"/>
 <link rel="dns-prefetch" href="//phar.gu-web.net"/>
-<link rel="dns-prefetch" href="//www.google-analytics.com"/>
 <link rel="preconnect" href="https://assets.guim.co.uk/"/>
 <link rel="preconnect" href="https://i.guim.co.uk"/>
 <link rel="preconnect" href="//interactive.guim.co.uk"/>
-<link rel="preconnect" href="//www.google-analytics.com"/>
-<link rel="dns-prefetch" href="//sb.scorecardresearch.com"/>
 <link rel="apple-touch-icon" sizes="152x152" href="https://assets.guim.co.uk/images/favicons/fee5e2d638d1c35f6d501fa397e53329/152x152.png"/>
 <link rel="apple-touch-icon" sizes="144x144" href="https://assets.guim.co.uk/images/favicons/1fe70b29879674433702d5266abcb0d4/144x144.png"/>
 <link rel="apple-touch-icon" sizes="120x120" href="https://assets.guim.co.uk/images/favicons/c58143bd2a5b5426b6256cd90ba6eb47/120x120.png"/>


### PR DESCRIPTION
## What does this change?
Removes 3rd parties from preconnect/prefetch even on the blank atom template. I doubt this makes practical difference to users because this isn't userfacing (as far as I know?) but it's best to not have it in a template that gets copied to other repos.