### PR TITLE
fix: add alt attrs to imgs (general multi-newsletters)

### DIFF
--- a/atoms/default/server/templates/main.html
+++ b/atoms/default/server/templates/main.html
@@ -7,7 +7,7 @@
 
         <aside class="multi-thrasher__aside">
             <img class="multi-thrasher__aside-image" src="<%= path %>/the-guardian-newsletters.png"
-                alt="The Guardian Newsletters" height="22.3" width="150" />
+                alt="The Guardian Newsletters logo" height="22.3" width="150" />
             <a class="multi-thrasher__aside-link" href="https://www.theguardian.com/email-newsletters">Explore all
                 newsletters</a>
         </aside>
@@ -19,7 +19,7 @@
                         <h2 class="newsletter-card__title">Pushing Buttons</h2>
                     
                         <div class="newsletter-card__inner">
-                            <img class="newsletter-card__image" src="<%= path %>/pushing-buttons-square.png" alt="Pushing Buttons newsletter" height="100" width="100">
+                            <img class="newsletter-card__image" src="<%= path %>/pushing-buttons-square.png" alt="Pushing Buttons newsletter image" height="100" width="100">
                             <div class="newsletter-card__content">
                                 <div class="newsletter-card__frequency-block">
                                     <svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -50,7 +50,7 @@
                         <h2 class="newsletter-card__title">First Edition</h2>
                     
                         <div class="newsletter-card__inner">
-                            <img class="newsletter-card__image" src="<%= path %>/first-edition-square.png" alt="First Edition newsletter" height="100" width="100">
+                            <img class="newsletter-card__image" src="<%= path %>/first-edition-square.png" alt="First Edition newsletter image" height="100" width="100">
                             <div class="newsletter-card__content">
                                 <div class="newsletter-card__frequency-block">
                                     <svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -81,7 +81,7 @@
                         <h2 class="newsletter-card__title">The Long Read</h2>
                     
                         <div class="newsletter-card__inner">
-                            <img class="newsletter-card__image" src="<%= path %>/long-read-square.png" alt="The Long Read newsletter" height="100" width="100">
+                            <img class="newsletter-card__image" src="<%= path %>/long-read-square.png" alt="The Long Read newsletter image" height="100" width="100">
                             <div class="newsletter-card__content">
                                 <div class="newsletter-card__frequency-block">
                                     <svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -122,7 +122,7 @@
             </section>
             <section class="multi-thrasher__section multi-thrasher__section--mobile-footer">
                 <img class="multi-thrasher__footer-image" src="<%= path %>/the-guardian-newsletters.png"
-                    alt="The Guardian Newsletters" height="22.3" width="70" />
+                    alt="The Guardian Newsletters logo" height="22.3" width="70" />
             </section>
 
         </div>

--- a/atoms/set-2/server/templates/main.html
+++ b/atoms/set-2/server/templates/main.html
@@ -7,7 +7,7 @@
 
         <aside class="multi-thrasher__aside">
             <img class="multi-thrasher__aside-image" src="<%= path %>/the-guardian-newsletters.png"
-                alt="The Guardian Newsletters" height="22.3" width="150" />
+                alt="The Guardian Newsletters logo" height="22.3" width="150" />
             <a class="multi-thrasher__aside-link" href="https://www.theguardian.com/email-newsletters">Explore all
                 newsletters</a>
         </aside>
@@ -19,7 +19,7 @@
                         <h2 class="newsletter-card__title">TechScape</h2>
                     
                         <div class="newsletter-card__inner">
-                            <img class="newsletter-card__image" src="<%= path %>/techscape-square.png" height="100" width="100">
+                            <img class="newsletter-card__image" src="<%= path %>/techscape-square.png" alt="TechScape newsletter image" height="100" width="100">
                             <div class="newsletter-card__content">
                                 <div class="newsletter-card__frequency-block">
                                     <svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -50,7 +50,7 @@
                         <h2 class="newsletter-card__title">First Edition</h2>
                     
                         <div class="newsletter-card__inner">
-                            <img class="newsletter-card__image" src="<%= path %>/first-edition-square.png" height="100" width="100">
+                            <img class="newsletter-card__image" src="<%= path %>/first-edition-square.png" alt="First Edition newsletter image" height="100" width="100">
                             <div class="newsletter-card__content">
                                 <div class="newsletter-card__frequency-block">
                                     <svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -81,7 +81,7 @@
                         <h2 class="newsletter-card__title">This is Europe</h2>
                     
                         <div class="newsletter-card__inner">
-                            <img class="newsletter-card__image" src="<%= path %>/this-is-europe-square.png" height="100" width="100">
+                            <img class="newsletter-card__image" src="<%= path %>/this-is-europe-square.png" alt="This is Europe newsletter image" height="100" width="100">
                             <div class="newsletter-card__content">
                                 <div class="newsletter-card__frequency-block">
                                     <svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -122,7 +122,7 @@
             </section>
             <section class="multi-thrasher__section multi-thrasher__section--mobile-footer">
                 <img class="multi-thrasher__footer-image" src="<%= path %>/the-guardian-newsletters.png"
-                    alt="The Guardian Newsletters" height="22.3" width="70" />
+                    alt="The Guardian Newsletters logo" height="22.3" width="70" />
             </section>
 
         </div>

--- a/atoms/set-3/server/templates/main.html
+++ b/atoms/set-3/server/templates/main.html
@@ -7,7 +7,7 @@
 
         <aside class="multi-thrasher__aside">
             <img class="multi-thrasher__aside-image" src="<%= path %>/the-guardian-newsletters.png"
-                alt="The Guardian Newsletters" height="22.3" width="150" />
+                alt="The Guardian Newsletters logo" height="22.3" width="150" />
             <a class="multi-thrasher__aside-link" href="https://www.theguardian.com/email-newsletters">Explore all
                 newsletters</a>
         </aside>
@@ -19,7 +19,7 @@
                         <h2 class="newsletter-card__title">Word of Mouth</h2>
                     
                         <div class="newsletter-card__inner">
-                            <img class="newsletter-card__image" src="<%= path %>/word-of-mouth-square.png" height="100" width="100">
+                            <img class="newsletter-card__image" src="<%= path %>/word-of-mouth-square.png" alt="Word of Mouth newsletter image" height="100" width="100">
                             <div class="newsletter-card__content">
                                 <div class="newsletter-card__frequency-block">
                                     <svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -50,7 +50,7 @@
                         <h2 class="newsletter-card__title">Down to Earth</h2>
                     
                         <div class="newsletter-card__inner">
-                            <img class="newsletter-card__image" src="<%= path %>/down-to-earth-square.png" height="100" width="100">
+                            <img class="newsletter-card__image" src="<%= path %>/down-to-earth-square.png" alt="Down to Earth newsletter image" height="100" width="100">
                             <div class="newsletter-card__content">
                                 <div class="newsletter-card__frequency-block">
                                     <svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -81,7 +81,7 @@
                         <h2 class="newsletter-card__title">First Edition</h2>
                     
                         <div class="newsletter-card__inner">
-                            <img class="newsletter-card__image" src="<%= path %>/first-edition-square.png" height="100" width="100">
+                            <img class="newsletter-card__image" src="<%= path %>/first-edition-square.png" alt="First Edition newsletter image" height="100" width="100">
                             <div class="newsletter-card__content">
                                 <div class="newsletter-card__frequency-block">
                                     <svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -122,7 +122,7 @@
             </section>
             <section class="multi-thrasher__section multi-thrasher__section--mobile-footer">
                 <img class="multi-thrasher__footer-image" src="<%= path %>/the-guardian-newsletters.png"
-                    alt="The Guardian Newsletters" height="22.3" width="70" />
+                alt="The Guardian Newsletters logo" height="22.3" width="70" />
             </section>
 
         </div>

--- a/atoms/set-4/server/templates/main.html
+++ b/atoms/set-4/server/templates/main.html
@@ -7,7 +7,7 @@
 
         <aside class="multi-thrasher__aside">
             <img class="multi-thrasher__aside-image" src="<%= path %>/the-guardian-newsletters.png"
-                alt="The Guardian Newsletters" height="22.3" width="150" />
+                alt="The Guardian Newsletters logo" height="22.3" width="150" />
             <a class="multi-thrasher__aside-link" href="https://www.theguardian.com/email-newsletters">Explore all
                 newsletters</a>
         </aside>
@@ -19,7 +19,7 @@
                         <h2 class="newsletter-card__title">First Edition</h2>
                     
                         <div class="newsletter-card__inner">
-                            <img class="newsletter-card__image" src="<%= path %>/first-edition-square.png" height="100" width="100">
+                            <img class="newsletter-card__image" src="<%= path %>/first-edition-square.png" alt="First Edition newsletter image" height="100" width="100">
                             <div class="newsletter-card__content">
                                 <div class="newsletter-card__frequency-block">
                                     <svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -50,7 +50,7 @@
                         <h2 class="newsletter-card__title">Hear Here</h2>
                     
                         <div class="newsletter-card__inner">
-                            <img class="newsletter-card__image" src="<%= path %>/hear-here-square.png" height="100" width="100">
+                            <img class="newsletter-card__image" src="<%= path %>/hear-here-square.png" alt="Hear Here newsletter image" height="100" width="100">
                             <div class="newsletter-card__content">
                                 <div class="newsletter-card__frequency-block">
                                     <svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -81,7 +81,7 @@
                         <h2 class="newsletter-card__title">The Long Read</h2>
                     
                         <div class="newsletter-card__inner">
-                            <img class="newsletter-card__image" src="<%= path %>/long-read-square.png" height="100" width="100">
+                            <img class="newsletter-card__image" src="<%= path %>/long-read-square.png" alt="The Long Read newsletter image" height="100" width="100">
                             <div class="newsletter-card__content">
                                 <div class="newsletter-card__frequency-block">
                                     <svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -122,7 +122,7 @@
             </section>
             <section class="multi-thrasher__section multi-thrasher__section--mobile-footer">
                 <img class="multi-thrasher__footer-image" src="<%= path %>/the-guardian-newsletters.png"
-                    alt="The Guardian Newsletters" height="22.3" width="70" />
+                    alt="The Guardian Newsletters logo" height="22.3" width="70" />
             </section>
 
         </div>

--- a/atoms/set-5/server/templates/main.html
+++ b/atoms/set-5/server/templates/main.html
@@ -7,7 +7,7 @@
 
         <aside class="multi-thrasher__aside">
             <img class="multi-thrasher__aside-image" src="<%= path %>/the-guardian-newsletters.png"
-                alt="The Guardian Newsletters" height="22.3" width="150" />
+                alt="The Guardian Newsletters logo" height="22.3" width="150" />
             <a class="multi-thrasher__aside-link" href="https://www.theguardian.com/email-newsletters">Explore all
                 newsletters</a>
         </aside>
@@ -19,7 +19,7 @@
                         <h2 class="newsletter-card__title">The Guide</h2>
                     
                         <div class="newsletter-card__inner">
-                            <img class="newsletter-card__image" src="<%= path %>/the-guide-square.png" height="100" width="100">
+                            <img class="newsletter-card__image" src="<%= path %>/the-guide-square.png" alt="The Guide newsletter image" height="100" width="100">
                             <div class="newsletter-card__content">
                                 <div class="newsletter-card__frequency-block">
                                     <svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -50,7 +50,7 @@
                         <h2 class="newsletter-card__title">Inside Saturday</h2>
                     
                         <div class="newsletter-card__inner">
-                            <img class="newsletter-card__image" src="<%= path %>/inside-saturday-square.png" height="100" width="100">
+                            <img class="newsletter-card__image" src="<%= path %>/inside-saturday-square.png" alt="Inside Saturday newsletter image" height="100" width="100">
                             <div class="newsletter-card__content">
                                 <div class="newsletter-card__frequency-block">
                                     <svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -81,7 +81,7 @@
                         <h2 class="newsletter-card__title">Her Stage</h2>
                     
                         <div class="newsletter-card__inner">
-                            <img class="newsletter-card__image" src="<%= path %>/her-stage-square.png" height="100" width="100">
+                            <img class="newsletter-card__image" src="<%= path %>/her-stage-square.png" alt="Her Stage newsletter image" height="100" width="100">
                             <div class="newsletter-card__content">
                                 <div class="newsletter-card__frequency-block">
                                     <svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -122,7 +122,7 @@
             </section>
             <section class="multi-thrasher__section multi-thrasher__section--mobile-footer">
                 <img class="multi-thrasher__footer-image" src="<%= path %>/the-guardian-newsletters.png"
-                    alt="The Guardian Newsletters" height="22.3" width="70" />
+                    alt="The Guardian Newsletters logo" height="22.3" width="70" />
             </section>
 
         </div>

--- a/atoms/set-6/server/templates/main.html
+++ b/atoms/set-6/server/templates/main.html
@@ -7,7 +7,7 @@
 
         <aside class="multi-thrasher__aside">
             <img class="multi-thrasher__aside-image" src="<%= path %>/the-guardian-newsletters.png"
-                alt="The Guardian Newsletters" height="22.3" width="150" />
+                alt="The Guardian Newsletters logo" height="22.3" width="150" />
             <a class="multi-thrasher__aside-link" href="https://www.theguardian.com/email-newsletters">Explore all
                 newsletters</a>
         </aside>
@@ -19,7 +19,7 @@
                         <h2 class="newsletter-card__title">Sleeve Notes</h2>
                     
                         <div class="newsletter-card__inner">
-                            <img class="newsletter-card__image" src="<%= path %>/sleeve-notes-square.png" height="100" width="100">
+                            <img class="newsletter-card__image" src="<%= path %>/sleeve-notes-square.png" alt="Sleeve Notes newsletter image" height="100" width="100">
                             <div class="newsletter-card__content">
                                 <div class="newsletter-card__frequency-block">
                                     <svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -50,7 +50,7 @@
                         <h2 class="newsletter-card__title">Film Weekly</h2>
                     
                         <div class="newsletter-card__inner">
-                            <img class="newsletter-card__image" src="<%= path %>/film-weekly-square.png" height="100" width="100">
+                            <img class="newsletter-card__image" src="<%= path %>/film-weekly-square.png" alt="Film Weekly newsletter image" height="100" width="100">
                             <div class="newsletter-card__content">
                                 <div class="newsletter-card__frequency-block">
                                     <svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -81,7 +81,7 @@
                         <h2 class="newsletter-card__title">Bookmarks</h2>
                     
                         <div class="newsletter-card__inner">
-                            <img class="newsletter-card__image" src="<%= path %>/bookmarks-square.png" height="100" width="100">
+                            <img class="newsletter-card__image" src="<%= path %>/bookmarks-square.png" alt="Bookmarks newsletter image" height="100" width="100">
                             <div class="newsletter-card__content">
                                 <div class="newsletter-card__frequency-block">
                                     <svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -122,7 +122,7 @@
             </section>
             <section class="multi-thrasher__section multi-thrasher__section--mobile-footer">
                 <img class="multi-thrasher__footer-image" src="<%= path %>/the-guardian-newsletters.png"
-                    alt="The Guardian Newsletters" height="22.3" width="70" />
+                    alt="The Guardian Newsletters logo" height="22.3" width="70" />
             </section>
 
         </div>

--- a/atoms/set-7/server/templates/main.html
+++ b/atoms/set-7/server/templates/main.html
@@ -7,7 +7,7 @@
 
         <aside class="multi-thrasher__aside">
             <img class="multi-thrasher__aside-image" src="<%= path %>/the-guardian-newsletters.png"
-                alt="The Guardian Newsletters" height="22.3" width="150" />
+                alt="The Guardian Newsletters logo" height="22.3" width="150" />
             <a class="multi-thrasher__aside-link" href="https://www.theguardian.com/email-newsletters">Explore all
                 newsletters</a>
         </aside>
@@ -19,7 +19,7 @@
                         <h2 class="newsletter-card__title">The Fiver</h2>
                     
                         <div class="newsletter-card__inner">
-                            <img class="newsletter-card__image" src="<%= path %>/the-fiver-square.png" height="100" width="100">
+                            <img class="newsletter-card__image" src="<%= path %>/the-fiver-square.png" alt="The Fiver newsletter image" height="100" width="100">
                             <div class="newsletter-card__content">
                                 <div class="newsletter-card__frequency-block">
                                     <svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -50,7 +50,7 @@
                         <h2 class="newsletter-card__title">First Edition</h2>
                     
                         <div class="newsletter-card__inner">
-                            <img class="newsletter-card__image" src="<%= path %>/first-edition-square.png" height="100" width="100">
+                            <img class="newsletter-card__image" src="<%= path %>/first-edition-square.png" alt="First Edition newsletter image" height="100" width="100">
                             <div class="newsletter-card__content">
                                 <div class="newsletter-card__frequency-block">
                                     <svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -81,7 +81,7 @@
                         <h2 class="newsletter-card__title">The Long Read</h2>
                     
                         <div class="newsletter-card__inner">
-                            <img class="newsletter-card__image" src="<%= path %>/long-read-square.png" height="100" width="100">
+                            <img class="newsletter-card__image" src="<%= path %>/long-read-square.png" alt="The Long Read newsletter image" height="100" width="100">
                             <div class="newsletter-card__content">
                                 <div class="newsletter-card__frequency-block">
                                     <svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -122,7 +122,7 @@
             </section>
             <section class="multi-thrasher__section multi-thrasher__section--mobile-footer">
                 <img class="multi-thrasher__footer-image" src="<%= path %>/the-guardian-newsletters.png"
-                    alt="The Guardian Newsletters" height="22.3" width="70" />
+                    alt="The Guardian Newsletters logo" height="22.3" width="70" />
             </section>
 
         </div>


### PR DESCRIPTION
## What does this change?

Adds `alt` attributes to the `<img>` tags in the multi newsletter general thrasher which previously had them omitted.
`alt` attributes contain the names of the newsletters that their image card represents