### PR TITLE
fix: add alt attrs to imgs (culture multi-newsletters)

### DIFF
--- a/atoms/default/server/templates/main.html
+++ b/atoms/default/server/templates/main.html
@@ -7,7 +7,7 @@
 
         <aside class="multi-thrasher__aside">
             <img class="multi-thrasher__aside-image" src="<%= path %>/the-guardian-newsletters.png"
-                alt="The Guardian Newsletters" height="22.3" width="150" />
+                alt="The Guardian Newsletters logo" height="22.3" width="150" />
             <a class="multi-thrasher__aside-link" href="https://www.theguardian.com/email-newsletters">Explore all
                 newsletters</a>
         </aside>
@@ -20,7 +20,7 @@
                     <article class="newsletter-card" style="background-color:#e7d4b9; color:#000">
                         <h2 class="newsletter-card__title">The Guide</h2>
                         <div class="newsletter-card__inner">
-                            <img class="newsletter-card__image" src="<%= path %>/the-guide-square.png" alt="The Guide newsletter" height="100" width="100">
+                            <img class="newsletter-card__image" src="<%= path %>/the-guide-square.png" alt="The Guide newsletter image" height="100" width="100">
                             <div class="newsletter-card__content">
                                 <div class="newsletter-card__frequency-block">
                                     <svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -53,7 +53,7 @@
                         <h2 class="newsletter-card__title">Hear Here</h2>
                     
                         <div class="newsletter-card__inner">
-                            <img class="newsletter-card__image" src="<%= path %>/hear-here-square.png" alt="Hear Here newsletter" height="100" width="100">
+                            <img class="newsletter-card__image" src="<%= path %>/hear-here-square.png" alt="Hear Here newsletter image" height="100" width="100">
                             <div class="newsletter-card__content">
                                 <div class="newsletter-card__frequency-block">
                                     <svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -86,7 +86,7 @@
                         <h2 class="newsletter-card__title">Pushing Buttons</h2>
                     
                         <div class="newsletter-card__inner">
-                            <img class="newsletter-card__image" src="<%= path %>/pushing-buttons-square.png" alt="Pushing Buttons newsletter"height="100" width="100">
+                            <img class="newsletter-card__image" src="<%= path %>/pushing-buttons-square.png" alt="Pushing Buttons newsletter image"height="100" width="100">
                             <div class="newsletter-card__content">
                                 <div class="newsletter-card__frequency-block">
                                     <svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -119,7 +119,7 @@
                         <h2 class="newsletter-card__title">Film Weekly</h2>
                     
                         <div class="newsletter-card__inner">
-                            <img class="newsletter-card__image" src="<%= path %>/film-weekly-square.png" alt="Film Weekly newsletter" height="100" width="100">
+                            <img class="newsletter-card__image" src="<%= path %>/film-weekly-square.png" alt="Film Weekly newsletter image" height="100" width="100">
                             <div class="newsletter-card__content">
                                 <div class="newsletter-card__frequency-block">
                                     <svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -152,7 +152,7 @@
                         <h2 class="newsletter-card__title">Bookmarks</h2>
                     
                         <div class="newsletter-card__inner">
-                            <img class="newsletter-card__image" src="<%= path %>/bookmarks-square.png" alt="Bookmarks newsletter" height="100" width="100">
+                            <img class="newsletter-card__image" src="<%= path %>/bookmarks-square.png" alt="Bookmarks newsletter image" height="100" width="100">
                             <div class="newsletter-card__content">
                                 <div class="newsletter-card__frequency-block">
                                     <svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -185,7 +185,7 @@
                         <h2 class="newsletter-card__title">Sleeve Notes</h2>
                     
                         <div class="newsletter-card__inner">
-                            <img class="newsletter-card__image" src="<%= path %>/sleeve-notes-square.png" alt="Sleeve Notes newsletter" height="100" width="100">
+                            <img class="newsletter-card__image" src="<%= path %>/sleeve-notes-square.png" alt="Sleeve Notes newsletter image" height="100" width="100">
                             <div class="newsletter-card__content">
                                 <div class="newsletter-card__frequency-block">
                                     <svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -227,7 +227,7 @@
             </section>
             <section class="multi-thrasher__section multi-thrasher__section--mobile-footer">
                 <img class="multi-thrasher__footer-image" src="<%= path %>/the-guardian-newsletters.png"
-                    alt="The Guardian Newsletters" height="22.3" width="70" />
+                    alt="The Guardian Newsletters logo" height="22.3" width="70" />
             </section>
 
         </div>


### PR DESCRIPTION
## What does this change?

Adds `alt` attributes to the `<img>` tags in the multi newsletter culture thrasher which previously had them omitted.
`alt` attributes contain the names of the newsletters that their image card represents