### PR TITLE
AWS and Apps improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,14 @@ Some things to remember:
 
 <br>
 
+## Apps compatibility
+To ensure maximum compatibility with apps, ensure the following:
+ - Test with the "Android front webview" after starting the `gulp` build. This allows you to preview how the thrasher looks like in the app (without the styles inherited from dotcom).
+ - All assets have a fully qualified URL. For instance `assets/myimage.png` might work on dotcom but it won't work on apps. However `https://interactive.guim.co.uk/atoms/thrashers/2020/10/first-thing-election-special/assets/v/1602172252139/demo.png` will do just fine. 
+
 ## Compiling and Deploying
+
+_Before deploying you'll need to pull credentials from Janus for the `interactives` account_
 
 To push your thrasher to preview (pushes to a bucket in CAPI preview) run:
 

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -23,6 +23,7 @@ const ws = require('webpack-stream')
 const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
 const mkdirp = require("mkdirp")
 const rp = require("request-promise")
+const AWS = require('aws-sdk');
 
 const isDeploy = gutil.env._.indexOf('deploylive') > -1 || gutil.env._.indexOf('deploypreview') > -1
 const live = gutil.env._.indexOf('deploylive') > -1
@@ -199,8 +200,13 @@ const serve = () => {
   watch(["atoms/**/*.scss","shared/**/*.scss"], series(buildCSS, local))
 }
 
+const awsCredentials = new AWS.CredentialProviderChain([
+    function() { return new AWS.EnvironmentCredentials('AWS')},
+    function() { return new AWS.SharedIniFileCredentials({profile: 'interactives'})}
+]);
+
 const s3Upload = (cacheControl, keyPrefix) => {
-  return s3()({
+  return s3({credentialProvider: awsCredentials})({
       'Bucket': 'gdn-cdn',
       'ACL': 'public-read',
       'CacheControl': cacheControl,

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -1,6 +1,5 @@
 const { series, dest, src, parallel, watch } = require("gulp");
 const del = require("del");
-const tap = require("gulp-tap");
 const gutil = require("gulp-util");
 const rename = require("gulp-rename");
 const requireUncached = require("require-uncached");
@@ -11,11 +10,9 @@ const replace = require('gulp-replace');
 const sass = require("gulp-sass");
 const file = require("gulp-file");
 sass.compiler = require("node-sass");
-const browserSync = require("browser-sync");3
+const browserSync = require("browser-sync");
 const browser = browserSync.create();
-const uglify = require("gulp-uglify")
 const cleanCSS = require('gulp-clean-css');
-const es = require('event-stream');
 const mergeStream = require('merge-stream');
 const config = require("./config.json")
 const path = require("path")
@@ -120,7 +117,7 @@ const buildJS = () => {
     })
     .pipe(rename((path) => {
       path.dirname = path.dirname.replace(/client/g, "");
-    })) 
+    }))
     .pipe(replace('<%= path %>', assetPath))
     .pipe(dest(".build/"));
 }
@@ -168,11 +165,11 @@ const _template = (x) => {
 const local = () => {
   const atoms = getAtoms();
 
-  const atomPromises = atoms.map(atom => { 
+  const atomPromises = atoms.map(atom => {
     const js = _template((fs.readFileSync(`.build/${atom}/main.js`)).toString());
     const css = _template((fs.readFileSync(`.build/${atom}/main.css`)).toString());
     const html = _template((fs.readFileSync(`.build/${atom}/main.html`)).toString());
-    
+
     return src(["harness/*", "!harness/_index.html"])
       .pipe(template({js,css,html,atom,version}))
       .pipe(dest(".build/" + atom))
@@ -244,7 +241,7 @@ const upload = () => {
     src(`.build/assets/**/*`)
         .pipe(s3Upload('max-age=31536000', `${s3Path}/assets/${version}`))
   );
-  
+
   return mergeStream(uploadTasks)
 }
 


### PR DESCRIPTION
Hey 👋 

I've noticed it wasn't possible to use the credentials as generated by Janus and that we had to always "Export to shell".

This isn't great as if you inadvertently close your terminal, or if you have to work on more than one AWS account in the same day it becomes quite combersome.

Now you can use the default option provided by Janus, and you don't have to copy paste new credentials each time you close your terminal, but if habits die hards, you can still export to shell and it will work anyway.
![image](https://user-images.githubusercontent.com/3389563/95609941-6fdb2f00-0a57-11eb-8281-5b81f11f2b29.png)
