### PR TITLE
Thrashers/multi newsletters 1  invert result pages

### DIFF
--- a/atoms/default/client/js/app.js
+++ b/atoms/default/client/js/app.js
@@ -16,7 +16,7 @@ function initCardSections() {
       return;
     }
     var lastScrollCheckTime = 0;
-    var lastButtonClickTime = 0
+    var lastButtonClickTime = 0;
     var cardHolder = thrasher.querySelector(
       '[data-role="multi-thrasher-card-holder"]'
     );
@@ -63,7 +63,7 @@ function initCardSections() {
     }
     function scrollLeft() {
       var intendedPosition = cardHolder.scrollLeft - getScrollDistance();
-      lastButtonClickTime = Date.now()
+      lastButtonClickTime = Date.now();
       cardHolder.scrollTo({
         left: intendedPosition,
         top: 0,
@@ -73,7 +73,7 @@ function initCardSections() {
     }
     function scrollRight() {
       var intendedPosition = cardHolder.scrollLeft + getScrollDistance();
-      lastButtonClickTime = Date.now()
+      lastButtonClickTime = Date.now();
       cardHolder.scrollTo({
         left: intendedPosition,
         top: 0,
@@ -84,14 +84,14 @@ function initCardSections() {
 
     function throttledSetDisabled(event) {
       var now = Date.now();
-      var sinceLastCheck = now - lastScrollCheckTime
-      var sinceLastButtonClick = now - lastButtonClickTime
+      var sinceLastCheck = now - lastScrollCheckTime;
+      var sinceLastButtonClick = now - lastButtonClickTime;
 
       if (sinceLastCheck > 100 && sinceLastButtonClick > 2000) {
         lastScrollCheckTime = now;
-        window.setTimeout(function() {
-          setDisabled(cardHolder.scrollLeft)
-        }, 100)
+        window.setTimeout(function () {
+          setDisabled(cardHolder.scrollLeft);
+        }, 100);
       }
     }
 
@@ -110,4 +110,35 @@ function initCardSections() {
   });
 }
 
+function invertColorOnIframeResultPages(event) {
+  if (!event.data.subject || event.data.subject !== "emailEmbedPageLoaded") {
+    return;
+  }
+  if (!event.data.path || typeof event.data.path !== "string") {
+    return;
+  }
+  if (
+    !event.data.path.startsWith("/email/error") &&
+    !event.data.path.startsWith("/email/success")
+  ) {
+    return;
+  }
+  if (event.origin !== window.origin) {
+    console.warn('emailEmbedPageLoaded received from wrong origin:', event.origin)
+    return;
+  }
+  var iframesOnDarkBackgrounds = [
+    ...document.querySelectorAll(
+      ".newsletter-card__iframe-wrapper iframe.invert-colors"
+    ),
+  ];
+
+  iframesOnDarkBackgrounds.forEach(function (iframe) {
+    if (iframe.contentWindow === event.source) {
+      iframe.style.filter = "invert(1)";
+    }
+  });
+}
+
+window.addEventListener("message", invertColorOnIframeResultPages, false);
 initCardSections();

--- a/atoms/default/server/templates/main.html
+++ b/atoms/default/server/templates/main.html
@@ -43,7 +43,7 @@
                             data-form-description="Keza MacDonald&#x27;s weekly look at the world of gaming" 
                             data-form-campaign-code="pushing_buttons "
                             scrolling="no" seamless="" frameborder="0" 
-                            class="iframed--overflow-hidden email-sub__iframe js-email-sub__iframe js-email-sub__iframe--article" 
+                            class="iframed--overflow-hidden email-sub__iframe js-email-sub__iframe js-email-sub__iframe--article invert-colors" 
                             data-form-success-desc="Thanks for subscribing!" 
                             title="Sign up for Pushing Buttons"></iframe>    </div>
                     </article><article class="newsletter-card" style="background-color:#8fdcfe; color:#000">

--- a/atoms/set-2/client/js/app.js
+++ b/atoms/set-2/client/js/app.js
@@ -110,4 +110,35 @@ function initCardSections() {
   });
 }
 
+function invertColorOnIframeResultPages(event) {
+  if (!event.data.subject || event.data.subject !== "emailEmbedPageLoaded") {
+    return;
+  }
+  if (!event.data.path || typeof event.data.path !== "string") {
+    return;
+  }
+  if (
+    !event.data.path.startsWith("/email/error") &&
+    !event.data.path.startsWith("/email/success")
+  ) {
+    return;
+  }
+  if (event.origin !== window.origin) {
+    console.warn('emailEmbedPageLoaded received from wrong origin:', event.origin)
+    return;
+  }
+  var iframesOnDarkBackgrounds = [
+    ...document.querySelectorAll(
+      ".newsletter-card__iframe-wrapper iframe.invert-colors"
+    ),
+  ];
+
+  iframesOnDarkBackgrounds.forEach(function (iframe) {
+    if (iframe.contentWindow === event.source) {
+      iframe.style.filter = "invert(1)";
+    }
+  });
+}
+
+window.addEventListener("message", invertColorOnIframeResultPages, false);
 initCardSections();

--- a/atoms/set-2/server/templates/main.html
+++ b/atoms/set-2/server/templates/main.html
@@ -105,7 +105,7 @@
                             data-form-description="The most pressing stories and debates for Europeans – from identity to economics to the environment" 
                             data-form-campaign-code="thisiseurope_email "
                             scrolling="no" seamless="" frameborder="0" 
-                            class="iframed--overflow-hidden email-sub__iframe js-email-sub__iframe js-email-sub__iframe--article" 
+                            class="iframed--overflow-hidden email-sub__iframe js-email-sub__iframe js-email-sub__iframe--article invert-colors" 
                             data-form-success-desc="We&#x27;ll send you This is Europe every week" 
                             title="Sign up for This is Europe"></iframe>    </div>
                     </article>                </div>

--- a/atoms/set-3/client/js/app.js
+++ b/atoms/set-3/client/js/app.js
@@ -110,4 +110,35 @@ function initCardSections() {
   });
 }
 
+function invertColorOnIframeResultPages(event) {
+  if (!event.data.subject || event.data.subject !== "emailEmbedPageLoaded") {
+    return;
+  }
+  if (!event.data.path || typeof event.data.path !== "string") {
+    return;
+  }
+  if (
+    !event.data.path.startsWith("/email/error") &&
+    !event.data.path.startsWith("/email/success")
+  ) {
+    return;
+  }
+  if (event.origin !== window.origin) {
+    console.warn('emailEmbedPageLoaded received from wrong origin:', event.origin)
+    return;
+  }
+  var iframesOnDarkBackgrounds = [
+    ...document.querySelectorAll(
+      ".newsletter-card__iframe-wrapper iframe.invert-colors"
+    ),
+  ];
+
+  iframesOnDarkBackgrounds.forEach(function (iframe) {
+    if (iframe.contentWindow === event.source) {
+      iframe.style.filter = "invert(1)";
+    }
+  });
+}
+
+window.addEventListener("message", invertColorOnIframeResultPages, false);
 initCardSections();

--- a/atoms/set-3/server/templates/main.html
+++ b/atoms/set-3/server/templates/main.html
@@ -43,7 +43,7 @@
                             data-form-description="Recipes from all our star cooks, seasonal eating ideas and restaurant reviews. Get our best food writing every week" 
                             data-form-campaign-code="wordofmouth_email "
                             scrolling="no" seamless="" frameborder="0" 
-                            class="iframed--overflow-hidden email-sub__iframe js-email-sub__iframe js-email-sub__iframe--article" 
+                            class="iframed--overflow-hidden email-sub__iframe js-email-sub__iframe js-email-sub__iframe--article invert-colors" 
                             data-form-success-desc="We&#x27;ll send you Word of Mouth every week" 
                             title="Sign up for Word of Mouth"></iframe>    </div>
                     </article><article class="newsletter-card" style="background-color:#22874D; color:#fff">
@@ -74,7 +74,7 @@
                             data-form-description="The planet&#x27;s most important stories. Get all the week&#x27;s environment news - the good, the bad and the essential" 
                             data-form-campaign-code="greenlight_email "
                             scrolling="no" seamless="" frameborder="0" 
-                            class="iframed--overflow-hidden email-sub__iframe js-email-sub__iframe js-email-sub__iframe--article" 
+                            class="iframed--overflow-hidden email-sub__iframe js-email-sub__iframe js-email-sub__iframe--article invert-colors" 
                             data-form-success-desc="We&#x27;ll send you Down to Earth every week." 
                             title="Sign up for Down to Earth"></iframe>    </div>
                     </article><article class="newsletter-card" style="background-color:#8fdcfe; color:#000">

--- a/atoms/set-4/client/js/app.js
+++ b/atoms/set-4/client/js/app.js
@@ -110,4 +110,35 @@ function initCardSections() {
   });
 }
 
+function invertColorOnIframeResultPages(event) {
+  if (!event.data.subject || event.data.subject !== "emailEmbedPageLoaded") {
+    return;
+  }
+  if (!event.data.path || typeof event.data.path !== "string") {
+    return;
+  }
+  if (
+    !event.data.path.startsWith("/email/error") &&
+    !event.data.path.startsWith("/email/success")
+  ) {
+    return;
+  }
+  if (event.origin !== window.origin) {
+    console.warn('emailEmbedPageLoaded received from wrong origin:', event.origin)
+    return;
+  }
+  var iframesOnDarkBackgrounds = [
+    ...document.querySelectorAll(
+      ".newsletter-card__iframe-wrapper iframe.invert-colors"
+    ),
+  ];
+
+  iframesOnDarkBackgrounds.forEach(function (iframe) {
+    if (iframe.contentWindow === event.source) {
+      iframe.style.filter = "invert(1)";
+    }
+  });
+}
+
+window.addEventListener("message", invertColorOnIframeResultPages, false);
 initCardSections();

--- a/atoms/set-4/server/templates/main.html
+++ b/atoms/set-4/server/templates/main.html
@@ -74,7 +74,7 @@
                             data-form-description="Podcast recommendations for unexpected audio pleasures. Our reviewers and audio producers pick the week&#x27;s top shows" 
                             data-form-campaign-code="hearhere_email "
                             scrolling="no" seamless="" frameborder="0" 
-                            class="iframed--overflow-hidden email-sub__iframe js-email-sub__iframe js-email-sub__iframe--article" 
+                            class="iframed--overflow-hidden email-sub__iframe js-email-sub__iframe js-email-sub__iframe--article invert-colors" 
                             data-form-success-desc="We&#x27;ll send you Hear Here every week" 
                             title="Sign up for Hear Here"></iframe>    </div>
                     </article><article class="newsletter-card" style="background-color:#F2DFD0; color:#000">

--- a/atoms/set-5/client/js/app.js
+++ b/atoms/set-5/client/js/app.js
@@ -110,4 +110,35 @@ function initCardSections() {
   });
 }
 
+function invertColorOnIframeResultPages(event) {
+  if (!event.data.subject || event.data.subject !== "emailEmbedPageLoaded") {
+    return;
+  }
+  if (!event.data.path || typeof event.data.path !== "string") {
+    return;
+  }
+  if (
+    !event.data.path.startsWith("/email/error") &&
+    !event.data.path.startsWith("/email/success")
+  ) {
+    return;
+  }
+  if (event.origin !== window.origin) {
+    console.warn('emailEmbedPageLoaded received from wrong origin:', event.origin)
+    return;
+  }
+  var iframesOnDarkBackgrounds = [
+    ...document.querySelectorAll(
+      ".newsletter-card__iframe-wrapper iframe.invert-colors"
+    ),
+  ];
+
+  iframesOnDarkBackgrounds.forEach(function (iframe) {
+    if (iframe.contentWindow === event.source) {
+      iframe.style.filter = "invert(1)";
+    }
+  });
+}
+
+window.addEventListener("message", invertColorOnIframeResultPages, false);
 initCardSections();

--- a/atoms/set-6/client/js/app.js
+++ b/atoms/set-6/client/js/app.js
@@ -110,4 +110,35 @@ function initCardSections() {
   });
 }
 
+function invertColorOnIframeResultPages(event) {
+  if (!event.data.subject || event.data.subject !== "emailEmbedPageLoaded") {
+    return;
+  }
+  if (!event.data.path || typeof event.data.path !== "string") {
+    return;
+  }
+  if (
+    !event.data.path.startsWith("/email/error") &&
+    !event.data.path.startsWith("/email/success")
+  ) {
+    return;
+  }
+  if (event.origin !== window.origin) {
+    console.warn('emailEmbedPageLoaded received from wrong origin:', event.origin)
+    return;
+  }
+  var iframesOnDarkBackgrounds = [
+    ...document.querySelectorAll(
+      ".newsletter-card__iframe-wrapper iframe.invert-colors"
+    ),
+  ];
+
+  iframesOnDarkBackgrounds.forEach(function (iframe) {
+    if (iframe.contentWindow === event.source) {
+      iframe.style.filter = "invert(1)";
+    }
+  });
+}
+
+window.addEventListener("message", invertColorOnIframeResultPages, false);
 initCardSections();

--- a/atoms/set-6/server/templates/main.html
+++ b/atoms/set-6/server/templates/main.html
@@ -43,7 +43,7 @@
                             data-form-description="Get music news, bold reviews and unexpected extras. Every genre, every era, every week" 
                             data-form-campaign-code="sleevenotes_email "
                             scrolling="no" seamless="" frameborder="0" 
-                            class="iframed--overflow-hidden email-sub__iframe js-email-sub__iframe js-email-sub__iframe--article" 
+                            class="iframed--overflow-hidden email-sub__iframe js-email-sub__iframe js-email-sub__iframe--article invert-colors" 
                             data-form-success-desc="We&#x27;ll send you Sleeve Notes every week" 
                             title="Sign up for Sleeve Notes"></iframe>    </div>
                     </article><article class="newsletter-card" style="background-color:#333333; color:#fff">
@@ -74,7 +74,7 @@
                             data-form-description="Take a front seat at the cinema with our weekly email filled with all the latest news and all the movie action that matters" 
                             data-form-campaign-code="filmtoday_email "
                             scrolling="no" seamless="" frameborder="0" 
-                            class="iframed--overflow-hidden email-sub__iframe js-email-sub__iframe js-email-sub__iframe--article" 
+                            class="iframed--overflow-hidden email-sub__iframe js-email-sub__iframe js-email-sub__iframe--article invert-colors" 
                             data-form-success-desc="We&#x27;ll send you Film Weekly every Friday" 
                             title="Sign up for Film Weekly"></iframe>    </div>
                     </article><article class="newsletter-card" style="background-color:#2B2625; color:#fff">
@@ -105,7 +105,7 @@
                             data-form-description="Discover new books with our expert reviews, author interviews and top 10s. Literary delights delivered direct you" 
                             data-form-campaign-code="bookmarks_email "
                             scrolling="no" seamless="" frameborder="0" 
-                            class="iframed--overflow-hidden email-sub__iframe js-email-sub__iframe js-email-sub__iframe--article" 
+                            class="iframed--overflow-hidden email-sub__iframe js-email-sub__iframe js-email-sub__iframe--article invert-colors" 
                             data-form-success-desc="We&#x27;ll send you Bookmarks every week" 
                             title="Sign up for Bookmarks"></iframe>    </div>
                     </article>                </div>

--- a/atoms/set-7/client/js/app.js
+++ b/atoms/set-7/client/js/app.js
@@ -110,4 +110,35 @@ function initCardSections() {
   });
 }
 
+function invertColorOnIframeResultPages(event) {
+  if (!event.data.subject || event.data.subject !== "emailEmbedPageLoaded") {
+    return;
+  }
+  if (!event.data.path || typeof event.data.path !== "string") {
+    return;
+  }
+  if (
+    !event.data.path.startsWith("/email/error") &&
+    !event.data.path.startsWith("/email/success")
+  ) {
+    return;
+  }
+  if (event.origin !== window.origin) {
+    console.warn('emailEmbedPageLoaded received from wrong origin:', event.origin)
+    return;
+  }
+  var iframesOnDarkBackgrounds = [
+    ...document.querySelectorAll(
+      ".newsletter-card__iframe-wrapper iframe.invert-colors"
+    ),
+  ];
+
+  iframesOnDarkBackgrounds.forEach(function (iframe) {
+    if (iframe.contentWindow === event.source) {
+      iframe.style.filter = "invert(1)";
+    }
+  });
+}
+
+window.addEventListener("message", invertColorOnIframeResultPages, false);
 initCardSections();

--- a/atoms/set-7/server/templates/main.html
+++ b/atoms/set-7/server/templates/main.html
@@ -43,7 +43,7 @@
                             data-form-description="Kick off your evenings with the Guardian&#x27;s take on the world of football" 
                             data-form-campaign-code="fiver_email "
                             scrolling="no" seamless="" frameborder="0" 
-                            class="iframed--overflow-hidden email-sub__iframe js-email-sub__iframe js-email-sub__iframe--article" 
+                            class="iframed--overflow-hidden email-sub__iframe js-email-sub__iframe js-email-sub__iframe--article invert-colors" 
                             data-form-success-desc="We&#x27;ll send you The Fiver every weekday" 
                             title="Sign up for The Fiver"></iframe>    </div>
                     </article><article class="newsletter-card" style="background-color:#8fdcfe; color:#000">

--- a/atoms/set-8/client/js/app.js
+++ b/atoms/set-8/client/js/app.js
@@ -110,4 +110,35 @@ function initCardSections() {
   });
 }
 
+function invertColorOnIframeResultPages(event) {
+  if (!event.data.subject || event.data.subject !== "emailEmbedPageLoaded") {
+    return;
+  }
+  if (!event.data.path || typeof event.data.path !== "string") {
+    return;
+  }
+  if (
+    !event.data.path.startsWith("/email/error") &&
+    !event.data.path.startsWith("/email/success")
+  ) {
+    return;
+  }
+  if (event.origin !== window.origin) {
+    console.warn('emailEmbedPageLoaded received from wrong origin:', event.origin)
+    return;
+  }
+  var iframesOnDarkBackgrounds = [
+    ...document.querySelectorAll(
+      ".newsletter-card__iframe-wrapper iframe.invert-colors"
+    ),
+  ];
+
+  iframesOnDarkBackgrounds.forEach(function (iframe) {
+    if (iframe.contentWindow === event.source) {
+      iframe.style.filter = "invert(1)";
+    }
+  });
+}
+
+window.addEventListener("message", invertColorOnIframeResultPages, false);
 initCardSections();

--- a/atoms/set-8/server/templates/main.html
+++ b/atoms/set-8/server/templates/main.html
@@ -107,7 +107,7 @@
                             data-form-description="Podcast recommendations for unexpected audio pleasures. Our reviewers and audio producers pick the week&#x27;s top shows" 
                             data-form-campaign-code="hearhere_email "
                             scrolling="no" seamless="" frameborder="0" 
-                            class="iframed--overflow-hidden email-sub__iframe js-email-sub__iframe js-email-sub__iframe--article" 
+                            class="iframed--overflow-hidden email-sub__iframe js-email-sub__iframe js-email-sub__iframe--article invert-colors" 
                             data-form-success-desc="We&#x27;ll send you Hear Here every week" 
                             title="Sign up for Hear Here"></iframe>    </div>
                     </article>               </div>

--- a/atoms/set-9/client/js/app.js
+++ b/atoms/set-9/client/js/app.js
@@ -110,4 +110,35 @@ function initCardSections() {
   });
 }
 
+function invertColorOnIframeResultPages(event) {
+  if (!event.data.subject || event.data.subject !== "emailEmbedPageLoaded") {
+    return;
+  }
+  if (!event.data.path || typeof event.data.path !== "string") {
+    return;
+  }
+  if (
+    !event.data.path.startsWith("/email/error") &&
+    !event.data.path.startsWith("/email/success")
+  ) {
+    return;
+  }
+  if (event.origin !== window.origin) {
+    console.warn('emailEmbedPageLoaded received from wrong origin:', event.origin)
+    return;
+  }
+  var iframesOnDarkBackgrounds = [
+    ...document.querySelectorAll(
+      ".newsletter-card__iframe-wrapper iframe.invert-colors"
+    ),
+  ];
+
+  iframesOnDarkBackgrounds.forEach(function (iframe) {
+    if (iframe.contentWindow === event.source) {
+      iframe.style.filter = "invert(1)";
+    }
+  });
+}
+
+window.addEventListener("message", invertColorOnIframeResultPages, false);
 initCardSections();

--- a/atoms/set-9/server/templates/main.html
+++ b/atoms/set-9/server/templates/main.html
@@ -107,7 +107,7 @@
                             data-form-description="Podcast recommendations for unexpected audio pleasures. Our reviewers and audio producers pick the week&#x27;s top shows" 
                             data-form-campaign-code="hearhere_email "
                             scrolling="no" seamless="" frameborder="0" 
-                            class="iframed--overflow-hidden email-sub__iframe js-email-sub__iframe js-email-sub__iframe--article" 
+                            class="iframed--overflow-hidden email-sub__iframe js-email-sub__iframe js-email-sub__iframe--article invert-colors" 
                             data-form-success-desc="We&#x27;ll send you Hear Here every week" 
                             title="Sign up for Hear Here"></iframe>    </div>
                     </article>               </div>


### PR DESCRIPTION
## What does this change?

Adds a function to the the client script which: 
 - listens for "emailEmbedPageLoaded" message events from the iframes (see https://github.com/guardian/frontend/pull/25594)
 - if the iframe that sent the message has the "invert-colors" class, the handler function inverts the colors when the iframe loads a success/failure page (so the text will be white, rather than black).

Puts the "invert-colors" class on all iframes with a dark background/white text card.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
Because of the "same origin" rule for the message events, the function will only work if the embed page and the thrasher have the same origin (this includes being on the same port - localhost:3000 is not the same origin as localhost:9000).

To see this work, you would have to:
 - checkout the frontend branch from the PR above (if not already merged) and run the server locally 
 - edit the script in frontend that send the "emailEmbedPageLoaded" so it will send the message to parent windows of any origin ('*', rather than window.origin)
 - edit the script in the thrasher to not check the origin of the iframe sending the message (or to allow the origin of the local frontend)
 - edit the main.html so the iframes load the pages from the local frontend, not guardian.com

in production, both the embed pages and the iframe will have http://theguardian.com/ as the origin.


## Images - inverted colors on the dark card (Left hand side)

<img width="957" alt="Screenshot 2022-10-17 at 18 15 53" src="https://user-images.githubusercontent.com/30567854/196382318-09b19ef0-a3f9-48f8-b5b3-33d6a52677d2.png">


<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
