### PR TITLE
fix: add alt attrs to imgs (football multi-newsletters)

### DIFF
--- a/atoms/default/server/templates/main.html
+++ b/atoms/default/server/templates/main.html
@@ -7,7 +7,7 @@
 
         <aside class="multi-thrasher__aside">
             <img class="multi-thrasher__aside-image" src="<%= path %>/the-guardian-newsletters.png"
-                alt="The Guardian Newsletters" height="22.3" width="150" />
+                alt="The Guardian Newsletters logo" height="22.3" width="150" />
             <a class="multi-thrasher__aside-link" href="https://www.theguardian.com/email-newsletters">Explore all
                 newsletters</a>
         </aside>
@@ -19,7 +19,7 @@
                         <h2 class="newsletter-card__title">The Fiver</h2>
                     
                         <div class="newsletter-card__inner">
-                            <img class="newsletter-card__image" src="<%= path %>/the-fiver-square.png" alt="The Fiver newsletter" height="100" width="100">
+                            <img class="newsletter-card__image" src="<%= path %>/the-fiver-square.png" alt="The Fiver newsletter image" height="100" width="100">
                             <div class="newsletter-card__content">
                                 <div class="newsletter-card__frequency-block">
                                     <svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -51,7 +51,7 @@
                         <h2 class="newsletter-card__title">Moving the Goalposts</h2>
                     
                         <div class="newsletter-card__inner">
-                            <img class="newsletter-card__image" src="<%= path %>/moving-the-goalposts-square.png" alt="Moving the Goalposts newsletter" height="100" width="100">
+                            <img class="newsletter-card__image" src="<%= path %>/moving-the-goalposts-square.png" alt="Moving the Goalposts newsletter image" height="100" width="100">
                             <div class="newsletter-card__content">
                                 <div class="newsletter-card__frequency-block">
                                     <svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -83,7 +83,7 @@
                         <h2 class="newsletter-card__title">The Recap</h2>
                     
                         <div class="newsletter-card__inner">
-                            <img class="newsletter-card__image" src="<%= path %>/recap-square.png" alt="The Recap newsletter" height="100" width="100">
+                            <img class="newsletter-card__image" src="<%= path %>/recap-square.png" alt="The Recap newsletter image" height="100" width="100">
                             <div class="newsletter-card__content">
                                 <div class="newsletter-card__frequency-block">
                                     <svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -126,7 +126,7 @@
             </section>
             <section class="multi-thrasher__section multi-thrasher__section--mobile-footer">
                 <img class="multi-thrasher__footer-image" src="<%= path %>/the-guardian-newsletters.png"
-                    alt="The Guardian Newsletters" height="22.3" width="70" />
+                    alt="The Guardian Newsletters logo" height="22.3" width="70" />
             </section>
 
         </div>


### PR DESCRIPTION
## What does this change?

Adds `alt` attributes to the `<img>` tags in the multi newsletter football thrasher which previously had them omitted.
`alt` attributes contain the names of the newsletters that their image card represents
