### PR TITLE
[WIP] fix colour on buttons for football weekly

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
     "title": "Football Weekly Podcast",
     "docData": "",
-    "path": "thrashers/2021/01/football-weekly-thrasher"
+    "path": "thrashers/2021/01/football-weekly-thrasher-dcr"
 }

--- a/harness/dcr-front-football.html
+++ b/harness/dcr-front-football.html
@@ -1,0 +1,17166 @@
+<!doctype html>
+<html lang="en">
+<head>
+
+  <!--
+
+We are hiring, ever thought about joining us?
+https://workforus.theguardian.com/careers/product-engineering/
+
+
+                                    GGGGGGGGG
+                           GGGGGGGGGGGGGGGGGGGGGGGGGG
+                       GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG
+                    GGGGGGGGGGGGGGGGG      GG   GGGGGGGGGGGGG
+                  GGGGGGGGGGGG        GGGGGGGGG      GGGGGGGGGG
+                GGGGGGGGGGG         GGGGGGGGGGGGG       GGGGGGGGG
+              GGGGGGGGGG          GGGGGGGGGGGGGGGGG     GGGGGGGGGGG
+             GGGGGGGGG           GGGGGGGGGGGGGGGGGGG    GGGGGGGGGGGG
+            GGGGGGGGG           GGGGGGGGGGGGGGGGGGGGGG  GGGGGGGGGGGGG
+           GGGGGGGGG            GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG
+           GGGGGGGG             GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG
+          GGGGGGGG              GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG
+          GGGGGGGG              GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG
+          GGGGGGGG              GGGGGGGGGGGG              GGGGGGGGGGGGG
+           GGGGGGG              GGGGGGGGGGGGG           GGGGGGGGGGGGGG
+           GGGGGGGG             GGGGGGGGGGGGG           GGGGGGGGGGGGGG
+            GGGGGGGG            GGGGGGGGGGGGG           GGGGGGGGGGGGG
+             GGGGGGGG            GGGGGGGGGGGG           GGGGGGGGGGGG
+              GGGGGGGGG           GGGGGGGGGGG           GGGGGGGGGGG
+                GGGGGGGGGG         GGGGGGGGGG           GGGGGGGGG
+                  GGGGGGGGGGG        GGGGGGGG        GGGGGGGGGG
+                    GGGGGGGGGGGGGG      GGGGG  GGGGGGGGGGGGGG
+                       GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG
+                            GGGGGGGGGGGGGGGGGGGGGGGGG
+                                    GGGGGGGGG
+
+
+         GGGGG    GGG     GGG
+        G     G  G   G   G   G     G   G  GGGGGG    GG    GGGGG    GGGG
+              G G     G G     G     G G   G        G  G   G    G  G
+         GGGGG  G     G G     G      G    GGGGG   G    G  G    G   GGGG
+        G       G     G G     G      G    G       GGGGGG  GGGGG        G
+        G        G   G   G   G       G    G       G    G  G   G   G    G
+        GGGGGGG   GGG     GGG        G    GGGGGG  G    G  G    G   GGGG
+
+--->
+  <title>Football news, match reports and fixtures | The Guardian</title>
+  <meta name="description"
+    content="Football news, results, fixtures, blogs, podcasts and comment on the Premier League, European and World football from the Guardian, the world&#x27;s leading liberal voice" />
+  <!-- no canonical URL -->
+  <meta charset="utf-8">
+
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <meta name="theme-color" content="#052962" />
+  <link rel="icon" href="https://static.guim.co.uk/images/favicon-32x32.ico">
+
+  <link rel="preconnect" href="https://assets.guim.co.uk/">
+  <link rel="preconnect" href="https://i.guim.co.uk">
+  <link rel="preconnect" href="https://j.ophan.co.uk">
+  <link rel="preconnect" href="https://ophan.theguardian.com">
+  <link rel="preconnect" href="https://sourcepoint.theguardian.com">
+  <link rel="dns-prefetch" href="https://assets.guim.co.uk/">
+  <link rel="dns-prefetch" href="https://i.guim.co.uk">
+  <link rel="dns-prefetch" href="https://j.ophan.co.uk">
+  <link rel="dns-prefetch" href="https://ophan.theguardian.com">
+  <link rel="dns-prefetch" href="https://api.nextgen.guardianapps.co.uk">
+  <link rel="dns-prefetch" href="https://hits-secure.theguardian.com">
+  <link rel="dns-prefetch" href="https://interactive.guim.co.uk">
+  <link rel="dns-prefetch" href="https://static.theguardian.com">
+  <link rel="dns-prefetch" href="https://support.theguardian.com">
+
+  <!-- no linked data -->
+
+  <!-- TODO make this conditional when we support more content types -->
+  <!-- no Amp link -->
+
+  <link rel="preload"
+    href="https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Bold.woff2?http3=true"
+    as="font" crossorigin>
+  <link rel="preload"
+    href="https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Regular.woff2?http3=true"
+    as="font" crossorigin>
+
+  <!-- no Open Graph meta tags -->
+
+  <meta name="twitter:dnt" content="on">
+
+  <!-- no Twitter meta tags -->
+
+  <!--  This tag enables pages to be featured in Google Discover as large previews
+                    See: https://developers.google.com/search/docs/advanced/mobile/google-discover?hl=en&visit_id=637424198370039526-3805703503&rd=1 -->
+  <meta name="robots" content="max-image-preview:large">
+
+  <script>
+    window.guardian = { "config": { "isDotcomRendering": true, "isDev": false, "stage": "PROD", "frontendAssetsFullURL": "https://assets.guim.co.uk/", "page": { "avatarApiUrl": "https://avatar.theguardian.com", "externalEmbedHost": "https://embed.theguardian.com", "ajaxUrl": "https://api.nextgen.guardianapps.co.uk", "keywords": "Football", "revisionNumber": "66c651cdb7e55c14411e158c57a757f0c5cac04e", "isProd": true, "switches": { "prebidAppnexusUkRow": true, "mobileStickyPrebid": true, "newsletterOnwards": false, "abSignInGateMainVariant": true, "commercialMetrics": true, "prebidTrustx": true, "scAdFreeBanner": false, "abSignInGateCopyTestJan2023": false, "frontsBannerAds": true, "prebidPermutiveAudience": true, "compareVariantDecision": false, "adFreeStrictExpiryEnforcement": false, "enableSentryReporting": true, "lazyLoadContainers": true, "ampArticleSwitch": true, "remarketing": true, "keyEventsCarousel": true, "fetchNonRefreshableLineItems": true, "actionCardRedesign": true, "registerWithPhone": false, "targeting": true, "remoteHeader": true, "deeplyReadSwitch": false, "slotBodyEnd": true, "prebidImproveDigitalSkins": true, "ampPrebidOzone": true, "extendedMostPopularFronts": true, "emailInlineInFooter": true, "showNewPrivacyWordingOnEmailSignupEmbeds": true, "iasAdTargeting": true, "prebidAnalytics": true, "extendedMostPopular": true, "ampContentAbTesting": false, "prebidCriteo": true, "okta": true, "abDeeplyReadArticleFooter": false, "puzzlesBanner": false, "imrWorldwide": true, "acast": true, "automaticFilters": true, "twitterUwt": true, "prebidAppnexusInvcode": true, "ampPrebidPubmatic": true, "a9HeaderBidding": true, "prebidAppnexus": true, "enableDiscussionSwitch": true, "prebidXaxis": true, "stickyVideos": true, "abRemoveBusinessLiveblogEpics": true, "interactiveFullHeaderSwitch": true, "discussionAllPageSize": true, "prebidUserSync": true, "audioOnwardJourneySwitch": true, "dcrJavascriptBundle": true, "brazeTaylorReport": false, "abConsentlessAds": true, "externalVideoEmbeds": true, "simpleReach": true, "abIntegrateIma": true, "callouts": true, "carrotTrafficDriver": true, "sentinelLogger": true, "geoMostPopular": true, "weAreHiring": true, "relatedContent": true, "thirdPartyEmbedTracking": true, "prebidOzone": true, "ampLiveblogSwitch": true, "ampAmazon": true, "borkFid": false, "prebidAdYouLike": true, "mostViewedFronts": true, "optOutAdvertising": true, "abSignInGateMainControl": true, "headerTopNav": true, "googleSearch": true, "brazeSwitch": true, "consentManagement": true, "borkFcp": false, "commercial": true, "personaliseSignInGateAfterCheckout": true, "redplanetForAus": true, "prebidSonobi": true, "idProfileNavigation": true, "confiantAdVerification": true, "discussionAllowAnonymousRecommendsSwitch": false, "permutive": true, "comscore": true, "headerTopBarSearchCapi": false, "ampPrebidCriteo": true, "webFonts": true, "europeNetworkFront": true, "abBillboardsInMerch": false, "prebidImproveDigital": true, "offerHttp3": true, "ophan": true, "crosswordSvgThumbnails": true, "prebidTriplelift": true, "weather": true, "commercialOutbrainNewids": true, "disableAmpTest": true, "abLimitInlineMerch": true, "serverShareCounts": false, "abAdblockAsk": true, "prebidPubmatic": true, "autoRefresh": true, "enhanceTweets": true, "prebidIndexExchange": true, "prebidOpenx": true, "abElementsManager": true, "prebidHeaderBidding": true, "idCookieRefresh": true, "serverSideLiveblogInlineAds": true, "discussionPageSize": true, "smartAppBanner": false, "boostGaUserTimingFidelity": false, "historyTags": true, "mobileStickyLeaderboard": true, "brazeContentCards": true, "surveys": true, "remoteBanner": true, "emailSignupRecaptcha": true, "prebidSmart": true, "inizio": true }, "keywordIds": "football/football", "locationapiurl": "/weatherapi/locations?query=", "sharedAdTargeting": { "ct": "section", "url": "/football", "edition": "uk", "p": "ng", "k": ["football"] }, "buildNumber": "47359", "ampIframeUrl": "https://assets.guim.co.uk/data/vendor/2533d5cb94302889e6a8f1b24b5329e7/amp-iframe.html", "beaconUrl": "//phar.gu-web.net", "userAttributesApiUrl": "https://members-data-api.theguardian.com/user-attributes", "brazeApiKey": "7f28c639-8bda-48ff-a3f6-24345abfc07c", "host": "https://www.theguardian.com", "calloutsUrl": "https://callouts.code.dev-guardianapis.com/formstack-campaign/submit", "requiresMembershipAccess": false, "onwardWebSocket": "ws://api.nextgen.guardianapps.co.uk/recently-published", "contentType": "", "pbIndexSites": [{ "bp": "D", "id": 208259 }, { "bp": "M", "id": 213530 }, { "bp": "T", "id": 215465 }], "a9PublisherId": "3722", "facebookIaAdUnitRoot": "facebook-instant-articles", "ophanEmbedJsUrl": "//j.ophan.co.uk/ophan.embed", "idUrl": "https://profile.theguardian.com", "dcrSentryDsn": "https://1937ab71c8804b2b8438178dfdd6468f@sentry.io/1377847", "isFront": true, "idWebAppUrl": "https://oauth.theguardian.com", "discussionApiUrl": "https://discussion.theguardian.com/discussion-api", "sentryPublicApiKey": "344003a8d11c41d8800fbad8383fdc50", "omnitureAccount": "guardiangu-network", "dfpAccountId": "59666047", "pageId": "football", "isAdFree": false, "forecastsapiurl": "/weatherapi/forecast", "assetsPath": "https://assets.guim.co.uk/", "pillar": "", "commercialBundleUrl": "https://assets.guim.co.uk/javascripts/commercial/83846fe715c5230f732d/graun.standalone.commercial.js", "discussionApiClientHeader": "nextgen", "membershipUrl": "https://membership.theguardian.com", "dfpHost": "pubads.g.doubleclick.net", "cardStyle": "", "googletagUrl": "//securepubads.g.doubleclick.net/tag/js/gpt.js", "sentryHost": "app.getsentry.com/35463", "shouldHideAdverts": false, "mmaUrl": "https://manage.theguardian.com", "isPreview": false, "membershipAccess": "", "abTests": { "actionCardRedesignControl": "control" }, "googletagJsUrl": "//securepubads.g.doubleclick.net/tag/js/gpt.js", "supportUrl": "https://support.theguardian.com", "edition": "UK", "discussionFrontendUrl": "", "ipsosTag": "football", "ophanJsUrl": "//j.ophan.co.uk/ophan.ng", "isPaidContent": false, "mobileAppsAdUnitRoot": "beta-guardian-app", "plistaPublicApiKey": "462925f4f131001fd974bebe", "frontendAssetsFullURL": "https://assets.guim.co.uk/", "googleSearchId": "007466294097402385199:m2ealvuxh1i", "allowUserGeneratedContent": false, "dfpAdUnitRoot": "theguardian.com", "idApiUrl": "https://idapi.theguardian.com", "omnitureAmpAccount": "guardiangu-thirdpartyapps", "adUnit": "/59666047/theguardian.com/football/front/ng", "hasPageSkin": false, "webTitle": "Football", "stripePublicToken": "pk_live_2O6zPMHXNs2AGea4bAmq5R7Z", "googleRecaptchaSiteKey": "6LdzlmsdAAAAALFH63cBVagSFPuuHXQ9OfpIDdMc", "discussionD2Uid": "zHoBy6HNKsk", "weatherapiurl": "/weatherapi/city", "googleSearchUrl": "//www.google.co.uk/cse/cse.js", "optimizeEpicUrl": "https://support.theguardian.com/epic/control/index.html", "stage": "PROD", "idOAuthUrl": "https://oauth.theguardian.com", "isSensitive": false, "isDev": false, "thirdPartyAppsAccount": "guardiangu-thirdpartyapps", "avatarImagesUrl": "https://avatar.guim.co.uk", "fbAppId": "180444840287", "dcrCouldRender": true, "showRelatedContent": true, "shouldHideReaderRevenue": false }, "libs": { "googletag": "//securepubads.g.doubleclick.net/tag/js/gpt.js" }, "switches": { "prebidAppnexusUkRow": true, "mobileStickyPrebid": true, "newsletterOnwards": false, "abSignInGateMainVariant": true, "commercialMetrics": true, "prebidTrustx": true, "scAdFreeBanner": false, "abSignInGateCopyTestJan2023": false, "frontsBannerAds": true, "prebidPermutiveAudience": true, "compareVariantDecision": false, "adFreeStrictExpiryEnforcement": false, "enableSentryReporting": true, "lazyLoadContainers": true, "ampArticleSwitch": true, "remarketing": true, "keyEventsCarousel": true, "fetchNonRefreshableLineItems": true, "actionCardRedesign": true, "registerWithPhone": false, "targeting": true, "remoteHeader": true, "deeplyReadSwitch": false, "slotBodyEnd": true, "prebidImproveDigitalSkins": true, "ampPrebidOzone": true, "extendedMostPopularFronts": true, "emailInlineInFooter": true, "showNewPrivacyWordingOnEmailSignupEmbeds": true, "iasAdTargeting": true, "prebidAnalytics": true, "extendedMostPopular": true, "ampContentAbTesting": false, "prebidCriteo": true, "okta": true, "abDeeplyReadArticleFooter": false, "puzzlesBanner": false, "imrWorldwide": true, "acast": true, "automaticFilters": true, "twitterUwt": true, "prebidAppnexusInvcode": true, "ampPrebidPubmatic": true, "a9HeaderBidding": true, "prebidAppnexus": true, "enableDiscussionSwitch": true, "prebidXaxis": true, "stickyVideos": true, "abRemoveBusinessLiveblogEpics": true, "interactiveFullHeaderSwitch": true, "discussionAllPageSize": true, "prebidUserSync": true, "audioOnwardJourneySwitch": true, "dcrJavascriptBundle": true, "brazeTaylorReport": false, "abConsentlessAds": true, "externalVideoEmbeds": true, "simpleReach": true, "abIntegrateIma": true, "callouts": true, "carrotTrafficDriver": true, "sentinelLogger": true, "geoMostPopular": true, "weAreHiring": true, "relatedContent": true, "thirdPartyEmbedTracking": true, "prebidOzone": true, "ampLiveblogSwitch": true, "ampAmazon": true, "borkFid": false, "prebidAdYouLike": true, "mostViewedFronts": true, "optOutAdvertising": true, "abSignInGateMainControl": true, "headerTopNav": true, "googleSearch": true, "brazeSwitch": true, "consentManagement": true, "borkFcp": false, "commercial": true, "personaliseSignInGateAfterCheckout": true, "redplanetForAus": true, "prebidSonobi": true, "idProfileNavigation": true, "confiantAdVerification": true, "discussionAllowAnonymousRecommendsSwitch": false, "permutive": true, "comscore": true, "headerTopBarSearchCapi": false, "ampPrebidCriteo": true, "webFonts": true, "europeNetworkFront": true, "abBillboardsInMerch": false, "prebidImproveDigital": true, "offerHttp3": true, "ophan": true, "crosswordSvgThumbnails": true, "prebidTriplelift": true, "weather": true, "commercialOutbrainNewids": true, "disableAmpTest": true, "abLimitInlineMerch": true, "serverShareCounts": false, "abAdblockAsk": true, "prebidPubmatic": true, "autoRefresh": true, "enhanceTweets": true, "prebidIndexExchange": true, "prebidOpenx": true, "abElementsManager": true, "prebidHeaderBidding": true, "idCookieRefresh": true, "serverSideLiveblogInlineAds": true, "discussionPageSize": true, "smartAppBanner": false, "boostGaUserTimingFidelity": false, "historyTags": true, "mobileStickyLeaderboard": true, "brazeContentCards": true, "surveys": true, "remoteBanner": true, "emailSignupRecaptcha": true, "prebidSmart": true, "inizio": true }, "tests": { "actionCardRedesignControl": "control" }, "ophan": { "pageViewId": "", "browserId": "" } }, "polyfilled": false, "adBlockers": { "onDetect": [] }, "modules": { "sentry": {} }, "borkWebVitals": {} };
+    window.guardian.queue = []; // Queue for functions to be fired by polyfill.io callback
+  </script>
+
+  <script type="module">
+    window.guardian.mustardCut = true;
+  </script>
+
+  <script nomodule>
+    // Browser fails mustard check
+    window.guardian.mustardCut = false;
+  </script>
+
+  <script>
+    // Noop monkey patch perf.mark and perf.measure if not supported
+    if (window.performance !== undefined && window.performance.mark === undefined) {
+      window.performance.mark = function () { };
+      window.performance.measure = function () { };
+    }
+  </script>
+
+  <script>
+    // record the number of times the browser goes offline during a pageview
+    window.guardian.offlineCount = 0;
+    window.addEventListener('offline', function incrementOfflineCount() { window.guardian.offlineCount++ });
+  </script>
+
+  <script>
+    // this is a global that's called at the bottom of the pf.io response,
+    // once the polyfills have run. This may be useful for debugging.
+    // mainly to support browsers that don't support async=false or defer
+    function guardianPolyfilled() {
+      window.guardian.polyfilled = true;
+      if (window.guardian.mustardCut === false) {
+        window.guardian.queue.forEach(function (startup) { startup() })
+      }
+    }
+
+    // We've got contracts to abide by with the Ophan tracker
+    // Setting pageViewId here ensures we're not getting race-conditions at all
+    window.guardian.config.ophan = {
+      // This is duplicated from
+      // https://github.com/guardian/ophan/blob/master/tracker-js/assets/coffee/ophan/transmit.coffee
+      // Please do not change this without talking to the Ophan project first.
+      pageViewId:
+        new Date().getTime().toString(36) +
+        'xxxxxxxxxxxx'.replace(/x/g, function () {
+          return Math.floor(Math.random() * 36).toString(36);
+        }),
+    };
+  </script>
+
+  <script>
+    // Set the browserId from the bwid cookie on the ophan object created above
+    // This will need to be replaced later with an async request to an endpoint
+    (function (window, document) {
+
+      function getCookieValue(name) {
+        var nameEq = name + "=",
+          cookies = document.cookie.split(';'),
+          value = null;
+        cookies.forEach(function (cookie) {
+          while (cookie.charAt(0) === ' ') {
+            cookie = cookie.substring(1, cookie.length);
+          }
+          if (cookie.indexOf(nameEq) === 0) {
+            value = cookie.substring(nameEq.length, cookie.length);
+          }
+        });
+        return value;
+      }
+
+      window.guardian.config.ophan.browserId = getCookieValue("bwid");
+
+    })(window, document);
+  </script>
+
+  <script>
+    window.curlConfig = {
+      baseUrl: 'https://assets.guim.co.uk/assets',
+      apiName: 'require'
+    };
+    window.curl = window.curlConfig;
+  </script>
+
+  <!-- no borking -->
+
+
+
+
+
+  <noscript>
+    <img src="https://sb.scorecardresearch.com/p?c1=2&c2=6035250&cv=2.0&cj=1&cs_ucfr=0&comscorekw=Football" />
+
+
+    <style>
+      gu-island[clientOnly=true] {
+        display: none;
+      }
+    </style>
+
+  </noscript>
+
+  <!-- The following script does not vary between modern & legacy browsers -->
+  <script defer
+    src="https://assets.guim.co.uk/polyfill.io/v3/polyfill.min.js?rum=0&features=es6%2Ces7%2Ces2017%2Ces2018%2Ces2019%2Cdefault-3.6%2CHTMLPictureElement%2CIntersectionObserver%2CIntersectionObserverEntry%2CURLSearchParams%2Cfetch%2CNodeList.prototype.forEach%2Cnavigator.sendBeacon%2Cperformance.now%2CPromise.allSettled&flags=gated&callback=guardianPolyfilled&unknown=polyfill&cacheClear=1&http3=true"></script>
+  <script type="module"
+    src="https://assets.guim.co.uk/assets/frameworks.modern.e855de231d40f9b5e577.js?http3=true"></script>
+  <script defer nomodule
+    src="https://assets.guim.co.uk/assets/frameworks.legacy.e855de231d40f9b5e577.js?http3=true"></script>
+  <script type="module" src="https://assets.guim.co.uk/assets/index.modern.9d945f06c637969ca32e.js?http3=true"></script>
+  <script defer nomodule
+    src="https://assets.guim.co.uk/assets/index.legacy.7a2b00a4bf68aa52ce4c.js?http3=true"></script>
+  <!-- The following script does not vary between modern & legacy browsers -->
+  <script defer
+    src="https://assets.guim.co.uk/javascripts/commercial/83846fe715c5230f732d/graun.standalone.commercial.js?http3=true"></script>
+  <style class="webfont">
+    @font-face {
+      font-family: "GH Guardian Headline";
+      src: url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Light.woff2?http3=true) format("woff2"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-Light.woff?http3=true) format("woff"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-Light.ttf?http3=true) format("truetype");
+      font-weight: 300;
+      font-style: normal;
+      font-display: swap;
+    }
+
+    @font-face {
+      font-family: "Guardian Egyptian Web";
+      src: url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Light.woff2?http3=true) format("woff2"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-Light.woff?http3=true) format("woff"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-Light.ttf?http3=true) format("truetype");
+      font-weight: 300;
+      font-style: normal;
+      font-display: swap;
+    }
+
+    @font-face {
+      font-family: "GH Guardian Headline";
+      src: url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-LightItalic.woff2?http3=true) format("woff2"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-LightItalic.woff?http3=true) format("woff"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-LightItalic.ttf?http3=true) format("truetype");
+      font-weight: 300;
+      font-style: italic;
+      font-display: swap;
+    }
+
+    @font-face {
+      font-family: "Guardian Egyptian Web";
+      src: url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-LightItalic.woff2?http3=true) format("woff2"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-LightItalic.woff?http3=true) format("woff"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-LightItalic.ttf?http3=true) format("truetype");
+      font-weight: 300;
+      font-style: italic;
+      font-display: swap;
+    }
+
+    @font-face {
+      font-family: "GH Guardian Headline";
+      src: url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Medium.woff2?http3=true) format("woff2"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Medium.woff?http3=true) format("woff"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-Medium.ttf?http3=true) format("truetype");
+      font-weight: 500;
+      font-style: normal;
+      font-display: swap;
+    }
+
+    @font-face {
+      font-family: "Guardian Egyptian Web";
+      src: url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Medium.woff2?http3=true) format("woff2"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Medium.woff?http3=true) format("woff"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-Medium.ttf?http3=true) format("truetype");
+      font-weight: 500;
+      font-style: normal;
+      font-display: swap;
+    }
+
+    @font-face {
+      font-family: "GH Guardian Headline";
+      src: url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-MediumItalic.woff2?http3=true) format("woff2"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-MediumItalic.woff?http3=true) format("woff"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-MediumItalic.ttf?http3=true) format("truetype");
+      font-weight: 500;
+      font-style: italic;
+      font-display: swap;
+    }
+
+    @font-face {
+      font-family: "Guardian Egyptian Web";
+      src: url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-MediumItalic.woff2?http3=true) format("woff2"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-MediumItalic.woff?http3=true) format("woff"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-MediumItalic.ttf?http3=true) format("truetype");
+      font-weight: 500;
+      font-style: italic;
+      font-display: swap;
+    }
+
+    @font-face {
+      font-family: "GH Guardian Headline";
+      src: url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Bold.woff2?http3=true) format("woff2"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-Bold.woff?http3=true) format("woff"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-Bold.ttf?http3=true) format("truetype");
+      font-weight: 700;
+      font-style: normal;
+      font-display: swap;
+    }
+
+    @font-face {
+      font-family: "Guardian Egyptian Web";
+      src: url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Bold.woff2?http3=true) format("woff2"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-Bold.woff?http3=true) format("woff"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-Bold.ttf?http3=true) format("truetype");
+      font-weight: 700;
+      font-style: normal;
+      font-display: swap;
+    }
+
+    @font-face {
+      font-family: "GH Guardian Headline";
+      src: url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-BoldItalic.woff2?http3=true) format("woff2"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-BoldItalic.woff?http3=true) format("woff"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-BoldItalic.ttf?http3=true) format("truetype");
+      font-weight: 700;
+      font-style: italic;
+      font-display: swap;
+    }
+
+    @font-face {
+      font-family: "Guardian Egyptian Web";
+      src: url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-BoldItalic.woff2?http3=true) format("woff2"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-BoldItalic.woff?http3=true) format("woff"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-BoldItalic.ttf?http3=true) format("truetype");
+      font-weight: 700;
+      font-style: italic;
+      font-display: swap;
+    }
+
+    @font-face {
+      font-family: "GuardianTextEgyptian";
+      src: url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Regular.woff2?http3=true) format("woff2"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Regular.woff?http3=true) format("woff"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/latin1-not-hinted/GuardianTextEgyptian-Regular.ttf?http3=true) format("truetype");
+      font-weight: 400;
+      font-style: normal;
+      font-display: swap;
+    }
+
+    @font-face {
+      font-family: "Guardian Text Egyptian Web";
+      src: url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Regular.woff2?http3=true) format("woff2"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Regular.woff?http3=true) format("woff"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/latin1-not-hinted/GuardianTextEgyptian-Regular.ttf?http3=true) format("truetype");
+      font-weight: 400;
+      font-style: normal;
+      font-display: swap;
+    }
+
+    @font-face {
+      font-family: "GuardianTextEgyptian";
+      src: url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-RegularItalic.woff2?http3=true) format("woff2"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/latin1-not-hinted/GuardianTextEgyptian-RegularItalic.woff?http3=true) format("woff"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/latin1-not-hinted/GuardianTextEgyptian-RegularItalic.ttf?http3=true) format("truetype");
+      font-weight: 400;
+      font-style: italic;
+      font-display: swap;
+    }
+
+    @font-face {
+      font-family: "Guardian Text Egyptian Web";
+      src: url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-RegularItalic.woff2?http3=true) format("woff2"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/latin1-not-hinted/GuardianTextEgyptian-RegularItalic.woff?http3=true) format("woff"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/latin1-not-hinted/GuardianTextEgyptian-RegularItalic.ttf?http3=true) format("truetype");
+      font-weight: 400;
+      font-style: italic;
+      font-display: swap;
+    }
+
+    @font-face {
+      font-family: "GuardianTextEgyptian";
+      src: url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Bold.woff2?http3=true) format("woff2"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/latin1-not-hinted/GuardianTextEgyptian-Bold.woff?http3=true) format("woff"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/latin1-not-hinted/GuardianTextEgyptian-Bold.ttf?http3=true) format("truetype");
+      font-weight: 700;
+      font-style: normal;
+      font-display: swap;
+    }
+
+    @font-face {
+      font-family: "Guardian Text Egyptian Web";
+      src: url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Bold.woff2?http3=true) format("woff2"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/latin1-not-hinted/GuardianTextEgyptian-Bold.woff?http3=true) format("woff"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/latin1-not-hinted/GuardianTextEgyptian-Bold.ttf?http3=true) format("truetype");
+      font-weight: 700;
+      font-style: normal;
+      font-display: swap;
+    }
+
+    @font-face {
+      font-family: "GuardianTextEgyptian";
+      src: url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-BoldItalic.woff2?http3=true) format("woff2"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/latin1-not-hinted/GuardianTextEgyptian-BoldItalic.woff?http3=true) format("woff"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/latin1-not-hinted/GuardianTextEgyptian-BoldItalic.ttf?http3=true) format("truetype");
+      font-weight: 700;
+      font-style: italic;
+      font-display: swap;
+    }
+
+    @font-face {
+      font-family: "Guardian Text Egyptian Web";
+      src: url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-BoldItalic.woff2?http3=true) format("woff2"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/latin1-not-hinted/GuardianTextEgyptian-BoldItalic.woff?http3=true) format("woff"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/latin1-not-hinted/GuardianTextEgyptian-BoldItalic.ttf?http3=true) format("truetype");
+      font-weight: 700;
+      font-style: italic;
+      font-display: swap;
+    }
+
+    @font-face {
+      font-family: "GuardianTextSans";
+      src: url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Regular.woff2?http3=true) format("woff2"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Regular.woff?http3=true) format("woff"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/latin1-not-hinted/GuardianTextSans-Regular.ttf?http3=true) format("truetype");
+      font-weight: 400;
+      font-style: normal;
+      font-display: swap;
+    }
+
+    @font-face {
+      font-family: "Guardian Text Sans Web";
+      src: url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Regular.woff2?http3=true) format("woff2"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Regular.woff?http3=true) format("woff"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/latin1-not-hinted/GuardianTextSans-Regular.ttf?http3=true) format("truetype");
+      font-weight: 400;
+      font-style: normal;
+      font-display: swap;
+    }
+
+    @font-face {
+      font-family: "GuardianTextSans";
+      src: url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-RegularItalic.woff2?http3=true) format("woff2"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/latin1-not-hinted/GuardianTextSans-RegularItalic.woff?http3=true) format("woff"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/latin1-not-hinted/GuardianTextSans-RegularItalic.ttf?http3=true) format("truetype");
+      font-weight: 400;
+      font-style: italic;
+      font-display: swap;
+    }
+
+    @font-face {
+      font-family: "Guardian Text Sans Web";
+      src: url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-RegularItalic.woff2?http3=true) format("woff2"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/latin1-not-hinted/GuardianTextSans-RegularItalic.woff?http3=true) format("woff"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/latin1-not-hinted/GuardianTextSans-RegularItalic.ttf?http3=true) format("truetype");
+      font-weight: 400;
+      font-style: italic;
+      font-display: swap;
+    }
+
+    @font-face {
+      font-family: "GuardianTextSans";
+      src: url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Bold.woff2?http3=true) format("woff2"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/latin1-not-hinted/GuardianTextSans-Bold.woff?http3=true) format("woff"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/latin1-not-hinted/GuardianTextSans-Bold.ttf?http3=true) format("truetype");
+      font-weight: 700;
+      font-style: normal;
+      font-display: swap;
+    }
+
+    @font-face {
+      font-family: "Guardian Text Sans Web";
+      src: url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Bold.woff2?http3=true) format("woff2"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/latin1-not-hinted/GuardianTextSans-Bold.woff?http3=true) format("woff"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/latin1-not-hinted/GuardianTextSans-Bold.ttf?http3=true) format("truetype");
+      font-weight: 700;
+      font-style: normal;
+      font-display: swap;
+    }
+
+    @font-face {
+      font-family: "GuardianTextSans";
+      src: url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-BoldItalic.woff2?http3=true) format("woff2"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/latin1-not-hinted/GuardianTextSans-BoldItalic.woff?http3=true) format("woff"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/latin1-not-hinted/GuardianTextSans-BoldItalic.ttf?http3=true) format("truetype");
+      font-weight: 700;
+      font-style: italic;
+      font-display: swap;
+    }
+
+    @font-face {
+      font-family: "Guardian Text Sans Web";
+      src: url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-BoldItalic.woff2?http3=true) format("woff2"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/latin1-not-hinted/GuardianTextSans-BoldItalic.woff?http3=true) format("woff"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/latin1-not-hinted/GuardianTextSans-BoldItalic.ttf?http3=true) format("truetype");
+      font-weight: 700;
+      font-style: italic;
+      font-display: swap;
+    }
+  </style>
+  <style>
+    html,
+    body,
+    div,
+    span,
+    applet,
+    object,
+    iframe,
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6,
+    p,
+    blockquote,
+    pre,
+    a,
+    abbr,
+    acronym,
+    address,
+    big,
+    cite,
+    code,
+    del,
+    dfn,
+    em,
+    img,
+    ins,
+    kbd,
+    q,
+    s,
+    samp,
+    small,
+    strike,
+    strong,
+    sub,
+    sup,
+    tt,
+    var,
+    b,
+    u,
+    i,
+    center,
+    dl,
+    dt,
+    dd,
+    menu,
+    ol,
+    ul,
+    li,
+    fieldset,
+    form,
+    label,
+    legend,
+    table,
+    caption,
+    tbody,
+    tfoot,
+    thead,
+    tr,
+    th,
+    td,
+    article,
+    aside,
+    canvas,
+    details,
+    embed,
+    figure,
+    figcaption,
+    footer,
+    header,
+    hgroup,
+    main,
+    menu,
+    nav,
+    output,
+    ruby,
+    section,
+    summary,
+    time,
+    mark,
+    audio,
+    video {
+      margin: 0;
+      padding: 0;
+      border: 0;
+      font-size: 100%;
+      font: inherit;
+      vertical-align: baseline;
+    }
+
+    /* HTML5 display-role reset for older browsers */
+    article,
+    aside,
+    details,
+    figcaption,
+    figure,
+    footer,
+    header,
+    hgroup,
+    main,
+    menu,
+    nav,
+    section {
+      display: block;
+    }
+
+    /* HTML5 hidden-attribute fix for newer browsers */
+    *[hidden] {
+      display: none;
+    }
+
+    body {
+      line-height: 1;
+    }
+
+    menu,
+    ol,
+    ul {
+      list-style: none;
+    }
+
+    blockquote,
+    q {
+      quotes: none;
+    }
+
+    blockquote:before,
+    blockquote:after,
+    q:before,
+    q:after {
+      content: '';
+      content: none;
+    }
+
+    table {
+      border-collapse: collapse;
+      border-spacing: 0;
+    }
+
+
+    *,
+    *:before,
+    *:after {
+      box-sizing: border-box;
+    }
+
+    html {
+      -moz-osx-font-smoothing: grayscale;
+      -webkit-font-smoothing: antialiased;
+      /* always show the vertical scroll bar to stop the page
+         * jumping about when navigating between pages where
+         * one has content shorter than the viewport */
+      overflow-y: scroll;
+    }
+
+    html,
+    body {
+      text-rendering: optimizeLegibility;
+      font-feature-settings: 'kern';
+      font-kerning: normal;
+      /* Safari 7+, Firefox 24+, Chrome 33(?)+, Opera 21 */
+      font-variant-ligatures: common-ligatures;
+    }
+
+    body {
+      background-color: #FFFFFF;
+      color: #121212;
+    }
+
+    em {
+      font-style: italic;
+    }
+  </style>
+  <style data-emotion="dcr-global 0"></style>
+  <style data-emotion="dcr-global 1l07i1x">
+    *:focus {
+      outline: 0;
+    }
+
+    html:not(.src-focus-disabled) *:focus {
+      box-shadow: 0 0 0 5px #0077B6;
+    }
+
+    ::selection {
+      background: #FFE500;
+      color: #121212;
+    }
+  </style>
+  <style data-emotion="dcr-global 1uvnolp">
+    .bz-custom-container~#bannerandheader .top-banner-ad-container {
+      display: none;
+    }
+  </style>
+  <style data-emotion="dcr-global o115em">
+    @media (max-width: 979px) {
+      .nav-is-open {
+        overflow: hidden;
+      }
+    }
+  </style>
+  <style data-emotion="dcr-global animation-111ynch">
+    @-webkit-keyframes animation-111ynch {
+      0% {
+        opacity: 1;
+      }
+
+      10% {
+        opacity: .25;
+      }
+
+      40% {
+        opacity: 1;
+      }
+
+      100% {
+        opacity: 1;
+      }
+    }
+
+    @keyframes animation-111ynch {
+      0% {
+        opacity: 1;
+      }
+
+      10% {
+        opacity: .25;
+      }
+
+      40% {
+        opacity: 1;
+      }
+
+      100% {
+        opacity: 1;
+      }
+    }
+  </style>
+  <style
+    data-emotion="dcr vg6br7 8h2mpe v339xn 1s8spa1 1u9kji9 1bn3p0w zzftu fks95w 12433rp 1uyetce henwc 1kfeu4u 1kvcc9o 1492oy5 1086n7e bi2aot xg94hc 1gd007l 1yaip4y j7jlyl 14f8c26 h39xrs g8r8o3 pzbwhq 1w7ojan 1irynrj 16rjsjj 127sebo 12xduix 1ppwqv1 1z074wr x2bp9n 1yaxlqk sy54ny 1ikbe4v 1aeyz4o h2gqsd c8vw16 a6bcsq 1tabvac 1t1n4fm 1kuh7tf 1nvgr5i a2u3ka 13vr4eh 120u0k1 mebke 18m7gh9 1kn7o79 1y4qg42 1acea34 1fqnu7z nqw243 9ra8aa 13wwvzl 4hq641 16d24hr 15vcq54 bu7bnv 1xxnrhn 11zodys 1efvfp0 xlajkp hmp1vw 1kltmkq 8lx8k9 19s2ze7 1ay3cld g8v7m4 19ilr9m 1xcf7cw 190ztmi 1p0hins a7qyd9 12vycz3 e1bf28 r07hem 1sks1z0 b3zdlu jv36lp 17sb2rc vwltw3 6sdrzu pt8pb9 4phbzi nnfu1a wzkd0n 1h92x0c 188zz3t v6jxf0 1gt8egs izfjfz qo5392 65xb9q vkkuzs 1ykr3rf 1a2uz3 r91ehr b25wgn 1kx60rc 1n8hb96 15t9kli 1iz7gbk 1atljbz eubdc owfrse kfs8io 1lex7d6 1mi5u71 w3rkaf 6vr3s5 pkharf 1eb5jgw 1pe3pea yosj9c evn1e9 rrcudz dbozpd 14gfmlq zdnpsd adlhb4 hcib8t 4xb9x1 j8q3ty gf0nnr z7lzm0 wi48h0 os58m2 15f6w0y ibz96v 1ttos39 8cyqm2 1cgn3lv 17h8ziz 1pb5o7w 1y2cu33 p1dvl6 14ukgk6 wwzlz2 kz9nqe 1hipxkh ect2dm y4cf8a elbm7f 1e9i83y 17yg843 tttgpl 16fqzm2 1lcaowc avaain 12hccii y8nd8l 9e78hl glvxc9 rdw702 1mbvac 109rq7o 3tlap1 12r3co1 1uz1ca8 1r4i92e klul57 1a53cuj 1shzr3u tosbt8 isu8nh 1xir693 vkpbou 1wwe1mi 11xe9bu 1p6anfw 1o7trcs er9oa0 11vxpqc w6hc5l 194i6pr 10hq5cq 5zzwsk 1sdaje0 16zn8nb lqxdi4 1izbchs 3tss6n 1e7l74i awenke 14mz37s 1le4ixv 1rtvtu5 1qxltt 18hfuhz 1ysdk7i 1t8mymo mhxc3l mfwrfv dnk6tr 66hogn 1tx4sqk 9zdshs kt9wlt 1i342d0 14tkj09 41bl8c 18pitmu 18cyach 4mjixn nj5jao 1x0hldo 1w0fo28 heqd82 17t8q7b 1m23nk7 1lbbgad pocf23 zu1fd9 1pp81zm pu1sy6 yg4zrc k1vhee fossqd j3w6wb 1giivcq ddf1wi xf43jl 3x1x0z 1h1ezso 18411a1 21isvz vi7os3 1q2dk60 fo4w6z ygjxgh 102ctxe hqoq27 9e1ukq xyss4m q76bkn 14gme47 n4owjk 1haxrmz t2dtan 1ij4tou 10j4v47 1o3p705 1wxws1r 19eam1p yi9s71 1lbz6ez vibzgs qprpng 1yduq3m 1ngqhfk 10kck6o i5gfxx ge5xgp 1v397f0 1hy529c kammsl c4kygy 91lgpk nosp2s 10rqwzg 1w2x6ij 11rhxc6 yqz51q 1dijbt5 qjynpy 1vrrbyb 1xyi04h 1wf840d 1creg26 ygowzy 5hi9qv sts64 1g9k069 1xnlu54 1bljy3y 4rr662 18yycfp 13lm9u3 1qbs42f">
+    .dcr-vg6br7 {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 1.0625rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 40px;
+      top: -40px;
+      line-height: 30px;
+      overflow: hidden;
+      padding: 0;
+      position: absolute;
+      background: #FFFFFF;
+      display: block;
+      text-align: center;
+      margin: 0;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      color: #000000;
+    }
+
+    .dcr-vg6br7:focus,
+    .dcr-vg6br7:active {
+      border: 5px solid #0077B6;
+      position: static;
+    }
+
+    .dcr-vg6br7:visited,
+    .dcr-vg6br7:active {
+      color: #000000;
+    }
+
+    .dcr-8h2mpe {
+      position: -webkit-sticky;
+      position: sticky;
+      top: 0;
+      z-index: 17;
+      background-color: white;
+    }
+
+    .dcr-1u9kji9 {
+      position: static;
+    }
+
+    @media (max-width: 739px) {
+      .dcr-1bn3p0w {
+        display: none;
+      }
+    }
+
+    .dcr-zzftu {
+      z-index: 1080;
+      width: 100%;
+      background-color: #F6F6F6;
+      min-height: 132px;
+      border-bottom: 1px solid #DCDCDC;
+      padding-bottom: 18px;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+      -webkit-box-pack: center;
+      -ms-flex-pack: center;
+      -webkit-justify-content: center;
+      justify-content: center;
+      position: -webkit-sticky;
+      position: sticky;
+      top: 0;
+    }
+
+    .dcr-zzftu .ad-slot__scroll {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      max-height: 24px;
+      background-color: #F6F6F6;
+      padding: 0 8px;
+      border-top: 1px solid #DCDCDC;
+      color: #707070;
+      text-align: left;
+      box-sizing: border-box;
+      position: relative;
+    }
+
+    .dcr-zzftu .ad-slot__scroll.visible {
+      visibility: initial;
+    }
+
+    .dcr-zzftu .ad-slot__scroll.hidden {
+      visibility: hidden;
+    }
+
+    .dcr-zzftu .ad-slot__close-button {
+      display: none;
+    }
+
+    .dcr-zzftu .ad-slot__scroll {
+      position: fixed;
+      bottom: 0;
+      width: 100%;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      max-height: 24px;
+      background-color: #F6F6F6;
+      padding: 0 8px;
+      border-top: 1px solid #DCDCDC;
+      color: #707070;
+      text-align: left;
+      box-sizing: border-box;
+    }
+
+    .dcr-zzftu .ad-slot:not[data-label-show='true']::before {
+      content: '';
+      display: block;
+      height: 24px;
+      visibility: hidden;
+    }
+
+    .dcr-zzftu .ad-slot[data-label-show='true']:not(.ad-slot--interscroller):not(.ad-slot--merchandising):not(.ad-slot--merchandising-high)::before {
+      content: attr(ad-label-text);
+      display: block;
+      position: relative;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      max-height: 24px;
+      background-color: #F6F6F6;
+      padding: 0 8px;
+      border-top: 1px solid #DCDCDC;
+      color: #707070;
+      text-align: left;
+      box-sizing: border-box;
+    }
+
+    .dcr-zzftu .ad-slot--merchandising[data-label-show='true']::before,
+    .dcr-zzftu .ad-slot--merchandising-high[data-label-show='true']::before {
+      content: attr(ad-label-text);
+      display: block;
+      position: relative;
+      max-width: 970px;
+      margin: auto;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      max-height: 24px;
+      background-color: #F6F6F6;
+      padding: 0 8px;
+      border-top: 1px solid #DCDCDC;
+      color: #707070;
+      text-align: left;
+      box-sizing: border-box;
+    }
+
+    .dcr-zzftu .ad-slot__adtest-cookie-clear-link {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      text-align: left;
+      position: absolute;
+      left: 268px;
+      top: 1px;
+      z-index: 10;
+      padding: 0;
+      border: 0;
+    }
+
+    .dcr-fks95w[top-above-nav-ad-rendered] {
+      width: -webkit-fit-content;
+      width: -moz-fit-content;
+      width: fit-content;
+      margin: auto;
+    }
+
+    .dcr-fks95w .ad-slot.ad-slot--collapse {
+      display: none;
+    }
+
+    .dcr-12433rp {
+      position: relative;
+      margin: 0 auto;
+      min-height: 90px;
+      text-align: left;
+      display: block;
+      min-width: 728px;
+    }
+
+    .dcr-12433rp .ad-slot__scroll {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      max-height: 24px;
+      background-color: #F6F6F6;
+      padding: 0 8px;
+      border-top: 1px solid #DCDCDC;
+      color: #707070;
+      text-align: left;
+      box-sizing: border-box;
+      position: relative;
+    }
+
+    .dcr-12433rp .ad-slot__scroll.visible {
+      visibility: initial;
+    }
+
+    .dcr-12433rp .ad-slot__scroll.hidden {
+      visibility: hidden;
+    }
+
+    .dcr-12433rp .ad-slot__close-button {
+      display: none;
+    }
+
+    .dcr-12433rp .ad-slot__scroll {
+      position: fixed;
+      bottom: 0;
+      width: 100%;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      max-height: 24px;
+      background-color: #F6F6F6;
+      padding: 0 8px;
+      border-top: 1px solid #DCDCDC;
+      color: #707070;
+      text-align: left;
+      box-sizing: border-box;
+    }
+
+    .dcr-12433rp .ad-slot:not[data-label-show='true']::before {
+      content: '';
+      display: block;
+      height: 24px;
+      visibility: hidden;
+    }
+
+    .dcr-12433rp .ad-slot[data-label-show='true']:not(.ad-slot--interscroller):not(.ad-slot--merchandising):not(.ad-slot--merchandising-high)::before {
+      content: attr(ad-label-text);
+      display: block;
+      position: relative;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      max-height: 24px;
+      background-color: #F6F6F6;
+      padding: 0 8px;
+      border-top: 1px solid #DCDCDC;
+      color: #707070;
+      text-align: left;
+      box-sizing: border-box;
+    }
+
+    .dcr-12433rp .ad-slot--merchandising[data-label-show='true']::before,
+    .dcr-12433rp .ad-slot--merchandising-high[data-label-show='true']::before {
+      content: attr(ad-label-text);
+      display: block;
+      position: relative;
+      max-width: 970px;
+      margin: auto;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      max-height: 24px;
+      background-color: #F6F6F6;
+      padding: 0 8px;
+      border-top: 1px solid #DCDCDC;
+      color: #707070;
+      text-align: left;
+      box-sizing: border-box;
+    }
+
+    .dcr-12433rp .ad-slot__adtest-cookie-clear-link {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      text-align: left;
+      position: absolute;
+      left: 268px;
+      top: 1px;
+      z-index: 10;
+      padding: 0;
+      border: 0;
+    }
+
+    .dcr-12433rp.ad-slot--fluid {
+      min-height: 250px;
+      line-height: 10px;
+      padding: 0;
+      margin: 0;
+    }
+
+    .dcr-12433rp .ad-slot.ad-slot--collapse {
+      display: none;
+    }
+
+    .dcr-12433rp.ad-slot--fluid {
+      width: 100%;
+    }
+
+    .dcr-1uyetce {
+      background-color: #052962;
+    }
+
+    .dcr-henwc {
+      background-color: #052962;
+    }
+
+    .dcr-1kfeu4u {
+      background-color: #041F4A;
+    }
+
+    .dcr-1kvcc9o {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      height: 30px;
+      background-color: #041F4A;
+      box-sizing: border-box;
+      padding-left: 10px;
+      position: relative;
+      margin: auto;
+    }
+
+    @media (min-width: 480px) {
+      .dcr-1kvcc9o {
+        padding-left: 20px;
+      }
+    }
+
+    @media (min-width: 740px) {
+      .dcr-1kvcc9o {
+        padding-left: 15px;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-1kvcc9o {
+        height: 35px;
+        -webkit-box-pack: end;
+        -ms-flex-pack: end;
+        -webkit-justify-content: flex-end;
+        justify-content: flex-end;
+        padding-right: 20px;
+      }
+    }
+
+    @media (min-width: 1300px) {
+      .dcr-1kvcc9o {
+        padding-right: 96px;
+      }
+    }
+
+    @media (min-width: 740px) {
+      .dcr-1kvcc9o {
+        max-width: 740px;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-1kvcc9o {
+        max-width: 980px;
+      }
+    }
+
+    @media (min-width: 1140px) {
+      .dcr-1kvcc9o {
+        max-width: 1140px;
+      }
+    }
+
+    @media (min-width: 1300px) {
+      .dcr-1kvcc9o {
+        max-width: 1300px;
+      }
+    }
+
+    .dcr-1492oy5 {
+      display: none;
+    }
+
+    @media (min-width: 980px) {
+      .dcr-1492oy5 {
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+      }
+    }
+
+    .dcr-1086n7e {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-align-items: center;
+      -webkit-box-align: center;
+      -ms-flex-align: center;
+      align-items: center;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 1.0625rem;
+      line-height: 1.35;
+      font-weight: 700;
+      --source-text-decoration-thickness: 2px;
+      font-size: 1rem;
+      height: -webkit-fit-content;
+      height: -moz-fit-content;
+      height: fit-content;
+      line-height: 1;
+      color: #FFE500;
+      -webkit-transition: color 80ms ease-out;
+      transition: color 80ms ease-out;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      padding: 7px 0;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-1086n7e {
+        padding: 7px 10px 7px 6px;
+      }
+    }
+
+    .dcr-1086n7e:hover,
+    .dcr-1086n7e:focus {
+      -webkit-text-decoration: underline;
+      text-decoration: underline;
+    }
+
+    .dcr-1086n7e svg {
+      fill: currentColor;
+      float: left;
+      height: 18px;
+      width: 18px;
+      margin: 0 4px 0 0;
+    }
+
+    .dcr-bi2aot {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-align-items: center;
+      -webkit-box-align: center;
+      -ms-flex-align: center;
+      align-items: center;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-bi2aot {
+        -webkit-align-items: stretch;
+        -webkit-box-align: stretch;
+        -ms-flex-align: stretch;
+        align-items: stretch;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-bi2aot:before {
+        content: '';
+        border-left: 1px solid #506991;
+        height: 24px;
+      }
+    }
+
+    .dcr-xg94hc {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-align-items: center;
+      -webkit-box-align: center;
+      -ms-flex-align: center;
+      align-items: center;
+      height: -webkit-fit-content;
+      height: -moz-fit-content;
+      height: fit-content;
+      position: relative;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 1.0625rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      font-size: 1rem;
+      line-height: 1;
+      color: #FFFFFF;
+      -webkit-transition: color 80ms ease-out;
+      transition: color 80ms ease-out;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      padding: 0;
+      z-index: 11;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-xg94hc {
+        padding: 7px 10px 7px 6px;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-xg94hc {
+        font-weight: bold;
+      }
+    }
+
+    .dcr-xg94hc:hover,
+    .dcr-xg94hc:focus {
+      -webkit-text-decoration: underline;
+      text-decoration: underline;
+    }
+
+    .dcr-xg94hc svg {
+      fill: currentColor;
+      float: left;
+      height: 18px;
+      width: 18px;
+      margin: 0 4px 0 0;
+    }
+
+    .dcr-1gd007l {
+      display: none;
+    }
+
+    .dcr-1gd007l:before {
+      content: '';
+      border-left: 1px solid #506991;
+      height: 24px;
+    }
+
+    @media (min-width: 980px) {
+      .dcr-1gd007l {
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+      }
+    }
+
+    .dcr-1yaip4y {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 1.0625rem;
+      line-height: 1.35;
+      font-weight: 700;
+      --source-text-decoration-thickness: 2px;
+      font-size: 1rem;
+      line-height: 1;
+      color: #FFFFFF;
+      -webkit-transition: color 80ms ease-out;
+      transition: color 80ms ease-out;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      padding: 7px 0;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-1yaip4y {
+        padding: 8px 10px 7px 6px;
+      }
+    }
+
+    .dcr-1yaip4y:hover,
+    .dcr-1yaip4y:focus {
+      -webkit-text-decoration: underline;
+      text-decoration: underline;
+    }
+
+    .dcr-j7jlyl {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-align-items: center;
+      -webkit-box-align: center;
+      -ms-flex-align: center;
+      align-items: center;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 1.0625rem;
+      line-height: 1.35;
+      font-weight: 700;
+      --source-text-decoration-thickness: 2px;
+      line-height: 1;
+      font-size: 1rem;
+      height: -webkit-fit-content;
+      height: -moz-fit-content;
+      height: fit-content;
+      color: #FFFFFF;
+      -webkit-transition: color 80ms ease-out;
+      transition: color 80ms ease-out;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      padding: 7px 0;
+      z-index: 10;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-j7jlyl {
+        padding: 7px 10px 7px 6px;
+      }
+    }
+
+    .dcr-j7jlyl:hover,
+    .dcr-j7jlyl:focus {
+      -webkit-text-decoration: underline;
+      text-decoration: underline;
+    }
+
+    .dcr-j7jlyl svg {
+      fill: currentColor;
+      float: left;
+      height: 18px;
+      width: 18px;
+      margin: 0 4px 0 0;
+    }
+
+    @media (max-width: 979px) {
+      .dcr-14f8c26 {
+        display: none;
+      }
+    }
+
+    .dcr-h39xrs {
+      z-index: 15;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      position: relative;
+    }
+
+    .dcr-h39xrs:before {
+      content: '';
+      border-left: 1px solid #506991;
+      height: 24px;
+    }
+
+    .dcr-g8r8o3 #checkbox-id-edition {
+      position: absolute;
+      overflow: hidden;
+      white-space: nowrap;
+      width: 1px;
+      height: 1px;
+      margin: -1px;
+      padding: 0;
+      border: 0;
+      clip: rect(1px, 1px, 1px, 1px);
+      -webkit-clip-path: inset(50%);
+      -webkit-clip-path: inset(50%);
+      clip-path: inset(50%);
+    }
+
+    .dcr-g8r8o3 #dropbox-id-edition {
+      display: none;
+    }
+
+    .dcr-g8r8o3 #checkbox-id-edition:checked+#dropbox-id-edition {
+      display: block;
+    }
+
+    .dcr-pzbwhq {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 1.0625rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      display: block;
+      cursor: pointer;
+      background: none;
+      border: none;
+      line-height: 1.2;
+      color: #FFFFFF;
+      -webkit-transition: color 80ms ease-out;
+      transition: color 80ms ease-out;
+      padding: 0px 10px 6px 5px;
+      margin: 1px 0 0;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      position: relative;
+      color: #FFFFFF;
+      padding-right: 0;
+      padding-bottom: 0;
+      margin-top: 0;
+      font-size: 1rem;
+      padding-top: 6px;
+    }
+
+    .dcr-pzbwhq:hover {
+      color: #FFE500;
+    }
+
+    .dcr-pzbwhq:hover:after {
+      -webkit-transform: translateY(0) rotate(45deg);
+      -moz-transform: translateY(0) rotate(45deg);
+      -ms-transform: translateY(0) rotate(45deg);
+      transform: translateY(0) rotate(45deg);
+    }
+
+    .dcr-pzbwhq:after {
+      content: '';
+      display: inline-block;
+      width: 5px;
+      height: 5px;
+      -webkit-transform: translateY(-2px) rotate(45deg);
+      -moz-transform: translateY(-2px) rotate(45deg);
+      -ms-transform: translateY(-2px) rotate(45deg);
+      transform: translateY(-2px) rotate(45deg);
+      border: 1px solid currentColor;
+      border-left: transparent;
+      border-top: transparent;
+      margin-left: 5px;
+      vertical-align: middle;
+      -webkit-transition: -webkit-transform 250ms ease-out;
+      transition: transform 250ms ease-out;
+    }
+
+    .dcr-pzbwhq:not(ul):hover {
+      color: #FFFFFF;
+      -webkit-text-decoration: underline;
+      text-decoration: underline;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-pzbwhq {
+        right: 0;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-pzbwhq {
+        font-weight: bold;
+      }
+    }
+
+    .dcr-1w7ojan {
+      z-index: 23;
+      list-style: none;
+      background-color: white;
+      padding: 6px 0;
+      box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
+      color: #FFFFFF;
+      padding-right: 0;
+      padding-bottom: 0;
+      margin-top: 0;
+      font-size: 1rem;
+      padding-top: 6px;
+    }
+
+    .dcr-1w7ojan li::before {
+      content: '\200B';
+      display: block;
+      height: 0;
+      width: 0;
+    }
+
+    @media (max-width: 739px) {
+      .dcr-1w7ojan {
+        position: fixed;
+        border-radius: 0;
+        top: 32px;
+        left: 0;
+        right: 0;
+        width: auto;
+        max-height: calc(100% - 50px);
+        overflow: auto;
+      }
+    }
+
+    @media (min-width: 740px) {
+      .dcr-1w7ojan {
+        position: absolute;
+        top: 100%;
+        width: 200px;
+        border-radius: 3px;
+      }
+    }
+
+    .dcr-1w7ojan:not(ul):hover {
+      color: #FFFFFF;
+      -webkit-text-decoration: underline;
+      text-decoration: underline;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-1w7ojan {
+        right: 0;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-1w7ojan {
+        font-weight: bold;
+      }
+    }
+
+    .dcr-1irynrj {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.9375rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      color: #121212;
+      position: relative;
+      -webkit-transition: color 80ms ease-out;
+      transition: color 80ms ease-out;
+      margin: -1px 0 0 0;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      display: block;
+      padding: 10px 18px 15px 30px;
+      font-weight: bold;
+    }
+
+    .dcr-1irynrj:hover {
+      background-color: #EDEDED;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+    }
+
+    .dcr-1irynrj:focus {
+      -webkit-text-decoration: underline;
+      text-decoration: underline;
+    }
+
+    .dcr-1irynrj:before {
+      content: '';
+      border-top: 1px solid #DCDCDC;
+      display: block;
+      position: absolute;
+      top: 0px;
+      left: 30px;
+      right: 0px;
+    }
+
+    .dcr-1irynrj:after {
+      content: '';
+      border: 2px solid #C70000;
+      border-top: 0px;
+      border-right: 0px;
+      position: absolute;
+      top: 19px;
+      left: 12px;
+      width: 10px;
+      height: 4px;
+      -webkit-transform: rotate(-45deg);
+      -moz-transform: rotate(-45deg);
+      -ms-transform: rotate(-45deg);
+      transform: rotate(-45deg);
+    }
+
+    .dcr-1irynrj:before {
+      content: none;
+    }
+
+    .dcr-16rjsjj {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.9375rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      color: #121212;
+      position: relative;
+      -webkit-transition: color 80ms ease-out;
+      transition: color 80ms ease-out;
+      margin: -1px 0 0 0;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      display: block;
+      padding: 10px 18px 15px 30px;
+    }
+
+    .dcr-16rjsjj:hover {
+      background-color: #EDEDED;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+    }
+
+    .dcr-16rjsjj:focus {
+      -webkit-text-decoration: underline;
+      text-decoration: underline;
+    }
+
+    .dcr-16rjsjj:before {
+      content: '';
+      border-top: 1px solid #DCDCDC;
+      display: block;
+      position: absolute;
+      top: 0px;
+      left: 30px;
+      right: 0px;
+    }
+
+    .dcr-127sebo {
+      position: relative;
+      margin: auto;
+      overflow: hidden;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-127sebo {
+        max-width: 740px;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-127sebo {
+        max-width: 980px;
+      }
+    }
+
+    @media (min-width: 1140px) {
+      .dcr-127sebo {
+        max-width: 1140px;
+      }
+    }
+
+    @media (min-width: 1300px) {
+      .dcr-127sebo {
+        max-width: 1300px;
+      }
+    }
+
+    .dcr-12xduix {
+      float: right;
+      margin-top: 6px;
+      margin-right: 54px;
+      margin-bottom: 10px;
+      width: 146px;
+      z-index: 9;
+    }
+
+    @media (min-width: 375px) {
+      .dcr-12xduix {
+        margin-right: 10px;
+        width: 195px;
+      }
+    }
+
+    @media (min-width: 480px) {
+      .dcr-12xduix {
+        margin-right: 20px;
+      }
+    }
+
+    @media (min-width: 740px) {
+      .dcr-12xduix {
+        width: 224px;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-12xduix {
+        margin-top: 5px;
+        margin-bottom: 12px;
+        position: relative;
+        width: 295px;
+      }
+    }
+
+    @media (min-width: 1300px) {
+      .dcr-12xduix {
+        margin-right: 96px;
+      }
+    }
+
+    .dcr-1ppwqv1 {
+      position: absolute;
+      overflow: hidden;
+      white-space: nowrap;
+      width: 1px;
+      height: 1px;
+      margin: -1px;
+      padding: 0;
+      border: 0;
+      clip: rect(1px, 1px, 1px, 1px);
+      -webkit-clip-path: inset(50%);
+      -webkit-clip-path: inset(50%);
+      clip-path: inset(50%);
+    }
+
+    .dcr-1z074wr {
+      position: relative;
+      margin: auto;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-1z074wr {
+        max-width: 740px;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-1z074wr {
+        max-width: 980px;
+      }
+    }
+
+    @media (min-width: 1140px) {
+      .dcr-1z074wr {
+        max-width: 1140px;
+      }
+    }
+
+    @media (min-width: 1300px) {
+      .dcr-1z074wr {
+        max-width: 1300px;
+      }
+    }
+
+    @media (min-width: 740px) {
+      .dcr-1z074wr {
+        border-left: 1px solid #506991;
+        border-right: 1px solid #506991;
+      }
+    }
+
+    .dcr-x2bp9n {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: row;
+      -ms-flex-direction: row;
+      flex-direction: row;
+      -webkit-box-pack: justify;
+      -webkit-justify-content: space-between;
+      justify-content: space-between;
+    }
+
+    .dcr-1yaxlqk {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: row;
+      -ms-flex-direction: row;
+      flex-direction: row;
+      -webkit-box-pack: justify;
+      -webkit-justify-content: space-between;
+      justify-content: space-between;
+    }
+
+    .dcr-1yaxlqk:after {
+      content: '';
+      display: table;
+      clear: both;
+    }
+
+    .dcr-sy54ny {
+      position: absolute;
+      overflow: hidden;
+      white-space: nowrap;
+      width: 1px;
+      height: 1px;
+      margin: -1px;
+      padding: 0;
+      border: 0;
+      clip: rect(1px, 1px, 1px, 1px);
+      -webkit-clip-path: inset(50%);
+      -webkit-clip-path: inset(50%);
+      clip-path: inset(50%);
+    }
+
+    .dcr-1ikbe4v {
+      clear: right;
+      margin: 0;
+      list-style: none;
+      list-style-image: none;
+      padding-left: 10px;
+    }
+
+    @media (min-width: 480px) {
+      .dcr-1ikbe4v {
+        padding-left: 20px;
+      }
+    }
+
+    .dcr-1ikbe4v li {
+      float: left;
+      display: block;
+      position: relative;
+      width: auto;
+    }
+
+    @media (min-width: 980px) {
+      .dcr-1ikbe4v li {
+        width: 134px;
+      }
+    }
+
+    @media (min-width: 1140px) {
+      .dcr-1ikbe4v li {
+        width: 160px;
+      }
+    }
+
+    .dcr-1ikbe4v li::before {
+      content: '\200B';
+      display: block;
+      height: 0;
+      width: 0;
+    }
+
+    .dcr-1ikbe4v:after {
+      content: '';
+      border-top: 1px solid #506991;
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      height: 36px;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-1ikbe4v:after {
+        border-bottom: 0;
+        height: 49px;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-1ikbe4v:after {
+        height: 42px;
+      }
+    }
+
+    .dcr-1aeyz4o:first-of-type {
+      margin-left: -20px;
+      width: auto;
+    }
+
+    @media (min-width: 980px) {
+      .dcr-1aeyz4o:first-of-type {
+        width: 144px;
+      }
+    }
+
+    @media (min-width: 1140px) {
+      .dcr-1aeyz4o:first-of-type {
+        width: 171px;
+      }
+    }
+
+    .dcr-1aeyz4o:first-of-type a {
+      padding-left: 20px;
+    }
+
+    @media (max-width: 979px) {
+      .dcr-1aeyz4o:last-child a:before {
+        content: none;
+      }
+    }
+
+    .dcr-h2gqsd {
+      font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+      font-size: 1.0625rem;
+      line-height: 1.15;
+      font-weight: 500;
+      --source-text-decoration-thickness: 2px;
+      box-sizing: border-box;
+      font-weight: 900;
+      color: #FFFFFF;
+      cursor: pointer;
+      display: block;
+      font-size: 15.4px;
+      height: 36px;
+      padding-top: 9px;
+      padding-right: 5px;
+      padding-bottom: 0;
+      padding-left: 5px;
+      position: relative;
+      overflow: hidden;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      z-index: 1;
+    }
+
+    @media (min-width: 375px) {
+      .dcr-h2gqsd {
+        font-size: 15.7px;
+        padding-top: 9px;
+        padding-right: 5px;
+        padding-bottom: 0;
+        padding-left: 5px;
+      }
+    }
+
+    @media (min-width: 480px) {
+      .dcr-h2gqsd {
+        font-size: 18px;
+        padding-top: 9px;
+        padding-right: 5px;
+        padding-bottom: 0;
+        padding-left: 5px;
+      }
+    }
+
+    @media (min-width: 740px) {
+      .dcr-h2gqsd {
+        font-size: 22px;
+        height: 48px;
+        padding-top: 9px;
+        padding-right: 20px;
+        padding-bottom: 0;
+        padding-left: 9px;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-h2gqsd {
+        padding-top: 5px;
+        height: 42px;
+      }
+    }
+
+    @media (min-width: 1300px) {
+      .dcr-h2gqsd {
+        padding-top: 7px;
+        font-size: 24px;
+      }
+    }
+
+    .dcr-h2gqsd:focus:after {
+      -webkit-transform: translateY(4px);
+      -moz-transform: translateY(4px);
+      -ms-transform: translateY(4px);
+      transform: translateY(4px);
+    }
+
+    .dcr-h2gqsd:hover {
+      -webkit-text-decoration: none;
+      text-decoration: none;
+    }
+
+    .dcr-h2gqsd:hover:after {
+      -webkit-transform: translateY(4px);
+      -moz-transform: translateY(4px);
+      -ms-transform: translateY(4px);
+      transform: translateY(4px);
+    }
+
+    .dcr-h2gqsd:after {
+      border-top: 4px solid #FF5943;
+      left: 0;
+      right: 1px;
+      top: -4px;
+      content: '';
+      display: block;
+      position: absolute;
+      -webkit-transition: -webkit-transform 0.3s ease-in-out;
+      transition: transform 0.3s ease-in-out;
+    }
+
+    @media (min-width: 980px) {
+      #top-nav-input-checkbox:checked~ul li .dcr-h2gqsd:before {
+        bottom: 0;
+      }
+    }
+
+    #top-nav-input-checkbox:checked~ul li .dcr-h2gqsd:hover,
+    #top-nav-input-checkbox:checked~ul li .dcr-h2gqsd:focus {
+      -webkit-text-decoration: underline;
+      text-decoration: underline;
+      color: #FFE500;
+    }
+
+    #top-nav-input-checkbox:checked~ul li .dcr-h2gqsd:after {
+      -webkit-transform: translateY(4px);
+      -moz-transform: translateY(4px);
+      -ms-transform: translateY(4px);
+      transform: translateY(4px);
+    }
+
+    .dcr-h2gqsd:after {
+      -webkit-transform: translateY(4px);
+      -moz-transform: translateY(4px);
+      -ms-transform: translateY(4px);
+      transform: translateY(4px);
+    }
+
+    .dcr-h2gqsd:focus:after {
+      -webkit-transform: translateY(4px);
+      -moz-transform: translateY(4px);
+      -ms-transform: translateY(4px);
+      transform: translateY(4px);
+    }
+
+    .dcr-h2gqsd:hover {
+      -webkit-text-decoration: none;
+      text-decoration: none;
+    }
+
+    .dcr-h2gqsd:hover:after {
+      -webkit-transform: translateY(4px);
+      -moz-transform: translateY(4px);
+      -ms-transform: translateY(4px);
+      transform: translateY(4px);
+    }
+
+    .dcr-h2gqsd:before {
+      content: '';
+      display: block;
+      position: absolute;
+      right: 0;
+      top: 0;
+      bottom: 0;
+      width: 1px;
+      background-color: #506991;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-h2gqsd:before {
+        bottom: 17px;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-h2gqsd:before {
+        bottom: 0.6em;
+      }
+    }
+
+    .dcr-c8vw16 {
+      font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+      font-size: 1.0625rem;
+      line-height: 1.15;
+      font-weight: 500;
+      --source-text-decoration-thickness: 2px;
+      box-sizing: border-box;
+      font-weight: 900;
+      color: #FFFFFF;
+      cursor: pointer;
+      display: block;
+      font-size: 15.4px;
+      height: 36px;
+      padding-top: 9px;
+      padding-right: 5px;
+      padding-bottom: 0;
+      padding-left: 5px;
+      position: relative;
+      overflow: hidden;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      z-index: 1;
+    }
+
+    @media (min-width: 375px) {
+      .dcr-c8vw16 {
+        font-size: 15.7px;
+        padding-top: 9px;
+        padding-right: 5px;
+        padding-bottom: 0;
+        padding-left: 5px;
+      }
+    }
+
+    @media (min-width: 480px) {
+      .dcr-c8vw16 {
+        font-size: 18px;
+        padding-top: 9px;
+        padding-right: 5px;
+        padding-bottom: 0;
+        padding-left: 5px;
+      }
+    }
+
+    @media (min-width: 740px) {
+      .dcr-c8vw16 {
+        font-size: 22px;
+        height: 48px;
+        padding-top: 9px;
+        padding-right: 20px;
+        padding-bottom: 0;
+        padding-left: 9px;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-c8vw16 {
+        padding-top: 5px;
+        height: 42px;
+      }
+    }
+
+    @media (min-width: 1300px) {
+      .dcr-c8vw16 {
+        padding-top: 7px;
+        font-size: 24px;
+      }
+    }
+
+    .dcr-c8vw16:focus:after {
+      -webkit-transform: translateY(4px);
+      -moz-transform: translateY(4px);
+      -ms-transform: translateY(4px);
+      transform: translateY(4px);
+    }
+
+    .dcr-c8vw16:hover {
+      -webkit-text-decoration: none;
+      text-decoration: none;
+    }
+
+    .dcr-c8vw16:hover:after {
+      -webkit-transform: translateY(4px);
+      -moz-transform: translateY(4px);
+      -ms-transform: translateY(4px);
+      transform: translateY(4px);
+    }
+
+    .dcr-c8vw16:after {
+      border-top: 4px solid #FF7F0F;
+      left: 0;
+      right: 1px;
+      top: -4px;
+      content: '';
+      display: block;
+      position: absolute;
+      -webkit-transition: -webkit-transform 0.3s ease-in-out;
+      transition: transform 0.3s ease-in-out;
+    }
+
+    @media (min-width: 980px) {
+      #top-nav-input-checkbox:checked~ul li .dcr-c8vw16:before {
+        bottom: 0;
+      }
+    }
+
+    #top-nav-input-checkbox:checked~ul li .dcr-c8vw16:hover,
+    #top-nav-input-checkbox:checked~ul li .dcr-c8vw16:focus {
+      -webkit-text-decoration: underline;
+      text-decoration: underline;
+      color: #FFE500;
+    }
+
+    #top-nav-input-checkbox:checked~ul li .dcr-c8vw16:after {
+      -webkit-transform: translateY(4px);
+      -moz-transform: translateY(4px);
+      -ms-transform: translateY(4px);
+      transform: translateY(4px);
+    }
+
+    .dcr-c8vw16:before {
+      content: '';
+      display: block;
+      position: absolute;
+      right: 0;
+      top: 0;
+      bottom: 0;
+      width: 1px;
+      background-color: #506991;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-c8vw16:before {
+        bottom: 17px;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-c8vw16:before {
+        bottom: 0.6em;
+      }
+    }
+
+    .dcr-a6bcsq {
+      font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+      font-size: 1.0625rem;
+      line-height: 1.15;
+      font-weight: 500;
+      --source-text-decoration-thickness: 2px;
+      box-sizing: border-box;
+      font-weight: 900;
+      color: #FFFFFF;
+      cursor: pointer;
+      display: block;
+      font-size: 15.4px;
+      height: 36px;
+      padding-top: 9px;
+      padding-right: 5px;
+      padding-bottom: 0;
+      padding-left: 5px;
+      position: relative;
+      overflow: hidden;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      z-index: 1;
+    }
+
+    @media (min-width: 375px) {
+      .dcr-a6bcsq {
+        font-size: 15.7px;
+        padding-top: 9px;
+        padding-right: 5px;
+        padding-bottom: 0;
+        padding-left: 5px;
+      }
+    }
+
+    @media (min-width: 480px) {
+      .dcr-a6bcsq {
+        font-size: 18px;
+        padding-top: 9px;
+        padding-right: 5px;
+        padding-bottom: 0;
+        padding-left: 5px;
+      }
+    }
+
+    @media (min-width: 740px) {
+      .dcr-a6bcsq {
+        font-size: 22px;
+        height: 48px;
+        padding-top: 9px;
+        padding-right: 20px;
+        padding-bottom: 0;
+        padding-left: 9px;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-a6bcsq {
+        padding-top: 5px;
+        height: 42px;
+      }
+    }
+
+    @media (min-width: 1300px) {
+      .dcr-a6bcsq {
+        padding-top: 7px;
+        font-size: 24px;
+      }
+    }
+
+    .dcr-a6bcsq:focus:after {
+      -webkit-transform: translateY(4px);
+      -moz-transform: translateY(4px);
+      -ms-transform: translateY(4px);
+      transform: translateY(4px);
+    }
+
+    .dcr-a6bcsq:hover {
+      -webkit-text-decoration: none;
+      text-decoration: none;
+    }
+
+    .dcr-a6bcsq:hover:after {
+      -webkit-transform: translateY(4px);
+      -moz-transform: translateY(4px);
+      -ms-transform: translateY(4px);
+      transform: translateY(4px);
+    }
+
+    .dcr-a6bcsq:after {
+      border-top: 4px solid #00B2FF;
+      left: 0;
+      right: 1px;
+      top: -4px;
+      content: '';
+      display: block;
+      position: absolute;
+      -webkit-transition: -webkit-transform 0.3s ease-in-out;
+      transition: transform 0.3s ease-in-out;
+    }
+
+    @media (min-width: 980px) {
+      #top-nav-input-checkbox:checked~ul li .dcr-a6bcsq:before {
+        bottom: 0;
+      }
+    }
+
+    #top-nav-input-checkbox:checked~ul li .dcr-a6bcsq:hover,
+    #top-nav-input-checkbox:checked~ul li .dcr-a6bcsq:focus {
+      -webkit-text-decoration: underline;
+      text-decoration: underline;
+      color: #FFE500;
+    }
+
+    #top-nav-input-checkbox:checked~ul li .dcr-a6bcsq:after {
+      -webkit-transform: translateY(4px);
+      -moz-transform: translateY(4px);
+      -ms-transform: translateY(4px);
+      transform: translateY(4px);
+    }
+
+    .dcr-a6bcsq:before {
+      content: '';
+      display: block;
+      position: absolute;
+      right: 0;
+      top: 0;
+      bottom: 0;
+      width: 1px;
+      background-color: #506991;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-a6bcsq:before {
+        bottom: 17px;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-a6bcsq:before {
+        bottom: 0.6em;
+      }
+    }
+
+    .dcr-1tabvac {
+      font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+      font-size: 1.0625rem;
+      line-height: 1.15;
+      font-weight: 500;
+      --source-text-decoration-thickness: 2px;
+      box-sizing: border-box;
+      font-weight: 900;
+      color: #FFFFFF;
+      cursor: pointer;
+      display: block;
+      font-size: 15.4px;
+      height: 36px;
+      padding-top: 9px;
+      padding-right: 5px;
+      padding-bottom: 0;
+      padding-left: 5px;
+      position: relative;
+      overflow: hidden;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      z-index: 1;
+    }
+
+    @media (min-width: 375px) {
+      .dcr-1tabvac {
+        font-size: 15.7px;
+        padding-top: 9px;
+        padding-right: 5px;
+        padding-bottom: 0;
+        padding-left: 5px;
+      }
+    }
+
+    @media (min-width: 480px) {
+      .dcr-1tabvac {
+        font-size: 18px;
+        padding-top: 9px;
+        padding-right: 5px;
+        padding-bottom: 0;
+        padding-left: 5px;
+      }
+    }
+
+    @media (min-width: 740px) {
+      .dcr-1tabvac {
+        font-size: 22px;
+        height: 48px;
+        padding-top: 9px;
+        padding-right: 20px;
+        padding-bottom: 0;
+        padding-left: 9px;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-1tabvac {
+        padding-top: 5px;
+        height: 42px;
+      }
+    }
+
+    @media (min-width: 1300px) {
+      .dcr-1tabvac {
+        padding-top: 7px;
+        font-size: 24px;
+      }
+    }
+
+    .dcr-1tabvac:focus:after {
+      -webkit-transform: translateY(4px);
+      -moz-transform: translateY(4px);
+      -ms-transform: translateY(4px);
+      transform: translateY(4px);
+    }
+
+    .dcr-1tabvac:hover {
+      -webkit-text-decoration: none;
+      text-decoration: none;
+    }
+
+    .dcr-1tabvac:hover:after {
+      -webkit-transform: translateY(4px);
+      -moz-transform: translateY(4px);
+      -ms-transform: translateY(4px);
+      transform: translateY(4px);
+    }
+
+    .dcr-1tabvac:after {
+      border-top: 4px solid #EACCA0;
+      left: 0;
+      right: 1px;
+      top: -4px;
+      content: '';
+      display: block;
+      position: absolute;
+      -webkit-transition: -webkit-transform 0.3s ease-in-out;
+      transition: transform 0.3s ease-in-out;
+    }
+
+    @media (min-width: 980px) {
+      #top-nav-input-checkbox:checked~ul li .dcr-1tabvac:before {
+        bottom: 0;
+      }
+    }
+
+    #top-nav-input-checkbox:checked~ul li .dcr-1tabvac:hover,
+    #top-nav-input-checkbox:checked~ul li .dcr-1tabvac:focus {
+      -webkit-text-decoration: underline;
+      text-decoration: underline;
+      color: #FFE500;
+    }
+
+    #top-nav-input-checkbox:checked~ul li .dcr-1tabvac:after {
+      -webkit-transform: translateY(4px);
+      -moz-transform: translateY(4px);
+      -ms-transform: translateY(4px);
+      transform: translateY(4px);
+    }
+
+    .dcr-1tabvac:before {
+      content: '';
+      display: block;
+      position: absolute;
+      right: 0;
+      top: 0;
+      bottom: 0;
+      width: 1px;
+      background-color: #506991;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-1tabvac:before {
+        bottom: 17px;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-1tabvac:before {
+        bottom: 0.6em;
+      }
+    }
+
+    .dcr-1t1n4fm {
+      font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+      font-size: 1.0625rem;
+      line-height: 1.15;
+      font-weight: 500;
+      --source-text-decoration-thickness: 2px;
+      box-sizing: border-box;
+      font-weight: 900;
+      color: #FFFFFF;
+      cursor: pointer;
+      display: block;
+      font-size: 15.4px;
+      height: 36px;
+      padding-top: 9px;
+      padding-right: 5px;
+      padding-bottom: 0;
+      padding-left: 5px;
+      position: relative;
+      overflow: hidden;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      z-index: 1;
+    }
+
+    @media (min-width: 375px) {
+      .dcr-1t1n4fm {
+        font-size: 15.7px;
+        padding-top: 9px;
+        padding-right: 5px;
+        padding-bottom: 0;
+        padding-left: 5px;
+      }
+    }
+
+    @media (min-width: 480px) {
+      .dcr-1t1n4fm {
+        font-size: 18px;
+        padding-top: 9px;
+        padding-right: 5px;
+        padding-bottom: 0;
+        padding-left: 5px;
+      }
+    }
+
+    @media (min-width: 740px) {
+      .dcr-1t1n4fm {
+        font-size: 22px;
+        height: 48px;
+        padding-top: 9px;
+        padding-right: 20px;
+        padding-bottom: 0;
+        padding-left: 9px;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-1t1n4fm {
+        padding-top: 5px;
+        height: 42px;
+      }
+    }
+
+    @media (min-width: 1300px) {
+      .dcr-1t1n4fm {
+        padding-top: 7px;
+        font-size: 24px;
+      }
+    }
+
+    .dcr-1t1n4fm:focus:after {
+      -webkit-transform: translateY(4px);
+      -moz-transform: translateY(4px);
+      -ms-transform: translateY(4px);
+      transform: translateY(4px);
+    }
+
+    .dcr-1t1n4fm:hover {
+      -webkit-text-decoration: none;
+      text-decoration: none;
+    }
+
+    .dcr-1t1n4fm:hover:after {
+      -webkit-transform: translateY(4px);
+      -moz-transform: translateY(4px);
+      -ms-transform: translateY(4px);
+      transform: translateY(4px);
+    }
+
+    .dcr-1t1n4fm:after {
+      border-top: 4px solid #FFABDB;
+      left: 0;
+      right: 1px;
+      top: -4px;
+      content: '';
+      display: block;
+      position: absolute;
+      -webkit-transition: -webkit-transform 0.3s ease-in-out;
+      transition: transform 0.3s ease-in-out;
+    }
+
+    @media (min-width: 980px) {
+      #top-nav-input-checkbox:checked~ul li .dcr-1t1n4fm:before {
+        bottom: 0;
+      }
+    }
+
+    #top-nav-input-checkbox:checked~ul li .dcr-1t1n4fm:hover,
+    #top-nav-input-checkbox:checked~ul li .dcr-1t1n4fm:focus {
+      -webkit-text-decoration: underline;
+      text-decoration: underline;
+      color: #FFE500;
+    }
+
+    #top-nav-input-checkbox:checked~ul li .dcr-1t1n4fm:after {
+      -webkit-transform: translateY(4px);
+      -moz-transform: translateY(4px);
+      -ms-transform: translateY(4px);
+      transform: translateY(4px);
+    }
+
+    .dcr-1t1n4fm:before {
+      content: '';
+      display: block;
+      position: absolute;
+      right: 0;
+      top: 0;
+      bottom: 0;
+      width: 1px;
+      background-color: #506991;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-1t1n4fm:before {
+        bottom: 17px;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-1t1n4fm:before {
+        bottom: 0.6em;
+      }
+    }
+
+    .dcr-1kuh7tf {
+      font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+      font-size: 1.5rem;
+      line-height: 1.15;
+      font-weight: 500;
+      --source-text-decoration-thickness: 3px;
+      font-weight: 300;
+      color: #FFFFFF;
+      cursor: pointer;
+      display: none;
+      position: relative;
+      overflow: hidden;
+      border: 0;
+      background-color: transparent;
+      height: 48px;
+      padding-left: 9px;
+      padding-right: 20px;
+    }
+
+    @media (min-width: 980px) {
+      .dcr-1kuh7tf {
+        display: block;
+        padding-top: 5px;
+        height: 42px;
+      }
+    }
+
+    .dcr-1kuh7tf:hover,
+    .dcr-1kuh7tf:focus {
+      color: #FFE500;
+    }
+
+    .dcr-1kuh7tf:hover svg,
+    .dcr-1kuh7tf:focus svg {
+      -webkit-transform: translateY(2px);
+      -moz-transform: translateY(2px);
+      -ms-transform: translateY(2px);
+      transform: translateY(2px);
+    }
+
+    .dcr-1nvgr5i {
+      position: absolute;
+      overflow: hidden;
+      white-space: nowrap;
+      width: 1px;
+      height: 1px;
+      margin: -1px;
+      padding: 0;
+      border: 0;
+      clip: rect(1px, 1px, 1px, 1px);
+      -webkit-clip-path: inset(50%);
+      -webkit-clip-path: inset(50%);
+      clip-path: inset(50%);
+    }
+
+    .dcr-a2u3ka {
+      display: block;
+      height: 100%;
+    }
+
+    #top-nav-input-checkbox:checked~div label .dcr-a2u3ka svg {
+      -webkit-transform: translateY(-2px) rotate(-180deg);
+      -moz-transform: translateY(-2px) rotate(-180deg);
+      -ms-transform: translateY(-2px) rotate(-180deg);
+      transform: translateY(-2px) rotate(-180deg);
+    }
+
+    #top-nav-input-checkbox:checked~div label:hover .dcr-a2u3ka svg,
+    #top-nav-input-checkbox:checked~div label:focus .dcr-a2u3ka svg {
+      -webkit-transform: translateY(-4px) rotate(-180deg);
+      -moz-transform: translateY(-4px) rotate(-180deg);
+      -ms-transform: translateY(-4px) rotate(-180deg);
+      transform: translateY(-4px) rotate(-180deg);
+    }
+
+    .dcr-a2u3ka svg {
+      position: absolute;
+      right: 2px;
+      top: 14px;
+      fill: currentColor;
+      height: 16px;
+      width: 16px;
+      -webkit-transition: -webkit-transform 250ms ease-out;
+      transition: transform 250ms ease-out;
+    }
+
+    .dcr-13vr4eh {
+      background-color: #FFE500;
+      color: #121212;
+      cursor: pointer;
+      height: 42px;
+      min-width: 42px;
+      position: absolute;
+      border: 0;
+      border-radius: 50%;
+      right: 5px;
+      bottom: 58px;
+    }
+
+    @media (min-width: 375px) {
+      .dcr-13vr4eh {
+        bottom: -3px;
+        right: 5px;
+      }
+    }
+
+    @media (min-width: 480px) {
+      .dcr-13vr4eh {
+        right: 18px;
+      }
+    }
+
+    @media (min-width: 740px) {
+      .dcr-13vr4eh {
+        bottom: 3px;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-13vr4eh {
+        display: none;
+      }
+    }
+
+    #top-nav-input-checkbox:checked~div .dcr-13vr4eh {
+      z-index: 22;
+    }
+
+    .dcr-13vr4eh:focus {
+      outline: none;
+    }
+
+    .dcr-120u0k1 {
+      background-color: currentColor;
+      top: 50%;
+      right: 0;
+      margin-top: -1px;
+      margin-left: auto;
+      margin-right: auto;
+      height: 2px;
+      left: 0;
+      position: absolute;
+      width: 20px;
+    }
+
+    #top-nav-input-checkbox:checked~div .dcr-120u0k1 {
+      background-color: transparent;
+    }
+
+    .dcr-120u0k1:before {
+      height: 2px;
+      left: 0;
+      position: absolute;
+      width: 20px;
+      content: '';
+      background-color: currentColor;
+      top: -6px;
+    }
+
+    #top-nav-input-checkbox:checked~div .dcr-120u0k1:before {
+      top: 0;
+      -webkit-transform: rotate(-45deg);
+      -moz-transform: rotate(-45deg);
+      -ms-transform: rotate(-45deg);
+      transform: rotate(-45deg);
+    }
+
+    .dcr-120u0k1:after {
+      height: 2px;
+      left: 0;
+      position: absolute;
+      width: 20px;
+      content: '';
+      background-color: currentColor;
+      bottom: -6px;
+    }
+
+    #top-nav-input-checkbox:checked~div .dcr-120u0k1:after {
+      bottom: 0;
+      -webkit-transform: rotate(45deg);
+      -moz-transform: rotate(45deg);
+      -ms-transform: rotate(45deg);
+      transform: rotate(45deg);
+    }
+
+    .dcr-mebke {
+      background-color: rgba(0, 0, 0, 0.5);
+      z-index: 21;
+      left: 0;
+      top: 0;
+    }
+
+    @media (min-width: 980px) {
+      .dcr-mebke {
+        display: none;
+      }
+    }
+
+    @media (min-width: 980px) {
+      #top-nav-input-checkbox:checked~div .dcr-mebke {
+        display: block;
+        overflow: visible;
+      }
+    }
+
+    @media (max-width: 979px) {
+      #top-nav-input-checkbox:checked~div .dcr-mebke {
+        -webkit-transform: translateX(0%);
+        -moz-transform: translateX(0%);
+        -ms-transform: translateX(0%);
+        transform: translateX(0%);
+      }
+    }
+
+    @media (max-width: 979px) {
+      .dcr-mebke {
+        -webkit-transform: translateX(-110%);
+        -moz-transform: translateX(-110%);
+        -ms-transform: translateX(-110%);
+        transform: translateX(-110%);
+        -webkit-transition: -webkit-transform 0.4s cubic-bezier(0.23, 1, 0.32, 1);
+        transition: transform 0.4s cubic-bezier(0.23, 1, 0.32, 1);
+        box-shadow: 3px 0 16px rgba(0, 0, 0, 0.4);
+        bottom: 0;
+        height: 100%;
+        overflow: auto;
+        position: fixed;
+        right: 0;
+        will-change: transform;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-mebke {
+        display: none;
+      }
+    }
+
+    .dcr-18m7gh9 {
+      background-color: #052962;
+      box-sizing: border-box;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 1.25rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 3px;
+      margin-right: 29px;
+      left: 0;
+      top: 0;
+      z-index: 20;
+      overflow: hidden;
+    }
+
+    @media (min-width: 980px) {
+      .dcr-18m7gh9 {
+        position: absolute;
+        padding-bottom: 0;
+        padding-top: 0;
+        top: 100%;
+        left: 0;
+        right: 0;
+        width: 100%;
+      }
+
+      @supports (width: 100vw) {
+        .dcr-18m7gh9 {
+          left: 50%;
+          right: 50%;
+          width: 100vw;
+          margin-left: -50vw;
+          margin-right: -50vw;
+        }
+      }
+    }
+
+    @media (min-width: 375px) {
+      .dcr-18m7gh9 {
+        margin-right: 29px;
+      }
+    }
+
+    @media (min-width: 480px) {
+      .dcr-18m7gh9 {
+        margin-right: 40px;
+      }
+    }
+
+    @media (min-width: 740px) {
+      .dcr-18m7gh9 {
+        margin-right: 100px;
+      }
+    }
+
+    .dcr-1kn7o79 {
+      box-sizing: border-box;
+      max-width: none;
+    }
+
+    @media (min-width: 980px) {
+      .dcr-1kn7o79 {
+        max-width: 980px;
+        padding: 0 20px;
+        position: relative;
+        margin: 0 auto;
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        border-left: 1px solid #506991;
+        border-right: 1px solid #506991;
+        border-top: 1px solid #506991;
+      }
+    }
+
+    @media (min-width: 1140px) {
+      .dcr-1kn7o79 {
+        max-width: 1140px;
+      }
+    }
+
+    @media (min-width: 1300px) {
+      .dcr-1kn7o79 {
+        max-width: 1300px;
+      }
+    }
+
+    .dcr-1y4qg42 {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 1.0625rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      list-style: none;
+      margin: 0;
+      padding-bottom: 10px;
+      position: relative;
+    }
+
+    .dcr-1y4qg42::before {
+      content: '\200B';
+      display: block;
+      height: 0;
+      width: 0;
+    }
+
+    @media (min-width: 980px) {
+      .dcr-1y4qg42 {
+        width: 134px;
+        float: left;
+        position: relative;
+      }
+
+      .dcr-1y4qg42:after {
+        height: 100%;
+        left: 0;
+        width: 1px;
+      }
+
+      .dcr-1y4qg42:first-of-type {
+        width: 123px;
+      }
+    }
+
+    @media (min-width: 1140px) {
+      .dcr-1y4qg42 {
+        width: 160px;
+      }
+
+      .dcr-1y4qg42:first-of-type {
+        width: 150px;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-1y4qg42:before {
+        content: '';
+        display: block;
+        position: absolute;
+        right: 0;
+        top: 0;
+        bottom: 0;
+        width: 1px;
+        background-color: #506991;
+        z-index: 1;
+      }
+    }
+
+    .dcr-1acea34 {
+      position: absolute;
+      overflow: hidden;
+      white-space: nowrap;
+      width: 1px;
+      height: 1px;
+      margin: -1px;
+      padding: 0;
+      border: 0;
+      clip: rect(1px, 1px, 1px, 1px);
+      -webkit-clip-path: inset(50%);
+      -webkit-clip-path: inset(50%);
+      clip-path: inset(50%);
+    }
+
+    .dcr-1fqnu7z {
+      -webkit-user-select: none;
+      -moz-user-select: none;
+      -ms-user-select: none;
+      user-select: none;
+      background-color: transparent;
+      border: 0;
+      box-sizing: border-box;
+      cursor: pointer;
+      color: #FFFFFF;
+      display: block;
+      font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+      font-size: 1.5rem;
+      line-height: 1.15;
+      font-weight: 500;
+      --source-text-decoration-thickness: 3px;
+      font-weight: 700;
+      outline: none;
+      padding: 6px 34px 18px 50px;
+      position: relative;
+      text-align: left;
+      width: 100%;
+      text-transform: capitalize;
+    }
+
+    .dcr-1fqnu7z>* {
+      pointer-events: none;
+    }
+
+    .dcr-1fqnu7z:before {
+      margin-top: 4px;
+      left: 25px;
+      position: absolute;
+      border: 2px solid currentColor;
+      border-top: 0;
+      border-left: 0;
+      content: '';
+      display: inline-block;
+      height: 10px;
+      -webkit-transform: rotate(45deg);
+      -moz-transform: rotate(45deg);
+      -ms-transform: rotate(45deg);
+      transform: rotate(45deg);
+      width: 10px;
+    }
+
+    .dcr-1fqnu7z:hover,
+    .dcr-1fqnu7z:focus {
+      color: #FFE500;
+    }
+
+    #News-checkbox-input:checked~.dcr-1fqnu7z:before {
+      margin-top: 8px;
+      -webkit-transform: rotate(-135deg);
+      -moz-transform: rotate(-135deg);
+      -ms-transform: rotate(-135deg);
+      transform: rotate(-135deg);
+    }
+
+    @media (min-width: 980px) {
+      .dcr-1fqnu7z {
+        display: none;
+      }
+    }
+
+    .dcr-nqw243 {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 1.0625rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      box-sizing: border-box;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-box-flex-wrap: wrap;
+      -webkit-flex-wrap: wrap;
+      -ms-flex-wrap: wrap;
+      flex-wrap: wrap;
+      list-style: none;
+      margin: 0;
+      padding: 0 0 12px;
+      position: relative;
+    }
+
+    .dcr-nqw243 li::before {
+      content: '\200B';
+      display: block;
+      height: 0;
+      width: 0;
+    }
+
+    @media (min-width: 980px) {
+      .dcr-nqw243 {
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-flex-direction: column;
+        -ms-flex-direction: column;
+        flex-direction: column;
+        -webkit-box-flex-wrap: nowrap;
+        -webkit-flex-wrap: nowrap;
+        -ms-flex-wrap: nowrap;
+        flex-wrap: nowrap;
+        -webkit-order: 1;
+        -ms-flex-order: 1;
+        order: 1;
+        height: 100%;
+        width: 100%;
+        padding: 0 9px;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-nqw243 {
+        padding-left: 0;
+      }
+    }
+
+    @media (max-width: 739px) {
+      .dcr-nqw243 {
+        background: #041F4A;
+      }
+    }
+
+    @media (max-width: 739px) {
+      .dcr-nqw243 {
+        background: #041F4A;
+      }
+    }
+
+    @media (max-width: 979px) {
+      #News-checkbox-input:not(:checked)~.dcr-nqw243 {
+        display: none;
+      }
+    }
+
+    .dcr-9ra8aa {
+      box-sizing: border-box;
+      overflow: hidden;
+      position: relative;
+      width: 100%;
+    }
+
+    @media (min-width: 980px) {
+      .dcr-9ra8aa {
+        display: -webkit-box;
+        display: -webkit-list-item;
+        display: -ms-list-itembox;
+        display: list-item;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-9ra8aa {
+        display: none;
+      }
+    }
+
+    .dcr-13wwvzl {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 1.0625rem;
+      line-height: 1.15;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      background-color: transparent;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      border: 0;
+      box-sizing: border-box;
+      color: #FFFFFF;
+      cursor: pointer;
+      display: inline-block;
+      font-weight: 500;
+      outline: none;
+      padding: 8px 34px 8px 50px;
+      position: relative;
+      text-align: left;
+      width: 100%;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-13wwvzl {
+        padding-left: 60px;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-13wwvzl {
+        font-size: 16px;
+        padding: 6px 0;
+      }
+    }
+
+    .dcr-13wwvzl:hover,
+    .dcr-13wwvzl:focus {
+      color: #FFE500;
+      -webkit-text-decoration: underline;
+      text-decoration: underline;
+    }
+
+    .dcr-13wwvzl>* {
+      pointer-events: none;
+    }
+
+    .dcr-4hq641 {
+      box-sizing: border-box;
+      overflow: hidden;
+      position: relative;
+      width: 100%;
+    }
+
+    @media (min-width: 980px) {
+      .dcr-4hq641 {
+        display: -webkit-box;
+        display: -webkit-list-item;
+        display: -ms-list-itembox;
+        display: list-item;
+      }
+    }
+
+    .dcr-16d24hr {
+      background-color: #506991;
+      content: '';
+      display: block;
+      height: 1px;
+      margin-left: 50px;
+      right: 0;
+    }
+
+    @media (max-width: 979px) {
+      #News-checkbox-input:checked~.dcr-16d24hr {
+        display: none;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-16d24hr {
+        display: none;
+      }
+    }
+
+    .dcr-15vcq54 {
+      -webkit-user-select: none;
+      -moz-user-select: none;
+      -ms-user-select: none;
+      user-select: none;
+      background-color: transparent;
+      border: 0;
+      box-sizing: border-box;
+      cursor: pointer;
+      color: #FFFFFF;
+      display: block;
+      font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+      font-size: 1.5rem;
+      line-height: 1.15;
+      font-weight: 500;
+      --source-text-decoration-thickness: 3px;
+      font-weight: 700;
+      outline: none;
+      padding: 6px 34px 18px 50px;
+      position: relative;
+      text-align: left;
+      width: 100%;
+      text-transform: capitalize;
+    }
+
+    .dcr-15vcq54>* {
+      pointer-events: none;
+    }
+
+    .dcr-15vcq54:before {
+      margin-top: 4px;
+      left: 25px;
+      position: absolute;
+      border: 2px solid currentColor;
+      border-top: 0;
+      border-left: 0;
+      content: '';
+      display: inline-block;
+      height: 10px;
+      -webkit-transform: rotate(45deg);
+      -moz-transform: rotate(45deg);
+      -ms-transform: rotate(45deg);
+      transform: rotate(45deg);
+      width: 10px;
+    }
+
+    .dcr-15vcq54:hover,
+    .dcr-15vcq54:focus {
+      color: #FFE500;
+    }
+
+    #Opinion-checkbox-input:checked~.dcr-15vcq54:before {
+      margin-top: 8px;
+      -webkit-transform: rotate(-135deg);
+      -moz-transform: rotate(-135deg);
+      -ms-transform: rotate(-135deg);
+      transform: rotate(-135deg);
+    }
+
+    @media (min-width: 980px) {
+      .dcr-15vcq54 {
+        display: none;
+      }
+    }
+
+    .dcr-bu7bnv {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 1.0625rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      box-sizing: border-box;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-box-flex-wrap: wrap;
+      -webkit-flex-wrap: wrap;
+      -ms-flex-wrap: wrap;
+      flex-wrap: wrap;
+      list-style: none;
+      margin: 0;
+      padding: 0 0 12px;
+      position: relative;
+    }
+
+    .dcr-bu7bnv li::before {
+      content: '\200B';
+      display: block;
+      height: 0;
+      width: 0;
+    }
+
+    @media (min-width: 980px) {
+      .dcr-bu7bnv {
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-flex-direction: column;
+        -ms-flex-direction: column;
+        flex-direction: column;
+        -webkit-box-flex-wrap: nowrap;
+        -webkit-flex-wrap: nowrap;
+        -ms-flex-wrap: nowrap;
+        flex-wrap: nowrap;
+        -webkit-order: 1;
+        -ms-flex-order: 1;
+        order: 1;
+        height: 100%;
+        width: 100%;
+        padding: 0 9px;
+      }
+    }
+
+    @media (max-width: 739px) {
+      .dcr-bu7bnv {
+        background: #041F4A;
+      }
+    }
+
+    @media (max-width: 979px) {
+      #Opinion-checkbox-input:not(:checked)~.dcr-bu7bnv {
+        display: none;
+      }
+    }
+
+    .dcr-1xxnrhn {
+      background-color: #506991;
+      content: '';
+      display: block;
+      height: 1px;
+      margin-left: 50px;
+      right: 0;
+    }
+
+    @media (max-width: 979px) {
+      #Opinion-checkbox-input:checked~.dcr-1xxnrhn {
+        display: none;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-1xxnrhn {
+        display: none;
+      }
+    }
+
+    .dcr-11zodys {
+      -webkit-user-select: none;
+      -moz-user-select: none;
+      -ms-user-select: none;
+      user-select: none;
+      background-color: transparent;
+      border: 0;
+      box-sizing: border-box;
+      cursor: pointer;
+      color: #FFFFFF;
+      display: block;
+      font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+      font-size: 1.5rem;
+      line-height: 1.15;
+      font-weight: 500;
+      --source-text-decoration-thickness: 3px;
+      font-weight: 700;
+      outline: none;
+      padding: 6px 34px 18px 50px;
+      position: relative;
+      text-align: left;
+      width: 100%;
+      text-transform: capitalize;
+    }
+
+    .dcr-11zodys>* {
+      pointer-events: none;
+    }
+
+    .dcr-11zodys:before {
+      margin-top: 4px;
+      left: 25px;
+      position: absolute;
+      border: 2px solid currentColor;
+      border-top: 0;
+      border-left: 0;
+      content: '';
+      display: inline-block;
+      height: 10px;
+      -webkit-transform: rotate(45deg);
+      -moz-transform: rotate(45deg);
+      -ms-transform: rotate(45deg);
+      transform: rotate(45deg);
+      width: 10px;
+    }
+
+    .dcr-11zodys:hover,
+    .dcr-11zodys:focus {
+      color: #FFE500;
+    }
+
+    #Sport-checkbox-input:checked~.dcr-11zodys:before {
+      margin-top: 8px;
+      -webkit-transform: rotate(-135deg);
+      -moz-transform: rotate(-135deg);
+      -ms-transform: rotate(-135deg);
+      transform: rotate(-135deg);
+    }
+
+    @media (min-width: 980px) {
+      .dcr-11zodys {
+        display: none;
+      }
+    }
+
+    .dcr-1efvfp0 {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 1.0625rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      box-sizing: border-box;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-box-flex-wrap: wrap;
+      -webkit-flex-wrap: wrap;
+      -ms-flex-wrap: wrap;
+      flex-wrap: wrap;
+      list-style: none;
+      margin: 0;
+      padding: 0 0 12px;
+      position: relative;
+    }
+
+    .dcr-1efvfp0 li::before {
+      content: '\200B';
+      display: block;
+      height: 0;
+      width: 0;
+    }
+
+    @media (min-width: 980px) {
+      .dcr-1efvfp0 {
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-flex-direction: column;
+        -ms-flex-direction: column;
+        flex-direction: column;
+        -webkit-box-flex-wrap: nowrap;
+        -webkit-flex-wrap: nowrap;
+        -ms-flex-wrap: nowrap;
+        flex-wrap: nowrap;
+        -webkit-order: 1;
+        -ms-flex-order: 1;
+        order: 1;
+        height: 100%;
+        width: 100%;
+        padding: 0 9px;
+      }
+    }
+
+    @media (max-width: 739px) {
+      .dcr-1efvfp0 {
+        background: #041F4A;
+      }
+    }
+
+    @media (max-width: 979px) {
+      #Sport-checkbox-input:not(:checked)~.dcr-1efvfp0 {
+        display: none;
+      }
+    }
+
+    .dcr-xlajkp {
+      background-color: #506991;
+      content: '';
+      display: block;
+      height: 1px;
+      margin-left: 50px;
+      right: 0;
+    }
+
+    @media (max-width: 979px) {
+      #Sport-checkbox-input:checked~.dcr-xlajkp {
+        display: none;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-xlajkp {
+        display: none;
+      }
+    }
+
+    .dcr-hmp1vw {
+      -webkit-user-select: none;
+      -moz-user-select: none;
+      -ms-user-select: none;
+      user-select: none;
+      background-color: transparent;
+      border: 0;
+      box-sizing: border-box;
+      cursor: pointer;
+      color: #FFFFFF;
+      display: block;
+      font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+      font-size: 1.5rem;
+      line-height: 1.15;
+      font-weight: 500;
+      --source-text-decoration-thickness: 3px;
+      font-weight: 700;
+      outline: none;
+      padding: 6px 34px 18px 50px;
+      position: relative;
+      text-align: left;
+      width: 100%;
+      text-transform: capitalize;
+    }
+
+    .dcr-hmp1vw>* {
+      pointer-events: none;
+    }
+
+    .dcr-hmp1vw:before {
+      margin-top: 4px;
+      left: 25px;
+      position: absolute;
+      border: 2px solid currentColor;
+      border-top: 0;
+      border-left: 0;
+      content: '';
+      display: inline-block;
+      height: 10px;
+      -webkit-transform: rotate(45deg);
+      -moz-transform: rotate(45deg);
+      -ms-transform: rotate(45deg);
+      transform: rotate(45deg);
+      width: 10px;
+    }
+
+    .dcr-hmp1vw:hover,
+    .dcr-hmp1vw:focus {
+      color: #FFE500;
+    }
+
+    #Culture-checkbox-input:checked~.dcr-hmp1vw:before {
+      margin-top: 8px;
+      -webkit-transform: rotate(-135deg);
+      -moz-transform: rotate(-135deg);
+      -ms-transform: rotate(-135deg);
+      transform: rotate(-135deg);
+    }
+
+    @media (min-width: 980px) {
+      .dcr-hmp1vw {
+        display: none;
+      }
+    }
+
+    .dcr-1kltmkq {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 1.0625rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      box-sizing: border-box;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-box-flex-wrap: wrap;
+      -webkit-flex-wrap: wrap;
+      -ms-flex-wrap: wrap;
+      flex-wrap: wrap;
+      list-style: none;
+      margin: 0;
+      padding: 0 0 12px;
+      position: relative;
+    }
+
+    .dcr-1kltmkq li::before {
+      content: '\200B';
+      display: block;
+      height: 0;
+      width: 0;
+    }
+
+    @media (min-width: 980px) {
+      .dcr-1kltmkq {
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-flex-direction: column;
+        -ms-flex-direction: column;
+        flex-direction: column;
+        -webkit-box-flex-wrap: nowrap;
+        -webkit-flex-wrap: nowrap;
+        -ms-flex-wrap: nowrap;
+        flex-wrap: nowrap;
+        -webkit-order: 1;
+        -ms-flex-order: 1;
+        order: 1;
+        height: 100%;
+        width: 100%;
+        padding: 0 9px;
+      }
+    }
+
+    @media (max-width: 739px) {
+      .dcr-1kltmkq {
+        background: #041F4A;
+      }
+    }
+
+    @media (max-width: 979px) {
+      #Culture-checkbox-input:not(:checked)~.dcr-1kltmkq {
+        display: none;
+      }
+    }
+
+    .dcr-8lx8k9 {
+      background-color: #506991;
+      content: '';
+      display: block;
+      height: 1px;
+      margin-left: 50px;
+      right: 0;
+    }
+
+    @media (max-width: 979px) {
+      #Culture-checkbox-input:checked~.dcr-8lx8k9 {
+        display: none;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-8lx8k9 {
+        display: none;
+      }
+    }
+
+    .dcr-19s2ze7 {
+      -webkit-user-select: none;
+      -moz-user-select: none;
+      -ms-user-select: none;
+      user-select: none;
+      background-color: transparent;
+      border: 0;
+      box-sizing: border-box;
+      cursor: pointer;
+      color: #FFFFFF;
+      display: block;
+      font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+      font-size: 1.5rem;
+      line-height: 1.15;
+      font-weight: 500;
+      --source-text-decoration-thickness: 3px;
+      font-weight: 700;
+      outline: none;
+      padding: 6px 34px 18px 50px;
+      position: relative;
+      text-align: left;
+      width: 100%;
+      text-transform: capitalize;
+    }
+
+    .dcr-19s2ze7>* {
+      pointer-events: none;
+    }
+
+    .dcr-19s2ze7:before {
+      margin-top: 4px;
+      left: 25px;
+      position: absolute;
+      border: 2px solid currentColor;
+      border-top: 0;
+      border-left: 0;
+      content: '';
+      display: inline-block;
+      height: 10px;
+      -webkit-transform: rotate(45deg);
+      -moz-transform: rotate(45deg);
+      -ms-transform: rotate(45deg);
+      transform: rotate(45deg);
+      width: 10px;
+    }
+
+    .dcr-19s2ze7:hover,
+    .dcr-19s2ze7:focus {
+      color: #FFE500;
+    }
+
+    #Lifestyle-checkbox-input:checked~.dcr-19s2ze7:before {
+      margin-top: 8px;
+      -webkit-transform: rotate(-135deg);
+      -moz-transform: rotate(-135deg);
+      -ms-transform: rotate(-135deg);
+      transform: rotate(-135deg);
+    }
+
+    @media (min-width: 980px) {
+      .dcr-19s2ze7 {
+        display: none;
+      }
+    }
+
+    .dcr-1ay3cld {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 1.0625rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      box-sizing: border-box;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-box-flex-wrap: wrap;
+      -webkit-flex-wrap: wrap;
+      -ms-flex-wrap: wrap;
+      flex-wrap: wrap;
+      list-style: none;
+      margin: 0;
+      padding: 0 0 12px;
+      position: relative;
+    }
+
+    .dcr-1ay3cld li::before {
+      content: '\200B';
+      display: block;
+      height: 0;
+      width: 0;
+    }
+
+    @media (min-width: 980px) {
+      .dcr-1ay3cld {
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-flex-direction: column;
+        -ms-flex-direction: column;
+        flex-direction: column;
+        -webkit-box-flex-wrap: nowrap;
+        -webkit-flex-wrap: nowrap;
+        -ms-flex-wrap: nowrap;
+        flex-wrap: nowrap;
+        -webkit-order: 1;
+        -ms-flex-order: 1;
+        order: 1;
+        height: 100%;
+        width: 100%;
+        padding: 0 9px;
+      }
+    }
+
+    @media (max-width: 739px) {
+      .dcr-1ay3cld {
+        background: #041F4A;
+      }
+    }
+
+    @media (max-width: 979px) {
+      #Lifestyle-checkbox-input:not(:checked)~.dcr-1ay3cld {
+        display: none;
+      }
+    }
+
+    .dcr-g8v7m4 {
+      box-sizing: border-box;
+      display: block;
+      margin-left: 13px;
+      max-width: 380px;
+      position: relative;
+      margin-bottom: 24px;
+      margin-right: 41px;
+      padding-bottom: 15px;
+    }
+
+    @media (min-width: 980px) {
+      .dcr-g8v7m4 {
+        display: none;
+      }
+    }
+
+    .dcr-19ilr9m {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 1.0625rem;
+      line-height: 1.35;
+      font-weight: 700;
+      --source-text-decoration-thickness: 2px;
+      color: #121212;
+      position: absolute;
+      overflow: hidden;
+      white-space: nowrap;
+      width: 1px;
+      height: 1px;
+      margin: -1px;
+      padding: 0;
+      border: 0;
+      clip: rect(1px, 1px, 1px, 1px);
+      -webkit-clip-path: inset(50%);
+      -webkit-clip-path: inset(50%);
+      clip-path: inset(50%);
+    }
+
+    .dcr-1xcf7cw {
+      width: 100%;
+      box-sizing: border-box;
+      height: 44px;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 1.0625rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      color: #121212;
+      background-color: #FFFFFF;
+      border: 2px solid #707070;
+      padding: 0 8px;
+      margin-top: 4px;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 1.25rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 3px;
+      background-color: rgba(255, 255, 255, .1);
+      border: 0;
+      border-radius: 1000px;
+      box-sizing: border-box;
+      color: #FFFFFF;
+      height: 36px;
+      padding-left: 38px;
+      vertical-align: middle;
+      width: 100%;
+    }
+
+    .dcr-1xcf7cw:focus {
+      border: 2px solid #0077B6;
+      outline: 0;
+    }
+
+    html:not(.src-focus-disabled) .dcr-1xcf7cw:focus {
+      box-shadow: 0 0 0 5px #0077B6;
+    }
+
+    .dcr-1xcf7cw:invalid {
+      box-shadow: none;
+    }
+
+    .dcr-1xcf7cw:invalid[value]:not([value='']) {
+      border: 4px solid #C70000;
+      color: #121212;
+      margin-top: 0;
+    }
+
+    .dcr-1xcf7cw::-webkit-input-placeholder {
+      color: #FFFFFF;
+    }
+
+    .dcr-1xcf7cw::-moz-placeholder {
+      color: #FFFFFF;
+    }
+
+    .dcr-1xcf7cw:-ms-input-placeholder {
+      color: #FFFFFF;
+    }
+
+    .dcr-1xcf7cw::placeholder {
+      color: #FFFFFF;
+    }
+
+    .dcr-1xcf7cw:focus {
+      padding-right: 40px;
+    }
+
+    .dcr-1xcf7cw:focus::-webkit-input-placeholder {
+      opacity: 0;
+    }
+
+    .dcr-1xcf7cw:focus::-moz-placeholder {
+      opacity: 0;
+    }
+
+    .dcr-1xcf7cw:focus:-ms-input-placeholder {
+      opacity: 0;
+    }
+
+    .dcr-1xcf7cw:focus::placeholder {
+      opacity: 0;
+    }
+
+    .dcr-1xcf7cw:focus~button {
+      background-color: transparent;
+      opacity: 1;
+      pointer-events: all;
+    }
+
+    .dcr-190ztmi {
+      position: absolute;
+      left: 7px;
+      top: 7px;
+      fill: #FFFFFF;
+    }
+
+    .dcr-1p0hins {
+      position: absolute;
+      overflow: hidden;
+      white-space: nowrap;
+      width: 1px;
+      height: 1px;
+      margin: -1px;
+      padding: 0;
+      border: 0;
+      clip: rect(1px, 1px, 1px, 1px);
+      -webkit-clip-path: inset(50%);
+      -webkit-clip-path: inset(50%);
+      clip-path: inset(50%);
+    }
+
+    .dcr-a7qyd9 {
+      display: -webkit-inline-box;
+      display: -webkit-inline-flex;
+      display: -ms-inline-flexbox;
+      display: inline-flex;
+      -webkit-box-pack: justify;
+      -webkit-justify-content: space-between;
+      justify-content: space-between;
+      -webkit-align-items: center;
+      -webkit-box-align: center;
+      -ms-flex-align: center;
+      align-items: center;
+      box-sizing: border-box;
+      border: none;
+      background: transparent;
+      cursor: pointer;
+      -webkit-transition: .3s ease-in-out;
+      transition: .3s ease-in-out;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      white-space: nowrap;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 1.0625rem;
+      line-height: 1.35;
+      font-weight: 700;
+      --source-text-decoration-thickness: 2px;
+      height: 44px;
+      min-height: 44px;
+      padding: 0 20px;
+      border-radius: 44px;
+      padding-bottom: 2px;
+      background-color: #052962;
+      color: #FFFFFF;
+      -webkit-flex-direction: row-reverse;
+      -ms-flex-direction: row-reverse;
+      flex-direction: row-reverse;
+      background: transparent;
+      border: 0;
+      bottom: 0;
+      cursor: pointer;
+      display: block;
+      opacity: 0;
+      pointer-events: none;
+      position: absolute;
+      right: 0;
+      top: 0;
+      width: 50px;
+      fill: #FFFFFF;
+    }
+
+    .dcr-a7qyd9:disabled {
+      cursor: not-allowed;
+    }
+
+    .dcr-a7qyd9:focus {
+      outline: 0;
+    }
+
+    html:not(.src-focus-disabled) .dcr-a7qyd9:focus {
+      outline: 5px solid #0077B6;
+      outline-offset: 3px;
+    }
+
+    .dcr-a7qyd9:hover {
+      background-color: #234B8A;
+    }
+
+    .dcr-a7qyd9 svg {
+      -webkit-flex: 0 0 auto;
+      -ms-flex: 0 0 auto;
+      flex: 0 0 auto;
+      display: block;
+      fill: currentColor;
+      position: relative;
+      width: 30px;
+      height: auto;
+    }
+
+    .dcr-a7qyd9 .src-button-space {
+      width: 12px;
+    }
+
+    .dcr-a7qyd9 svg {
+      margin-left: -4px;
+    }
+
+    .dcr-a7qyd9:focus,
+    .dcr-a7qyd9:active {
+      opacity: 0;
+      pointer-events: all;
+    }
+
+    .dcr-a7qyd9:before {
+      height: 12px;
+      top: 12px;
+      width: 12px;
+    }
+
+    .dcr-a7qyd9:after {
+      border-right: 0;
+      top: 17px;
+      width: 20px;
+    }
+
+    .dcr-12vycz3 {
+      background-color: #506991;
+      content: '';
+      display: block;
+      height: 1px;
+      margin-left: 50px;
+      right: 0;
+    }
+
+    @media (min-width: 980px) {
+      .dcr-12vycz3 {
+        display: none;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-e1bf28 {
+        display: none;
+      }
+    }
+
+    .dcr-r07hem {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 1.0625rem;
+      line-height: 1.15;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      background-color: transparent;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      border: 0;
+      box-sizing: border-box;
+      color: #FFFFFF;
+      cursor: pointer;
+      display: inline-block;
+      font-weight: 500;
+      outline: none;
+      padding: 8px 34px 8px 50px;
+      position: relative;
+      text-align: left;
+      width: 100%;
+    }
+
+    @media (max-width: 979px) {
+      .dcr-r07hem {
+        color: #FFE500;
+        font-size: 20px;
+        font-weight: 700;
+      }
+    }
+
+    @media (min-width: 740px) {
+      .dcr-r07hem {
+        padding-left: 60px;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-r07hem {
+        font-size: 16px;
+        padding: 6px 0;
+      }
+    }
+
+    .dcr-r07hem:hover,
+    .dcr-r07hem:focus {
+      color: #FFE500;
+      -webkit-text-decoration: underline;
+      text-decoration: underline;
+    }
+
+    .dcr-r07hem>* {
+      pointer-events: none;
+    }
+
+    .dcr-1sks1z0 {
+      -webkit-user-select: none;
+      -moz-user-select: none;
+      -ms-user-select: none;
+      user-select: none;
+      background-color: transparent;
+      border: 0;
+      box-sizing: border-box;
+      cursor: pointer;
+      color: #FFFFFF;
+      display: block;
+      font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+      font-size: 1.5rem;
+      line-height: 1.15;
+      font-weight: 500;
+      --source-text-decoration-thickness: 3px;
+      font-weight: 700;
+      outline: none;
+      padding: 6px 34px 18px 50px;
+      position: relative;
+      text-align: left;
+      width: 100%;
+      text-transform: capitalize;
+      text-transform: none;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 1.0625rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+    }
+
+    .dcr-1sks1z0>* {
+      pointer-events: none;
+    }
+
+    .dcr-1sks1z0:before {
+      margin-top: 4px;
+      left: 25px;
+      position: absolute;
+      border: 2px solid currentColor;
+      border-top: 0;
+      border-left: 0;
+      content: '';
+      display: inline-block;
+      height: 10px;
+      -webkit-transform: rotate(45deg);
+      -moz-transform: rotate(45deg);
+      -ms-transform: rotate(45deg);
+      transform: rotate(45deg);
+      width: 10px;
+    }
+
+    .dcr-1sks1z0:hover,
+    .dcr-1sks1z0:focus {
+      color: #FFE500;
+    }
+
+    #UK-edition-checkbox-input:checked~.dcr-1sks1z0:before {
+      margin-top: 8px;
+      -webkit-transform: rotate(-135deg);
+      -moz-transform: rotate(-135deg);
+      -ms-transform: rotate(-135deg);
+      transform: rotate(-135deg);
+    }
+
+    @media (min-width: 980px) {
+      .dcr-1sks1z0 {
+        display: none;
+      }
+    }
+
+    .dcr-b3zdlu {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 1.0625rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      box-sizing: border-box;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-box-flex-wrap: wrap;
+      -webkit-flex-wrap: wrap;
+      -ms-flex-wrap: wrap;
+      flex-wrap: wrap;
+      list-style: none;
+      margin: 0;
+      padding: 0 0 12px;
+      position: relative;
+    }
+
+    .dcr-b3zdlu li::before {
+      content: '\200B';
+      display: block;
+      height: 0;
+      width: 0;
+    }
+
+    @media (min-width: 980px) {
+      .dcr-b3zdlu {
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-flex-direction: column;
+        -ms-flex-direction: column;
+        flex-direction: column;
+        -webkit-box-flex-wrap: nowrap;
+        -webkit-flex-wrap: nowrap;
+        -ms-flex-wrap: nowrap;
+        flex-wrap: nowrap;
+        -webkit-order: 1;
+        -ms-flex-order: 1;
+        order: 1;
+        height: 100%;
+        width: 100%;
+        padding: 0 9px;
+      }
+    }
+
+    @media (max-width: 739px) {
+      .dcr-b3zdlu {
+        background: #041F4A;
+      }
+    }
+
+    @media (max-width: 979px) {
+      #UK-edition-checkbox-input:not(:checked)~.dcr-b3zdlu {
+        display: none;
+      }
+    }
+
+    .dcr-jv36lp {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 1.0625rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      list-style: none;
+      margin: 0;
+      padding-bottom: 10px;
+      position: relative;
+    }
+
+    .dcr-jv36lp::before {
+      content: '\200B';
+      display: block;
+      height: 0;
+      width: 0;
+    }
+
+    .dcr-jv36lp:first-of-type:after {
+      content: none;
+    }
+
+    @media (min-width: 980px) {
+      .dcr-jv36lp {
+        width: 134px;
+        float: left;
+        position: relative;
+      }
+
+      .dcr-jv36lp:after {
+        content: none;
+      }
+
+      .dcr-jv36lp:first-of-type {
+        width: 123px;
+      }
+    }
+
+    @media (min-width: 1140px) {
+      .dcr-jv36lp {
+        width: 160px;
+      }
+
+      .dcr-jv36lp:first-of-type {
+        width: 150px;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-jv36lp:before {
+        content: '';
+        display: block;
+        position: absolute;
+        right: 0;
+        top: 0;
+        bottom: 0;
+        width: 1px;
+        height: auto;
+        background-color: #506991;
+        z-index: 1;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-jv36lp:before {
+        top: -42px;
+      }
+
+      .dcr-jv36lp:after {
+        content: '';
+        display: block;
+        position: absolute;
+        right: 0;
+        top: 0;
+        bottom: 0;
+        left: 0;
+        width: 1px;
+        height: auto;
+        background-color: #506991;
+        z-index: 1;
+      }
+    }
+
+    .dcr-17sb2rc {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 1.0625rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      box-sizing: border-box;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-box-flex-wrap: wrap;
+      -webkit-flex-wrap: wrap;
+      -ms-flex-wrap: wrap;
+      flex-wrap: wrap;
+      list-style: none;
+      margin: 0;
+      padding: 0 0 12px;
+      position: relative;
+    }
+
+    .dcr-17sb2rc li::before {
+      content: '\200B';
+      display: block;
+      height: 0;
+      width: 0;
+    }
+
+    @media (min-width: 980px) {
+      .dcr-17sb2rc {
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-flex-direction: column;
+        -ms-flex-direction: column;
+        flex-direction: column;
+        -webkit-box-flex-wrap: nowrap;
+        -webkit-flex-wrap: nowrap;
+        -ms-flex-wrap: nowrap;
+        flex-wrap: nowrap;
+        -webkit-order: 1;
+        -ms-flex-order: 1;
+        order: 1;
+        height: 100%;
+        width: 100%;
+        padding: 0 9px;
+      }
+    }
+
+    .dcr-vwltw3 {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 1.0625rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      list-style: none;
+      margin: 0;
+      padding-bottom: 10px;
+      position: relative;
+    }
+
+    .dcr-vwltw3::before {
+      content: '\200B';
+      display: block;
+      height: 0;
+      width: 0;
+    }
+
+    .dcr-vwltw3:first-of-type:after {
+      content: none;
+    }
+
+    @media (min-width: 980px) {
+      .dcr-vwltw3 {
+        width: 134px;
+        float: left;
+        position: relative;
+      }
+
+      .dcr-vwltw3:after {
+        content: none;
+      }
+
+      .dcr-vwltw3:first-of-type {
+        width: 123px;
+      }
+    }
+
+    @media (min-width: 1140px) {
+      .dcr-vwltw3 {
+        width: 160px;
+      }
+
+      .dcr-vwltw3:first-of-type {
+        width: 150px;
+      }
+    }
+
+    .dcr-6sdrzu {
+      fill: currentColor;
+      height: 28px;
+      left: 18px;
+      position: absolute;
+      top: 5px;
+      width: 28px;
+    }
+
+    .dcr-pt8pb9 {
+      display: none;
+      position: absolute;
+      right: 20px;
+      top: 4px;
+      bottom: 0;
+    }
+
+    @media (min-width: 980px) {
+      .dcr-pt8pb9 {
+        display: block;
+      }
+    }
+
+    .dcr-4phbzi {
+      width: 131px;
+      box-sizing: border-box;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 1.0625rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      -webkit-box-flex-wrap: wrap;
+      -webkit-flex-wrap: wrap;
+      -ms-flex-wrap: wrap;
+      flex-wrap: wrap;
+      list-style: none;
+      margin: 0;
+      padding: 0 0 12px;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+      padding-bottom: 0;
+    }
+
+    .dcr-4phbzi li::before {
+      content: '\200B';
+      display: block;
+      height: 0;
+      width: 0;
+    }
+
+    @media (min-width: 1140px) {
+      .dcr-4phbzi {
+        width: 140px;
+      }
+    }
+
+    @media (min-width: 1300px) {
+      .dcr-4phbzi {
+        width: 300px;
+      }
+    }
+
+    .dcr-nnfu1a {
+      margin-right: 0;
+      margin-top: -6px;
+      padding-bottom: 0;
+    }
+
+    .dcr-wzkd0n {
+      font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+      font-size: 1.25rem;
+      line-height: 1.15;
+      font-weight: 500;
+      --source-text-decoration-thickness: 3px;
+      font-weight: 700;
+      background-color: transparent;
+      border: 0;
+      box-sizing: border-box;
+      color: #FFFFFF;
+      cursor: pointer;
+      display: inline-block;
+      outline: none;
+      padding: 8px 34px 8px 50px;
+      position: relative;
+      text-align: left;
+      width: 100%;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-wzkd0n {
+        padding-left: 60px;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-wzkd0n {
+        padding: 6px 0;
+      }
+    }
+
+    @media (min-width: 1300px) {
+      .dcr-wzkd0n {
+        font-size: 24px;
+      }
+    }
+
+    .dcr-wzkd0n:hover,
+    .dcr-wzkd0n:focus {
+      color: #FFE500;
+    }
+
+    .dcr-wzkd0n>* {
+      pointer-events: none;
+    }
+
+    .dcr-1h92x0c {
+      background-color: transparent;
+    }
+
+    .dcr-188zz3t {
+      position: relative;
+      margin: auto;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-188zz3t {
+        max-width: 740px;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-188zz3t {
+        max-width: 980px;
+      }
+    }
+
+    @media (min-width: 1140px) {
+      .dcr-188zz3t {
+        max-width: 1140px;
+      }
+    }
+
+    @media (min-width: 1300px) {
+      .dcr-188zz3t {
+        max-width: 1300px;
+      }
+    }
+
+    @media (min-width: 740px) {
+      .dcr-188zz3t {
+        border-left: 1px solid #DCDCDC;
+        border-right: 1px solid #DCDCDC;
+      }
+    }
+
+    .dcr-v6jxf0 {
+      height: 36px;
+      overflow: hidden;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-box-pack: justify;
+      -webkit-justify-content: space-between;
+      justify-content: space-between;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-v6jxf0 {
+        height: 42px;
+      }
+    }
+
+    .dcr-1gt8egs {
+      list-style: none;
+      padding: 0 5px;
+    }
+
+    @media (min-width: 480px) {
+      .dcr-1gt8egs {
+        padding: 0 15px;
+      }
+    }
+
+    .dcr-1gt8egs li {
+      float: left;
+      display: block;
+    }
+
+    .dcr-izfjfz:after {
+      content: '';
+      display: inline-block;
+      width: 0;
+      height: 0;
+      border-top: 6px solid transparent;
+      border-bottom: 6px solid transparent;
+      border-left: 10px solid #121212;
+      margin-top: 12px;
+      margin-left: 2px;
+      border-left-color: #C70000;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-izfjfz:after {
+        margin-top: 16px;
+      }
+    }
+
+    .dcr-qo5392 {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.9375rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      font-size: 14px;
+      font-weight: 500;
+      color: #121212;
+      padding: 0 5px;
+      height: 36px;
+      line-height: 36px;
+      float: left;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-qo5392 {
+        font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+        font-size: 1.0625rem;
+        line-height: 1.35;
+        font-weight: 400;
+        --source-text-decoration-thickness: 2px;
+        font-size: 16px;
+      }
+    }
+
+    @media (min-width: 740px) {
+      .dcr-qo5392 {
+        height: 42px;
+        line-height: 42px;
+      }
+    }
+
+    .dcr-qo5392:hover {
+      color: #C70000;
+    }
+
+    .dcr-qo5392:focus {
+      line-height: 26px;
+      height: 26px;
+      margin-top: 5px;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-qo5392:focus {
+        height: 32px;
+        line-height: 32px;
+      }
+    }
+
+    .dcr-65xb9q {
+      display: block;
+    }
+
+    .dcr-vkkuzs section#palette-styles-do-not-delete,
+    .dcr-vkkuzs section#palette-styles-new-do-not-delete {
+      height: 0;
+      overflow: hidden;
+      margin: 0;
+      padding: 0;
+    }
+
+    .dcr-vkkuzs .fc-container--long-running-palette+.fc-container__mpu--mobile {
+      background-color: #939a9d;
+      margin-top: -12px;
+      padding-bottom: 20px;
+    }
+
+    .dcr-vkkuzs .interactive-atom {
+      margin: 0;
+      padding: 0;
+    }
+
+    .dcr-vkkuzs section:not(.fc-container--has-palette).fc-container--story-package .fc-item--is-dynamic-card .fc-item__content--above {
+      padding-left: .3125rem;
+      padding-right: .3125rem;
+    }
+
+    .dcr-vkkuzs section.fc-container--has-palette .fc-item--three-quarters-tall-tablet .fc-item__header {
+      padding-left: 5px;
+    }
+
+    .dcr-vkkuzs section.fc-container--has-palette .fc-item[class*=fc-item--pillar-][class*=fc-item--standard-] .fc-item__title,
+    .dcr-vkkuzs section.fc-container--has-palette .fc-slice-wrapper+.fc-slice-wrapper .fc-slice--q-q-q-q .fc-item[class*=fc-item--pillar-][class*=fc-item--standard-] .fc-item__title {
+      background-image: none;
+    }
+
+    .dcr-vkkuzs section.fc-container--has-palette .fc-item .fc-item__headline,
+    .dcr-vkkuzs section.fc-container--has-palette .fc-item.fc-item--live .fc-item__headline {
+      color: #fff;
+    }
+
+    .dcr-vkkuzs section.fc-container--has-palette .fc-item .fc-item__meta-wrapper>.fc-item__meta,
+    .dcr-vkkuzs section.fc-container--has-palette .fc-item .fc-item__standfirst-wrapper>.fc-item__meta {
+      color: #fff;
+      font-weight: 400;
+    }
+
+    .dcr-vkkuzs section.fc-container--has-palette .fc-item .fc-item__link:visited,
+    .dcr-vkkuzs section.fc-container--has-palette .fc-item .fc-sublink .fc-sublink__link,
+    .dcr-vkkuzs section.fc-container--has-palette .fc-item .fc-sublink .fc-sublink__link:visited,
+    .dcr-vkkuzs section.fc-container--has-palette .fc-item .fc-sublink__title {
+      color: #fff;
+    }
+
+    .dcr-vkkuzs section.fc-container--has-palette .fc-item .fc-trail__count--commentcount .inline-icon,
+    .dcr-vkkuzs section.fc-container--has-palette .fc-item .fc-trail__count--commentcount .inline-icon svg {
+      fill: #fff;
+    }
+
+    .dcr-vkkuzs section.fc-container--has-palette .fc-item .fc-item__standfirst,
+    .dcr-vkkuzs section.fc-container--has-palette .fc-item.fc-item--live .fc-item__standfirst {
+      color: #fff;
+    }
+
+    .dcr-vkkuzs section.fc-container--has-palette .fc-item .fc-item__timestamp,
+    .dcr-vkkuzs section.fc-container--has-palette .fc-item .fc-trail__count.fc-trail__count--commentcount,
+    .dcr-vkkuzs section.fc-container--has-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment .fc-trail__count.fc-trail__count--commentcount {
+      color: #fff;
+      font-weight: 400;
+    }
+
+    .dcr-vkkuzs section.fc-container--has-palette .fc-item.fc-item--type-comment.fc-item--has-cutout .fc-item__avatar {
+      background-color: transparent;
+      border-radius: unset;
+      bottom: 0;
+      top: auto;
+      width: 152px;
+      height: 152px;
+    }
+
+    @media (max-width:46.24em) {
+      .dcr-vkkuzs section.fc-container--has-palette .fc-item.fc-item--type-comment.fc-item--has-cutout .fc-item__avatar {
+        width: 96px;
+        height: 96px;
+      }
+    }
+
+    .dcr-vkkuzs section.fc-container--has-palette .fc-item.fc-item--type-comment.fc-item--has-cutout:hover .fc-item__avatar {
+      background: 0 0;
+    }
+
+    .dcr-vkkuzs section.fc-container--has-palette .fc-item.fc-item--type-comment.fc-item--has-cutout .fc-item__avatar__media {
+      height: 152px;
+    }
+
+    @media (max-width:46.24em) {
+      .dcr-vkkuzs section.fc-container--has-palette .fc-item.fc-item--type-comment.fc-item--has-cutout .fc-item__avatar__media {
+        height: 96px;
+      }
+    }
+
+    .dcr-vkkuzs section.fc-container--has-palette .l-list--rows-4 .fc-item.fc-item--type-comment.fc-item--has-cutout .fc-item__avatar {
+      width: 98px;
+      height: 98px;
+    }
+
+    .dcr-vkkuzs section.fc-container--has-palette .l-list--rows-4 .fc-item.fc-item--type-comment.fc-item--has-cutout .fc-item__avatar__media {
+      height: 95px;
+    }
+
+    .dcr-vkkuzs section.fc-container--has-palette .fc-item__title {
+      color: #fff;
+    }
+
+    .dcr-vkkuzs section.fc-container--has-palette .fc-item .youtube-media-atom__play-button .inline-play svg {
+      fill: #fff;
+    }
+
+    .dcr-vkkuzs section.fc-container--has-palette .fc-item--pillar-news .fc-item__media-meta,
+    .dcr-vkkuzs section.fc-container--has-palette .fc-item__media-meta {
+      color: #fff;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-palette {
+      background-color: #e4e5e8;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item--type-comment .fc-item__container:before,
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item.fc-item--live .fc-item__container:before,
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item__container:before {
+      background-color: #ff9081;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-palette+.fc-container__mpu--mobile {
+      background-color: #e4e5e8;
+      margin-top: -12px;
+      padding-bottom: 20px;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-container__header__title:after {
+      background-color: #d6d8dc;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-container__inner {
+      border-top: 1px solid #d6d8dc;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-slice {
+      overflow: visible;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-container__header__title h2,
+    .dcr-vkkuzs section.fc-container--long-running-palette.fc-container--story-package .fc-container__header__title h2.fc-container__title__text {
+      color: #052962;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-container__header__description {
+      color: #c70000;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-palette .treats__treat {
+      background-color: #e4e5e8;
+      border-color: #052962;
+      color: #052962;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-today,
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-today .fc-today__sub {
+      color: #c70000;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item,
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment,
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment.fc-item--type-comment {
+      background-color: #052962;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item .fc-item__kicker,
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item.fc-item--live .fc-item__kicker {
+      color: #ff9081;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item .u-faux-block-link--hover .fc-sublink {
+      background-color: #041f4a;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item .fc-sublink__title .fc-sublink__kicker {
+      color: #ff9081;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item .fc-item__container>.fc-item__meta {
+      background-image: repeating-linear-gradient(to bottom, , .0625rem, transparent .0625rem, transparent .25rem);
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item .fc-item__timestamp,
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item .fc-trail__count.fc-trail__count--commentcount,
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment .fc-trail__count.fc-trail__count--commentcount {
+      background-color: #052962;
+      color: #dcdcdc;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item .fc-trail__count.fc-trail__count--commentcount:hover {
+      background-color: #052962;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item .u-faux-block-link--hover,
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item .u-faux-block-link--hover .fc-trail__count--commentcount,
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item .u-faux-block-link--hover .fc-trail__count.fc-trail__count--commentcount,
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item.fc-item--type-comment:not(.fc-item--pillar-special-report) .fc-item__container.u-faux-block-link--hover {
+      background-color: #041f4a;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item__title--quoted .inline-garnett-quote,
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item__title--quoted .inline-quote {
+      fill: #ff9081;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-palette.fc-container--has-palette .fc-item__byline {
+      color: #ff9081;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item--live .live-pulse-icon::before,
+    .dcr-vkkuzs section.fc-container--long-running-palette .live-pulse-icon::before {
+      background-color: #ff9081;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item__liveblog-block__text {
+      border-bottom-color: #052962;
+      max-height: 3.57rem;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item__liveblog-block__text:hover {
+      -webkit-text-decoration: underline;
+      text-decoration: underline;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-palette .u-faux-block-link--hover .fc-item__liveblog-block__text {
+      border-bottom-color: #041f4a;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #052962;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-palette .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #041f4a;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item--type-live .fc-sublink .fc-sublink__title:before {
+      border-top-color: #ff9081;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item--is-commentable:not(.fc-item--type-comment) .fc-item__meta {
+      min-width: calc(4ch + 1rem);
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item .fc-item__media-meta .inline-icon {
+      background-color: #ff9081;
+      width: 1.5rem;
+      height: 1.4375rem;
+      display: inline-block;
+      border-radius: 50%;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item .fc-item__media-meta .inline-icon path,
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item .fc-item__media-meta .inline-icon svg {
+      fill: #052962;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-container__toggle {
+      color: #333;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette {
+      background-color: #f2f2f2;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item--type-comment .fc-item__container:before,
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item.fc-item--live .fc-item__container:before,
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item__container:before {
+      background-color: #8b0000;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette+.fc-container__mpu--mobile {
+      background-color: #f2f2f2;
+      margin-top: -12px;
+      padding-bottom: 20px;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-container__header__title:after {
+      background-color: #e5e5e5;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-container__inner {
+      border-top: 1px solid #e5e5e5;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-slice {
+      overflow: visible;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-container__header__title h2,
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette.fc-container--story-package .fc-container__header__title h2.fc-container__title__text {
+      color: #121212;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-container__header__description {
+      color: #8b0000;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .treats__treat {
+      background-color: #f2f2f2;
+      border-color: #121212;
+      color: #121212;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-today,
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-today .fc-today__sub {
+      color: #8b0000;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item,
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment,
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment.fc-item--type-comment {
+      background-color: #dcdcdc;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item .fc-item__headline,
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item.fc-item--live .fc-item__headline {
+      color: #121212;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item .fc-item__kicker,
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item.fc-item--live .fc-item__kicker {
+      color: #8b0000;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item .u-faux-block-link--hover .fc-sublink {
+      background-color: #cfcfcf;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item .fc-sublink__title {
+      color: #121212;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item .fc-sublink__title .fc-sublink__kicker {
+      color: #8b0000;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item .fc-item__container>.fc-item__meta {
+      background-image: repeating-linear-gradient(to bottom, , .0625rem, transparent .0625rem, transparent .25rem);
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item .fc-item__meta-wrapper>.fc-item__meta,
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item .fc-item__standfirst-wrapper>.fc-item__meta {
+      color: #121212;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item .fc-item__timestamp,
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item .fc-trail__count.fc-trail__count--commentcount,
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment .fc-trail__count.fc-trail__count--commentcount {
+      background-color: #dcdcdc;
+      color: #707070;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item .fc-trail__count.fc-trail__count--commentcount:hover {
+      background-color: #dcdcdc;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item .u-faux-block-link--hover .fc-trail__count--commentcount,
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item .u-faux-block-link--hover .fc-trail__count.fc-trail__count--commentcount {
+      background-color: #cfcfcf;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item .fc-trail__count--commentcount .inline-icon,
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item .fc-trail__count--commentcount .inline-icon svg {
+      fill: #121212;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item .u-faux-block-link--hover,
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item.fc-item--type-comment:not(.fc-item--pillar-special-report) .fc-item__container.u-faux-block-link--hover {
+      background-color: #cfcfcf;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item__title--quoted .inline-garnett-quote,
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item__title--quoted .inline-quote {
+      fill: #8b0000;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item__title {
+      color: #121212;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette.fc-container--has-palette .fc-item__byline {
+      color: #8b0000;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item .fc-item__standfirst,
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item.fc-item--live .fc-item__standfirst {
+      color: #121212;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item--live .live-pulse-icon::before,
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .live-pulse-icon::before {
+      background-color: #8b0000;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item__liveblog-block__time {
+      color: #121212;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item__liveblog-block__text {
+      border-bottom-color: #dcdcdc;
+      color: #121212;
+      max-height: 3.57rem;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item__liveblog-block__text:hover {
+      -webkit-text-decoration: underline;
+      text-decoration: underline;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .u-faux-block-link--hover .fc-item__liveblog-block__text {
+      border-bottom-color: #cfcfcf;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #dcdcdc;
+      color: #121212;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #cfcfcf;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item .fc-item__link:visited,
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item .fc-sublink .fc-sublink__link,
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item .fc-sublink .fc-sublink__link:visited {
+      color: #121212;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item--type-live .fc-sublink .fc-sublink__title:before {
+      border-top-color: #8b0000;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item--is-commentable:not(.fc-item--type-comment) .fc-item__meta {
+      min-width: calc(4ch + 1rem);
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item .fc-item__media-meta .inline-icon {
+      background-color: #8b0000;
+      width: 1.5rem;
+      height: 1.4375rem;
+      display: inline-block;
+      border-radius: 50%;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item .fc-item__media-meta .inline-icon path,
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item .fc-item__media-meta .inline-icon svg {
+      fill: #dcdcdc;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item .youtube-media-atom__play-button .inline-play svg {
+      fill: #121212;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item--pillar-news .fc-item__media-meta,
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item__media-meta {
+      color: #121212;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-container__toggle {
+      color: #333;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-palette {
+      background-color: #595c5f;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item--type-comment .fc-item__container:before,
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item.fc-item--live .fc-item__container:before,
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item__container:before {
+      background-color: #c1d8fc;
+      height: 4px;
+      top: -4px;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-palette+.fc-container__mpu--mobile {
+      background-color: #595c5f;
+      margin-top: -12px;
+      padding-bottom: 20px;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-container__header__title:after {
+      background-color: #4d4f52;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-container__inner {
+      border-top: 1px solid #4d4f52;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-slice {
+      overflow: visible;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-container__header__title h2,
+    .dcr-vkkuzs section.fc-container--sombre-palette.fc-container--story-package .fc-container__header__title h2.fc-container__title__text {
+      color: #fff;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-container__header__description {
+      color: #c1d8fc;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-palette .treats__treat {
+      background-color: #595c5f;
+      border-color: #fff;
+      color: #fff;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-today,
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-today .fc-today__sub {
+      color: #c1d8fc;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item,
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment,
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment.fc-item--type-comment {
+      background-color: #3f464a;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item .fc-item__kicker,
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item.fc-item--live .fc-item__kicker {
+      color: #c1d8fc;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item .u-faux-block-link--hover .fc-sublink {
+      background-color: #33393c;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item .fc-sublink__title .fc-sublink__kicker {
+      color: #c1d8fc;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item .fc-item__container>.fc-item__meta {
+      background-image: repeating-linear-gradient(to bottom, , .0625rem, transparent .0625rem, transparent .25rem);
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item .fc-item__timestamp,
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item .fc-trail__count.fc-trail__count--commentcount,
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment .fc-trail__count.fc-trail__count--commentcount {
+      background-color: #3f464a;
+      color: #dcdcdc;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item .fc-trail__count.fc-trail__count--commentcount:hover {
+      background-color: #3f464a;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item .u-faux-block-link--hover,
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item .u-faux-block-link--hover .fc-trail__count--commentcount,
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item .u-faux-block-link--hover .fc-trail__count.fc-trail__count--commentcount,
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item.fc-item--type-comment:not(.fc-item--pillar-special-report) .fc-item__container.u-faux-block-link--hover {
+      background-color: #33393c;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item__title--quoted .inline-garnett-quote,
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item__title--quoted .inline-quote {
+      fill: #c1d8fc;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-palette.fc-container--has-palette .fc-item__byline {
+      color: #c1d8fc;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item--live .live-pulse-icon::before,
+    .dcr-vkkuzs section.fc-container--sombre-palette .live-pulse-icon::before {
+      background-color: #c1d8fc;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item__liveblog-block__text {
+      border-bottom-color: #3f464a;
+      max-height: 3.57rem;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item__liveblog-block__text:hover {
+      -webkit-text-decoration: underline;
+      text-decoration: underline;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-palette .u-faux-block-link--hover .fc-item__liveblog-block__text {
+      border-bottom-color: #33393c;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #3f464a;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-palette .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #33393c;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item--type-live .fc-sublink .fc-sublink__title:before {
+      border-top-color: #c1d8fc;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item--is-commentable:not(.fc-item--type-comment) .fc-item__meta {
+      min-width: calc(4ch + 1rem);
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item .fc-item__media-meta .inline-icon {
+      background-color: #c1d8fc;
+      width: 1.5rem;
+      height: 1.4375rem;
+      display: inline-block;
+      border-radius: 50%;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item .fc-item__media-meta .inline-icon path,
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item .fc-item__media-meta .inline-icon svg {
+      fill: #3f464a;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-container__toggle {
+      color: #dcdcdc;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette {
+      background-color: #3f464a;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item--type-comment .fc-item__container:before,
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item.fc-item--live .fc-item__container:before,
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item__container:before {
+      background-color: #ff5943;
+      height: 4px;
+      top: -4px;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette+.fc-container__mpu--mobile {
+      background-color: #3f464a;
+      margin-top: -12px;
+      padding-bottom: 20px;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-container__header__title:after {
+      background-color: #33393c;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-container__inner {
+      border-top: 1px solid #33393c;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-slice {
+      overflow: visible;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-container__header__title h2,
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette.fc-container--story-package .fc-container__header__title h2.fc-container__title__text {
+      color: #fff;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-container__header__description {
+      color: #ff5943;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .treats__treat {
+      background-color: #3f464a;
+      border-color: #fff;
+      color: #fff;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-today,
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-today .fc-today__sub {
+      color: #ff5943;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item,
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment,
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment.fc-item--type-comment {
+      background-color: #222527;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item .fc-item__kicker,
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item.fc-item--live .fc-item__kicker {
+      color: #ff5943;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item .u-faux-block-link--hover .fc-sublink {
+      background-color: #161819;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item .fc-sublink__title .fc-sublink__kicker {
+      color: #ff5943;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item .fc-item__container>.fc-item__meta {
+      background-image: repeating-linear-gradient(to bottom, , .0625rem, transparent .0625rem, transparent .25rem);
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item .fc-item__timestamp,
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item .fc-trail__count.fc-trail__count--commentcount,
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment .fc-trail__count.fc-trail__count--commentcount {
+      background-color: #222527;
+      color: #999;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item .fc-trail__count.fc-trail__count--commentcount:hover {
+      background-color: #222527;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item .u-faux-block-link--hover,
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item .u-faux-block-link--hover .fc-trail__count--commentcount,
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item .u-faux-block-link--hover .fc-trail__count.fc-trail__count--commentcount,
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item.fc-item--type-comment:not(.fc-item--pillar-special-report) .fc-item__container.u-faux-block-link--hover {
+      background-color: #161819;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item__title--quoted .inline-garnett-quote,
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item__title--quoted .inline-quote {
+      fill: #ff5943;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette.fc-container--has-palette .fc-item__byline {
+      color: #ff5943;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item--live .live-pulse-icon::before,
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .live-pulse-icon::before {
+      background-color: #ff5943;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item__liveblog-block__text {
+      border-bottom-color: #222527;
+      max-height: 3.57rem;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item__liveblog-block__text:hover {
+      -webkit-text-decoration: underline;
+      text-decoration: underline;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .u-faux-block-link--hover .fc-item__liveblog-block__text {
+      border-bottom-color: #161819;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #222527;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #161819;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item--type-live .fc-sublink .fc-sublink__title:before {
+      border-top-color: #ff5943;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item--is-commentable:not(.fc-item--type-comment) .fc-item__meta {
+      min-width: calc(4ch + 1rem);
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item .fc-item__media-meta .inline-icon {
+      background-color: #ff5943;
+      width: 1.5rem;
+      height: 1.4375rem;
+      display: inline-block;
+      border-radius: 50%;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item .fc-item__media-meta .inline-icon path,
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item .fc-item__media-meta .inline-icon svg {
+      fill: #222527;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-container__toggle {
+      color: #dcdcdc;
+    }
+
+    .dcr-vkkuzs section.fc-container--investigation-palette {
+      background-color: #595c5f;
+    }
+
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item--type-comment .fc-item__container:before,
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item.fc-item--live .fc-item__container:before,
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item__container:before {
+      background-color: #ffe500;
+    }
+
+    .dcr-vkkuzs section.fc-container--investigation-palette+.fc-container__mpu--mobile {
+      background-color: #595c5f;
+      margin-top: -12px;
+      padding-bottom: 20px;
+    }
+
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-container__header__title:after {
+      background-color: #4d4f52;
+    }
+
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-container__inner {
+      border-top: 1px solid #4d4f52;
+    }
+
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-slice {
+      overflow: visible;
+    }
+
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-container__header__title h2,
+    .dcr-vkkuzs section.fc-container--investigation-palette.fc-container--story-package .fc-container__header__title h2.fc-container__title__text {
+      color: #fff;
+    }
+
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-container__header__description {
+      color: #ffe500;
+    }
+
+    .dcr-vkkuzs section.fc-container--investigation-palette .treats__treat {
+      background-color: #595c5f;
+      border-color: #fff;
+      color: #fff;
+    }
+
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-today,
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-today .fc-today__sub {
+      color: #ffe500;
+    }
+
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item,
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment,
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment.fc-item--type-comment {
+      background-color: #3f464a;
+    }
+
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item .fc-item__kicker,
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item.fc-item--live .fc-item__kicker {
+      color: #ffe500;
+    }
+
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item .u-faux-block-link--hover .fc-sublink {
+      background-color: #33393c;
+    }
+
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item .fc-sublink__title .fc-sublink__kicker {
+      color: #ffe500;
+    }
+
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item .fc-item__container>.fc-item__meta {
+      background-image: repeating-linear-gradient(to bottom, , .0625rem, transparent .0625rem, transparent .25rem);
+    }
+
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item .fc-item__timestamp,
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item .fc-trail__count.fc-trail__count--commentcount,
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment .fc-trail__count.fc-trail__count--commentcount {
+      background-color: #3f464a;
+      color: #dcdcdc;
+    }
+
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item .fc-trail__count.fc-trail__count--commentcount:hover {
+      background-color: #3f464a;
+    }
+
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item .u-faux-block-link--hover,
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item .u-faux-block-link--hover .fc-trail__count--commentcount,
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item .u-faux-block-link--hover .fc-trail__count.fc-trail__count--commentcount,
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item.fc-item--type-comment:not(.fc-item--pillar-special-report) .fc-item__container.u-faux-block-link--hover {
+      background-color: #33393c;
+    }
+
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item__title--quoted .inline-garnett-quote,
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item__title--quoted .inline-quote {
+      fill: #ffe500;
+    }
+
+    .dcr-vkkuzs section.fc-container--investigation-palette.fc-container--has-palette .fc-item__byline {
+      color: #ffe500;
+    }
+
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item--live .live-pulse-icon::before,
+    .dcr-vkkuzs section.fc-container--investigation-palette .live-pulse-icon::before {
+      background-color: #ffe500;
+    }
+
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item__liveblog-block__text {
+      border-bottom-color: #3f464a;
+      max-height: 3.57rem;
+    }
+
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item__liveblog-block__text:hover {
+      -webkit-text-decoration: underline;
+      text-decoration: underline;
+    }
+
+    .dcr-vkkuzs section.fc-container--investigation-palette .u-faux-block-link--hover .fc-item__liveblog-block__text {
+      border-bottom-color: #33393c;
+    }
+
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #3f464a;
+    }
+
+    .dcr-vkkuzs section.fc-container--investigation-palette .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #33393c;
+    }
+
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item--type-live .fc-sublink .fc-sublink__title:before {
+      border-top-color: #ffe500;
+    }
+
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item--is-commentable:not(.fc-item--type-comment) .fc-item__meta {
+      min-width: calc(4ch + 1rem);
+    }
+
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item .fc-item__media-meta .inline-icon {
+      background-color: #ffe500;
+      width: 1.5rem;
+      height: 1.4375rem;
+      display: inline-block;
+      border-radius: 50%;
+    }
+
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item .fc-item__media-meta .inline-icon path,
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item .fc-item__media-meta .inline-icon svg {
+      fill: #3f464a;
+    }
+
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-container__toggle {
+      color: #f6f6f6;
+    }
+
+    .dcr-vkkuzs section.fc-container--breaking-palette {
+      background-color: #fff;
+    }
+
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item--type-comment .fc-item__container:before,
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item.fc-item--live .fc-item__container:before,
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item__container:before {
+      background-color: #ffbac8;
+    }
+
+    .dcr-vkkuzs section.fc-container--breaking-palette+.fc-container__mpu--mobile {
+      background-color: #fff;
+      margin-top: -12px;
+      padding-bottom: 20px;
+    }
+
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-container__header__title:after {
+      background-color: #f2f2f2;
+    }
+
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-container__inner {
+      border-top: 1px solid #f2f2f2;
+    }
+
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-slice {
+      overflow: visible;
+    }
+
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-container__header__title h2,
+    .dcr-vkkuzs section.fc-container--breaking-palette.fc-container--story-package .fc-container__header__title h2.fc-container__title__text {
+      color: #121212;
+    }
+
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-container__header__description {
+      color: #8b0000;
+    }
+
+    .dcr-vkkuzs section.fc-container--breaking-palette .treats__treat {
+      background-color: #fff;
+      border-color: #121212;
+      color: #121212;
+    }
+
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-today,
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-today .fc-today__sub {
+      color: #8b0000;
+    }
+
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item,
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment,
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment.fc-item--type-comment {
+      background-color: #8b0000;
+    }
+
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item .fc-item__kicker,
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item.fc-item--live .fc-item__kicker {
+      color: #ffbac8;
+    }
+
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item .u-faux-block-link--hover .fc-sublink {
+      background-color: #720000;
+    }
+
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item .fc-sublink__title .fc-sublink__kicker {
+      color: #ffbac8;
+    }
+
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item .fc-item__container>.fc-item__meta {
+      background-image: repeating-linear-gradient(to bottom, , .0625rem, transparent .0625rem, transparent .25rem);
+    }
+
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item .fc-item__timestamp,
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item .fc-trail__count.fc-trail__count--commentcount,
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment .fc-trail__count.fc-trail__count--commentcount {
+      background-color: #8b0000;
+      color: #dcdcdc;
+    }
+
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item .fc-trail__count.fc-trail__count--commentcount:hover {
+      background-color: #8b0000;
+    }
+
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item .u-faux-block-link--hover,
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item .u-faux-block-link--hover .fc-trail__count--commentcount,
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item .u-faux-block-link--hover .fc-trail__count.fc-trail__count--commentcount,
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item.fc-item--type-comment:not(.fc-item--pillar-special-report) .fc-item__container.u-faux-block-link--hover {
+      background-color: #720000;
+    }
+
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item__title--quoted .inline-garnett-quote,
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item__title--quoted .inline-quote {
+      fill: #ffbac8;
+    }
+
+    .dcr-vkkuzs section.fc-container--breaking-palette.fc-container--has-palette .fc-item__byline {
+      color: #ffbac8;
+    }
+
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item--live .live-pulse-icon::before,
+    .dcr-vkkuzs section.fc-container--breaking-palette .live-pulse-icon::before {
+      background-color: #ffbac8;
+    }
+
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item__liveblog-block__text {
+      border-bottom-color: #8b0000;
+      max-height: 3.57rem;
+    }
+
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item__liveblog-block__text:hover {
+      -webkit-text-decoration: underline;
+      text-decoration: underline;
+    }
+
+    .dcr-vkkuzs section.fc-container--breaking-palette .u-faux-block-link--hover .fc-item__liveblog-block__text {
+      border-bottom-color: #720000;
+    }
+
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #8b0000;
+    }
+
+    .dcr-vkkuzs section.fc-container--breaking-palette .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #720000;
+    }
+
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item--type-live .fc-sublink .fc-sublink__title:before {
+      border-top-color: #ffbac8;
+    }
+
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item--is-commentable:not(.fc-item--type-comment) .fc-item__meta {
+      min-width: calc(4ch + 1rem);
+    }
+
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item .fc-item__media-meta .inline-icon {
+      background-color: #ffbac8;
+      width: 1.5rem;
+      height: 1.4375rem;
+      display: inline-block;
+      border-radius: 50%;
+    }
+
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item .fc-item__media-meta .inline-icon path,
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item .fc-item__media-meta .inline-icon svg {
+      fill: #8b0000;
+    }
+
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-container__toggle {
+      color: #707070;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette {
+      background-color: #f1f8fc;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item--type-comment .fc-item__container:before,
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item.fc-item--live .fc-item__container:before,
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item__container:before {
+      background-color: #c70000;
+      height: 4px;
+      top: -4px;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette+.fc-container__mpu--mobile {
+      background-color: #f1f8fc;
+      margin-top: -12px;
+      padding-bottom: 20px;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .fc-container__header__title:after {
+      background-color: #dceef8;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .fc-container__inner {
+      border-top: 1px solid #dceef8;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .fc-slice {
+      overflow: visible;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .fc-container__header__title h2,
+    .dcr-vkkuzs section.fc-container--event-palette.fc-container--story-package .fc-container__header__title h2.fc-container__title__text {
+      color: #041f4a;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .fc-container__header__description {
+      color: #c70000;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .treats__treat {
+      background-color: #f1f8fc;
+      border-color: #041f4a;
+      color: #041f4a;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .fc-today,
+    .dcr-vkkuzs section.fc-container--event-palette .fc-today .fc-today__sub {
+      color: #c70000;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item,
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment,
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment.fc-item--type-comment {
+      background-color: #ededed;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item .fc-item__headline,
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item.fc-item--live .fc-item__headline {
+      color: #041f4a;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item .fc-item__kicker,
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item.fc-item--live .fc-item__kicker {
+      color: #c70000;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item .u-faux-block-link--hover .fc-sublink {
+      background-color: #e0e0e0;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item .fc-sublink__title {
+      color: #041f4a;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item .fc-sublink__title .fc-sublink__kicker {
+      color: #c70000;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item .fc-item__container>.fc-item__meta {
+      background-image: repeating-linear-gradient(to bottom, , .0625rem, transparent .0625rem, transparent .25rem);
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item .fc-item__meta-wrapper>.fc-item__meta,
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item .fc-item__standfirst-wrapper>.fc-item__meta {
+      color: #041f4a;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item .fc-item__timestamp,
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item .fc-trail__count.fc-trail__count--commentcount,
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment .fc-trail__count.fc-trail__count--commentcount {
+      background-color: #ededed;
+      color: #707070;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item .fc-trail__count.fc-trail__count--commentcount:hover {
+      background-color: #ededed;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item .u-faux-block-link--hover .fc-trail__count--commentcount,
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item .u-faux-block-link--hover .fc-trail__count.fc-trail__count--commentcount {
+      background-color: #e0e0e0;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item .fc-trail__count--commentcount .inline-icon,
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item .fc-trail__count--commentcount .inline-icon svg {
+      fill: #041f4a;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item .u-faux-block-link--hover,
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item.fc-item--type-comment:not(.fc-item--pillar-special-report) .fc-item__container.u-faux-block-link--hover {
+      background-color: #e0e0e0;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item__title--quoted .inline-garnett-quote,
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item__title--quoted .inline-quote {
+      fill: #c70000;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item__title {
+      color: #041f4a;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette.fc-container--has-palette .fc-item__byline {
+      color: #c70000;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item .fc-item__standfirst,
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item.fc-item--live .fc-item__standfirst {
+      color: #041f4a;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item--live .live-pulse-icon::before,
+    .dcr-vkkuzs section.fc-container--event-palette .live-pulse-icon::before {
+      background-color: #c70000;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item__liveblog-block__time {
+      color: #041f4a;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item__liveblog-block__text {
+      border-bottom-color: #ededed;
+      color: #041f4a;
+      max-height: 3.57rem;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item__liveblog-block__text:hover {
+      -webkit-text-decoration: underline;
+      text-decoration: underline;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .u-faux-block-link--hover .fc-item__liveblog-block__text {
+      border-bottom-color: #e0e0e0;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #ededed;
+      color: #041f4a;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #e0e0e0;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item .fc-item__link:visited,
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item .fc-sublink .fc-sublink__link,
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item .fc-sublink .fc-sublink__link:visited {
+      color: #041f4a;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item--type-live .fc-sublink .fc-sublink__title:before {
+      border-top-color: #c70000;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item--is-commentable:not(.fc-item--type-comment) .fc-item__meta {
+      min-width: calc(4ch + 1rem);
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item .fc-item__media-meta .inline-icon {
+      background-color: #c70000;
+      width: 1.5rem;
+      height: 1.4375rem;
+      display: inline-block;
+      border-radius: 50%;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item .fc-item__media-meta .inline-icon path,
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item .fc-item__media-meta .inline-icon svg {
+      fill: #ededed;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item .youtube-media-atom__play-button .inline-play svg {
+      fill: #041f4a;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item--pillar-news .fc-item__media-meta,
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item__media-meta {
+      color: #041f4a;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .fc-container__toggle {
+      color: #707070;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette {
+      background-color: #fbf6ef;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item--type-comment .fc-item__container:before,
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item.fc-item--live .fc-item__container:before,
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item__container:before {
+      background-color: #e2352d;
+      height: 4px;
+      top: -4px;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette+.fc-container__mpu--mobile {
+      background-color: #fbf6ef;
+      margin-top: -12px;
+      padding-bottom: 20px;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-container__header__title:after {
+      background-color: #f6ebdb;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-container__inner {
+      border-top: 1px solid #f6ebdb;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-slice {
+      overflow: visible;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-container__header__title h2,
+    .dcr-vkkuzs section.fc-container--event-alt-palette.fc-container--story-package .fc-container__header__title h2.fc-container__title__text {
+      color: #041f4a;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-container__header__description {
+      color: #c70000;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .treats__treat {
+      background-color: #fbf6ef;
+      border-color: #041f4a;
+      color: #041f4a;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-today,
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-today .fc-today__sub {
+      color: #c70000;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item,
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment,
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment.fc-item--type-comment {
+      background-color: #efe8dd;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item .fc-item__headline,
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item.fc-item--live .fc-item__headline {
+      color: #041f4a;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item .fc-item__kicker,
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item.fc-item--live .fc-item__kicker {
+      color: #e2352d;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item .u-faux-block-link--hover .fc-sublink {
+      background-color: #e7dccc;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item .fc-sublink__title {
+      color: #041f4a;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item .fc-sublink__title .fc-sublink__kicker {
+      color: #e2352d;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item .fc-item__container>.fc-item__meta {
+      background-image: repeating-linear-gradient(to bottom, , .0625rem, transparent .0625rem, transparent .25rem);
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item .fc-item__meta-wrapper>.fc-item__meta,
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item .fc-item__standfirst-wrapper>.fc-item__meta {
+      color: #041f4a;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item .fc-item__timestamp,
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item .fc-trail__count.fc-trail__count--commentcount,
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment .fc-trail__count.fc-trail__count--commentcount {
+      background-color: #efe8dd;
+      color: #333;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item .fc-trail__count.fc-trail__count--commentcount:hover {
+      background-color: #efe8dd;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item .u-faux-block-link--hover .fc-trail__count--commentcount,
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item .u-faux-block-link--hover .fc-trail__count.fc-trail__count--commentcount {
+      background-color: #e7dccc;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item .fc-trail__count--commentcount .inline-icon,
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item .fc-trail__count--commentcount .inline-icon svg {
+      fill: #041f4a;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item .u-faux-block-link--hover,
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item.fc-item--type-comment:not(.fc-item--pillar-special-report) .fc-item__container.u-faux-block-link--hover {
+      background-color: #e7dccc;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item__title--quoted .inline-garnett-quote,
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item__title--quoted .inline-quote {
+      fill: #e2352d;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item__title {
+      color: #041f4a;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette.fc-container--has-palette .fc-item__byline {
+      color: #e2352d;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item .fc-item__standfirst,
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item.fc-item--live .fc-item__standfirst {
+      color: #041f4a;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item--live .live-pulse-icon::before,
+    .dcr-vkkuzs section.fc-container--event-alt-palette .live-pulse-icon::before {
+      background-color: #e2352d;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item__liveblog-block__time {
+      color: #041f4a;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item__liveblog-block__text {
+      border-bottom-color: #efe8dd;
+      color: #041f4a;
+      max-height: 3.57rem;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item__liveblog-block__text:hover {
+      -webkit-text-decoration: underline;
+      text-decoration: underline;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .u-faux-block-link--hover .fc-item__liveblog-block__text {
+      border-bottom-color: #e7dccc;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #efe8dd;
+      color: #041f4a;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #e7dccc;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item .fc-item__link:visited,
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item .fc-sublink .fc-sublink__link,
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item .fc-sublink .fc-sublink__link:visited {
+      color: #041f4a;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item--type-live .fc-sublink .fc-sublink__title:before {
+      border-top-color: #e2352d;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item--is-commentable:not(.fc-item--type-comment) .fc-item__meta {
+      min-width: calc(4ch + 1rem);
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item .fc-item__media-meta .inline-icon {
+      background-color: #e2352d;
+      width: 1.5rem;
+      height: 1.4375rem;
+      display: inline-block;
+      border-radius: 50%;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item .fc-item__media-meta .inline-icon path,
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item .fc-item__media-meta .inline-icon svg {
+      fill: #efe8dd;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item .youtube-media-atom__play-button .inline-play svg {
+      fill: #041f4a;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item--pillar-news .fc-item__media-meta,
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item__media-meta {
+      color: #041f4a;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-container__toggle {
+      color: #707070;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette {
+      background-color: #f5f0eb;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item--type-comment .fc-item__container:before,
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item.fc-item--live .fc-item__container:before,
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item__container:before {
+      background-color: #121212;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette+.fc-container__mpu--mobile {
+      background-color: #f5f0eb;
+      margin-top: -12px;
+      padding-bottom: 20px;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-container__header__title:after {
+      background-color: #ede3da;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-container__inner,
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-container__inner .fc-slice__item+.fc-slice__item:before {
+      border-top: 1px solid rgba(118, 118, 118, .3);
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-slice {
+      overflow: visible;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-container__header__title h2,
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette.fc-container--story-package .fc-container__header__title h2.fc-container__title__text {
+      color: #2b2b2a;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-container__header__description {
+      color: #121212;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .treats__treat {
+      background-color: #f5f0eb;
+      border-color: #2b2b2a;
+      color: #2b2b2a;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-today,
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-today .fc-today__sub {
+      color: #121212;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item,
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment,
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment.fc-item--type-comment {
+      background-color: #ebe6e1;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item .fc-item__headline,
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item.fc-item--live .fc-item__headline {
+      color: #2b2b2a;
+      font-weight: 500;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item .fc-item__kicker,
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item.fc-item--live .fc-item__kicker {
+      color: #121212;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item .u-faux-block-link--hover .fc-sublink {
+      background-color: #e1d9d2;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item .fc-sublink__title {
+      color: #2b2b2a;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item .fc-sublink__title .fc-sublink__kicker {
+      color: #121212;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item .fc-item__container>.fc-item__meta {
+      background-image: repeating-linear-gradient(to bottom, rgba(118, 118, 118, .3), rgba(118, 118, 118, .3) .0625rem, transparent .0625rem, transparent .25rem);
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item .fc-item__meta-wrapper>.fc-item__meta,
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item .fc-item__standfirst-wrapper>.fc-item__meta {
+      color: #2b2b2a;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item .fc-item__timestamp,
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item .fc-trail__count.fc-trail__count--commentcount,
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment .fc-trail__count.fc-trail__count--commentcount {
+      background-color: #ebe6e1;
+      color: #2b2b2a;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item .fc-trail__count.fc-trail__count--commentcount:hover {
+      background-color: #ebe6e1;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item .u-faux-block-link--hover .fc-trail__count--commentcount,
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item .u-faux-block-link--hover .fc-trail__count.fc-trail__count--commentcount {
+      background-color: #e1d9d2;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item .fc-trail__count--commentcount .inline-icon,
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item .fc-trail__count--commentcount .inline-icon svg {
+      fill: #2b2b2a;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item .u-faux-block-link--hover,
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item.fc-item--type-comment:not(.fc-item--pillar-special-report) .fc-item__container.u-faux-block-link--hover {
+      background-color: #e1d9d2;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item__title--quoted .inline-garnett-quote,
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item__title--quoted .inline-quote {
+      fill: #121212;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item__title {
+      color: #2b2b2a;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette.fc-container--has-palette .fc-item__byline {
+      color: #121212;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item .fc-item__standfirst,
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item.fc-item--live .fc-item__standfirst {
+      color: #2b2b2a;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item--live .live-pulse-icon::before,
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .live-pulse-icon::before {
+      background-color: #121212;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item__liveblog-block__time {
+      color: #2b2b2a;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item__liveblog-block__text {
+      border-bottom-color: #ebe6e1;
+      color: #2b2b2a;
+      max-height: 3.57rem;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item__liveblog-block__text:hover {
+      -webkit-text-decoration: underline;
+      text-decoration: underline;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .u-faux-block-link--hover .fc-item__liveblog-block__text {
+      border-bottom-color: #e1d9d2;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #ebe6e1;
+      color: #2b2b2a;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #e1d9d2;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item .fc-item__link:visited,
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item .fc-sublink .fc-sublink__link,
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item .fc-sublink .fc-sublink__link:visited {
+      color: #2b2b2a;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item--type-live .fc-sublink .fc-sublink__title:before {
+      border-top-color: #121212;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item--is-commentable:not(.fc-item--type-comment) .fc-item__meta {
+      min-width: calc(4ch + 1rem);
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item .fc-item__media-meta .inline-icon {
+      background-color: #121212;
+      width: 1.5rem;
+      height: 1.4375rem;
+      display: inline-block;
+      border-radius: 50%;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item .fc-item__media-meta .inline-icon path,
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item .fc-item__media-meta .inline-icon svg {
+      fill: #ebe6e1;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item .vjs-big-play-button .vjs-control-text {
+      background-color: #2b2b2b;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item .youtube-media-atom__play-button .inline-play svg {
+      fill: #2b2b2a;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item--pillar-news .fc-item__media-meta,
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item__media-meta {
+      color: #2b2b2a;
+    }
+
+    .dcr-vkkuzs .fc-item--is-dynamic-card .fc-sublink {
+      z-index: 1;
+    }
+
+    .dcr-vkkuzs .fc-item--is-dynamic-card .fc-sublink__link,
+    .dcr-vkkuzs .fc-item--is-dynamic-card.fc-item--type-live .fc-sublink__link {
+      color: #000;
+    }
+
+    .dcr-vkkuzs .fc-item--is-dynamic-card.fc-item--type-live .u-faux-block-link--hover {
+      background-color: #f2f2f2;
+    }
+
+    .dcr-vkkuzs .fc-item--is-dynamic-card.fc-item--has-floating-sublinks .fc-sublink__link,
+    .dcr-vkkuzs .fc-item--is-dynamic-card.fc-item--has-floating-sublinks.fc-item--type-live .fc-sublink__link {
+      color: #fff;
+    }
+
+    .dcr-vkkuzs .fc-item--is-dynamic-card .fc-item__liveblog-block__time {
+      color: #000;
+    }
+
+    .dcr-vkkuzs .fc-item--is-dynamic-card .fc-item__liveblog-block__text {
+      border-bottom-color: #fff;
+      color: #000;
+    }
+
+    .dcr-vkkuzs .fc-item--is-dynamic-card .u-faux-block-link--hover .fc-item__liveblog-block__text {
+      border-bottom-color: #f2f2f2;
+    }
+
+    .dcr-vkkuzs .fc-item--is-dynamic-card .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #fff;
+      color: #000;
+    }
+
+    .dcr-vkkuzs .fc-item--is-dynamic-card .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #f2f2f2;
+    }
+
+    .dcr-vkkuzs .fc-item--is-dynamic-card.fc-item--live-updates .fc-item__liveblog-block:first-of-type:not(:only-child):before {
+      border-left-color: #000;
+    }
+
+    .dcr-vkkuzs .fc-item--is-dynamic-card.fc-item--live-updates .fc-item__liveblog-block__time:before {
+      border-color: #000;
+    }
+
+    .dcr-vkkuzs .fc-item--is-dynamic-card.fc-item--live-updates .fc-item__liveblog-block__text:after {
+      background-color: #fff;
+    }
+
+    .dcr-vkkuzs .fc-item--is-dynamic-card.fc-item--live-updates .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      background-color: #f2f2f2;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-palette.fc-container--story-package .fc-container__body:before {
+      background-color: #d6d8dc;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-palette.fc-container--story-package .fc-container__inner {
+      border-top: 1px solid #d6d8dc;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-palette.fc-container--story-package .fc-item--live-updates .fc-item__liveblog-block__text:after {
+      background-color: #052962;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-palette.fc-container--story-package .fc-item--live-updates .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      background-color: #041f4a;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette.fc-container--story-package .fc-container__body:before {
+      background-color: #e5e5e5;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette.fc-container--story-package .fc-container__inner {
+      border-top: 1px solid #e5e5e5;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette.fc-container--story-package .fc-item--live-updates .fc-item__liveblog-block:first-of-type:not(:only-child):before {
+      border-left-color: #121212;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette.fc-container--story-package .fc-item--live-updates .fc-item__liveblog-block__time:before {
+      border-color: #121212;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette.fc-container--story-package .fc-item--live-updates .fc-item__liveblog-block__text:after {
+      background-color: #dcdcdc;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette.fc-container--story-package .fc-item--live-updates .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      background-color: #cfcfcf;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-palette.fc-container--story-package .fc-container__body:before {
+      background-color: #4d4f52;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-palette.fc-container--story-package .fc-container__inner {
+      border-top: 1px solid #4d4f52;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-palette.fc-container--story-package .fc-item--live-updates .fc-item__liveblog-block__text:after {
+      background-color: #3f464a;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette.fc-container--story-package .fc-container__body:before,
+    .dcr-vkkuzs section.fc-container--sombre-palette.fc-container--story-package .fc-item--live-updates .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      background-color: #33393c;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette.fc-container--story-package .fc-container__inner {
+      border-top: 1px solid #33393c;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette.fc-container--story-package .fc-item--live-updates .fc-item__liveblog-block__text:after {
+      background-color: #222527;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette.fc-container--story-package .fc-item--live-updates .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      background-color: #161819;
+    }
+
+    .dcr-vkkuzs section.fc-container--investigation-palette.fc-container--story-package .fc-container__body:before {
+      background-color: #4d4f52;
+    }
+
+    .dcr-vkkuzs section.fc-container--investigation-palette.fc-container--story-package .fc-container__inner {
+      border-top: 1px solid #4d4f52;
+    }
+
+    .dcr-vkkuzs section.fc-container--investigation-palette.fc-container--story-package .fc-item--live-updates .fc-item__liveblog-block__text:after {
+      background-color: #3f464a;
+    }
+
+    .dcr-vkkuzs section.fc-container--investigation-palette.fc-container--story-package .fc-item--live-updates .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      background-color: #33393c;
+    }
+
+    .dcr-vkkuzs section.fc-container--breaking-palette.fc-container--story-package .fc-container__body:before {
+      background-color: #f2f2f2;
+    }
+
+    .dcr-vkkuzs section.fc-container--breaking-palette.fc-container--story-package .fc-container__inner {
+      border-top: 1px solid #f2f2f2;
+    }
+
+    .dcr-vkkuzs section.fc-container--breaking-palette.fc-container--story-package .fc-item--live-updates .fc-item__liveblog-block__text:after {
+      background-color: #8b0000;
+    }
+
+    .dcr-vkkuzs section.fc-container--breaking-palette.fc-container--story-package .fc-item--live-updates .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      background-color: #720000;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette.fc-container--story-package .fc-container__body:before {
+      background-color: #dceef8;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette.fc-container--story-package .fc-container__inner {
+      border-top: 1px solid #dceef8;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette.fc-container--story-package .fc-item--live-updates .fc-item__liveblog-block:first-of-type:not(:only-child):before {
+      border-left-color: #041f4a;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette.fc-container--story-package .fc-item--live-updates .fc-item__liveblog-block__time:before {
+      border-color: #041f4a;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette.fc-container--story-package .fc-item--live-updates .fc-item__liveblog-block__text:after {
+      background-color: #ededed;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette.fc-container--story-package .fc-item--live-updates .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      background-color: #e0e0e0;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette.fc-container--story-package .fc-container__body:before {
+      background-color: #f6ebdb;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette.fc-container--story-package .fc-container__inner {
+      border-top: 1px solid #f6ebdb;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette.fc-container--story-package .fc-item--live-updates .fc-item__liveblog-block:first-of-type:not(:only-child):before {
+      border-left-color: #041f4a;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette.fc-container--story-package .fc-item--live-updates .fc-item__liveblog-block__time:before {
+      border-color: #041f4a;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette.fc-container--story-package .fc-item--live-updates .fc-item__liveblog-block__text:after {
+      background-color: #efe8dd;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette.fc-container--story-package .fc-item--live-updates .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      background-color: #e7dccc;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette.fc-container--story-package .fc-container__body:before {
+      background-color: rgba(118, 118, 118, .3);
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette.fc-container--story-package .fc-container__inner,
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette.fc-container--story-package .fc-container__inner .fc-slice__item+.fc-slice__item:before {
+      border-top: 1px solid rgba(118, 118, 118, .3);
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette.fc-container--story-package .fc-item--live-updates .fc-item__liveblog-block:first-of-type:not(:only-child):before {
+      border-left-color: #2b2b2a;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette.fc-container--story-package .fc-item--live-updates .fc-item__liveblog-block__time:before {
+      border-color: #2b2b2a;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette.fc-container--story-package .fc-item--live-updates .fc-item__liveblog-block__text:after {
+      background-color: #ebe6e1;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette.fc-container--story-package .fc-item--live-updates .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      background-color: #e1d9d2;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card,
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment.fc-item--is-dynamic-card,
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment.fc-item--type-comment.fc-item--is-dynamic-card {
+      background-color: #e4e5e8;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card .fc-item__headline,
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card .fc-item__standfirst,
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card.fc-item--live .fc-item__headline {
+      color: #052962;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card .fc-item__kicker,
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card .fc-sublink__kicker,
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card.fc-item--live .fc-item__kicker {
+      color: #c70000;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover,
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card.fc-item--type-comment:not(.fc-item--pillar-special-report) .fc-item__container.u-faux-block-link--hover,
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .u-faux-block-link--hover .fc-sublink {
+      background-color: #d6d8dc;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card .fc-item__title {
+      color: #052962;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card .fc-item__content--above:before,
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card .fc-item__content:before {
+      background-color: #c70000;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card .fc-item__title--quoted .inline-garnett-quote,
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card .fc-item__title--quoted .inline-quote {
+      fill: #c70000;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card .live-pulse-icon::before,
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card.fc-item--live .live-pulse-icon::before {
+      background-color: #c70000;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .fc-item__link:visited,
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .fc-sublink .fc-sublink__link,
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .fc-sublink .fc-sublink__link:visited {
+      color: #052962;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card .fc-item__timestamp,
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count.fc-trail__count--commentcount,
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card[class*=fc-item--pillar-].fc-item--type-comment .fc-trail__count.fc-trail__count--commentcount {
+      background-color: #e4e5e8;
+      color: #052962;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count--commentcount .inline-icon,
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count--commentcount .inline-icon svg {
+      fill: #052962;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count.fc-trail__count--commentcount:hover {
+      background-color: #e4e5e8;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-trail__count--commentcount,
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-trail__count.fc-trail__count--commentcount {
+      background-color: #d6d8dc;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card .fc-item__liveblog-block__time,
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card .fc-item__media-meta,
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card.fc-item--pillar-news .fc-item__media-meta {
+      color: #052962;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card .fc-item__liveblog-block__text {
+      border-bottom-color: #e4e5e8;
+      color: #052962;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-item__liveblog-block__text {
+      border-bottom-color: #d6d8dc;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #e4e5e8;
+      color: #052962;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #d6d8dc;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .fc-item__liveblog-block:first-of-type:not(:only-child):before {
+      border-left-color: #052962;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .fc-item__liveblog-block__time:before {
+      border-color: #052962;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .fc-item__liveblog-block__text:after {
+      background-color: #e4e5e8;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      background-color: #d6d8dc;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-palette.fc-container--has-palette .fc-item--is-dynamic-card .fc-item__byline {
+      color: #c70000;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card[class*=fc-item--has-sublinks] .fc-sublink {
+      background-color: #052962;
+    }
+
+    @media (min-width:740px) {
+      .dcr-vkkuzs section.fc-container--long-running-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card[class*=fc-item--has-sublinks] .fc-sublink {
+        background-color: rgba(5, 41, 98, .9);
+      }
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink__link,
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card.fc-item--type-live .fc-sublink__link {
+      color: #fff;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink__kicker {
+      color: #ff9081;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink .fc-sublink__title:before {
+      border-top-color: #ff9081;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card,
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment.fc-item--is-dynamic-card,
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment.fc-item--type-comment.fc-item--is-dynamic-card {
+      background-color: #f2f2f2;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__headline,
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__standfirst,
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--live .fc-item__headline {
+      color: #121212;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__kicker,
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card .fc-sublink__kicker,
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--live .fc-item__kicker {
+      color: #8b0000;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover,
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--type-comment:not(.fc-item--pillar-special-report) .fc-item__container.u-faux-block-link--hover,
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .u-faux-block-link--hover .fc-sublink {
+      background-color: #e5e5e5;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__title {
+      color: #dcdcdc;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__content--above:before,
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__content:before {
+      background-color: #8b0000;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__title--quoted .inline-garnett-quote,
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__title--quoted .inline-quote {
+      fill: #8b0000;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card .live-pulse-icon::before,
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--live .live-pulse-icon::before {
+      background-color: #8b0000;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .fc-item__link:visited,
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .fc-sublink .fc-sublink__link,
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .fc-sublink .fc-sublink__link:visited {
+      color: #121212;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__timestamp,
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count.fc-trail__count--commentcount,
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card[class*=fc-item--pillar-].fc-item--type-comment .fc-trail__count.fc-trail__count--commentcount {
+      background-color: #f2f2f2;
+      color: #121212;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count--commentcount .inline-icon,
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count--commentcount .inline-icon svg {
+      fill: #121212;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count.fc-trail__count--commentcount:hover {
+      background-color: #f2f2f2;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-trail__count--commentcount,
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-trail__count.fc-trail__count--commentcount {
+      background-color: #e5e5e5;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__media-meta,
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--pillar-news .fc-item__media-meta {
+      color: #dcdcdc;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__liveblog-block__time {
+      color: #121212;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__liveblog-block__text {
+      border-bottom-color: #f2f2f2;
+      color: #121212;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-item__liveblog-block__text {
+      border-bottom-color: #e5e5e5;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #f2f2f2;
+      color: #121212;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #e5e5e5;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .fc-item__liveblog-block:first-of-type:not(:only-child):before {
+      border-left-color: #121212;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .fc-item__liveblog-block__time:before {
+      border-color: #121212;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .fc-item__liveblog-block__text:after {
+      background-color: #f2f2f2;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      background-color: #e5e5e5;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette.fc-container--has-palette .fc-item--is-dynamic-card .fc-item__byline {
+      color: #8b0000;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card[class*=fc-item--has-sublinks] .fc-sublink {
+      background-color: #dcdcdc;
+    }
+
+    @media (min-width:740px) {
+      .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card[class*=fc-item--has-sublinks] .fc-sublink {
+        background-color: rgba(220, 220, 220, .9);
+      }
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink__link,
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card.fc-item--type-live .fc-sublink__link {
+      color: #fff;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink .fc-sublink__link,
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink .fc-sublink__title,
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card.fc-item--type-live .fc-sublink .fc-sublink__link,
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card.fc-item--type-live .fc-sublink .fc-sublink__title {
+      color: #121212;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink__kicker {
+      color: #8b0000;
+    }
+
+    .dcr-vkkuzs section.fc-container--long-running-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink .fc-sublink__title:before {
+      border-top-color: #8b0000;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card,
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment.fc-item--is-dynamic-card,
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment.fc-item--type-comment.fc-item--is-dynamic-card {
+      background-color: #595c5f;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card .fc-item__headline,
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card .fc-item__standfirst,
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card.fc-item--live .fc-item__headline {
+      color: #fff;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card .fc-item__kicker,
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card .fc-sublink__kicker,
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card.fc-item--live .fc-item__kicker {
+      color: #c1d8fc;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover,
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card.fc-item--type-comment:not(.fc-item--pillar-special-report) .fc-item__container.u-faux-block-link--hover,
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .u-faux-block-link--hover .fc-sublink {
+      background-color: #4d4f52;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card .fc-item__title {
+      color: #3f464a;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card .fc-item__content--above:before,
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card .fc-item__content:before {
+      background-color: #c1d8fc;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card .fc-item__title--quoted .inline-garnett-quote,
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card .fc-item__title--quoted .inline-quote {
+      fill: #c1d8fc;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card .live-pulse-icon::before,
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card.fc-item--live .live-pulse-icon::before {
+      background-color: #c1d8fc;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .fc-item__link:visited,
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .fc-sublink .fc-sublink__link,
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .fc-sublink .fc-sublink__link:visited {
+      color: #fff;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card .fc-item__timestamp,
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count.fc-trail__count--commentcount,
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card[class*=fc-item--pillar-].fc-item--type-comment .fc-trail__count.fc-trail__count--commentcount {
+      background-color: #595c5f;
+      color: #fff;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count--commentcount .inline-icon,
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count--commentcount .inline-icon svg {
+      fill: #fff;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count.fc-trail__count--commentcount:hover {
+      background-color: #595c5f;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-trail__count--commentcount,
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-trail__count.fc-trail__count--commentcount {
+      background-color: #4d4f52;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card .fc-item__media-meta,
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card.fc-item--pillar-news .fc-item__media-meta {
+      color: #3f464a;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card .fc-item__liveblog-block__time {
+      color: #fff;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card .fc-item__liveblog-block__text {
+      border-bottom-color: #595c5f;
+      color: #fff;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-item__liveblog-block__text {
+      border-bottom-color: #4d4f52;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #595c5f;
+      color: #fff;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #4d4f52;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .fc-item__liveblog-block:first-of-type:not(:only-child):before {
+      border-left-color: #fff;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .fc-item__liveblog-block__time:before {
+      border-color: #fff;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .fc-item__liveblog-block__text:after {
+      background-color: #595c5f;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      background-color: #4d4f52;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-palette.fc-container--has-palette .fc-item--is-dynamic-card .fc-item__byline {
+      color: #c1d8fc;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card[class*=fc-item--has-sublinks] .fc-sublink {
+      background-color: #3f464a;
+    }
+
+    @media (min-width:740px) {
+      .dcr-vkkuzs section.fc-container--sombre-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card[class*=fc-item--has-sublinks] .fc-sublink {
+        background-color: rgba(63, 70, 74, .9);
+      }
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink__link,
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card.fc-item--type-live .fc-sublink__link {
+      color: #fff;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink__kicker {
+      color: #c1d8fc;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink .fc-sublink__title:before {
+      border-top-color: #c1d8fc;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card,
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment.fc-item--is-dynamic-card,
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment.fc-item--type-comment.fc-item--is-dynamic-card {
+      background-color: #3f464a;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__headline,
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__standfirst,
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--live .fc-item__headline {
+      color: #fff;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__kicker,
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card .fc-sublink__kicker,
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--live .fc-item__kicker {
+      color: #ff5943;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover,
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--type-comment:not(.fc-item--pillar-special-report) .fc-item__container.u-faux-block-link--hover,
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .u-faux-block-link--hover .fc-sublink {
+      background-color: #33393c;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__title {
+      color: #222527;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__content--above:before,
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__content:before {
+      background-color: #ff5943;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__title--quoted .inline-garnett-quote,
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__title--quoted .inline-quote {
+      fill: #ff5943;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card .live-pulse-icon::before,
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--live .live-pulse-icon::before {
+      background-color: #ff5943;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .fc-item__link:visited,
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .fc-sublink .fc-sublink__link,
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .fc-sublink .fc-sublink__link:visited {
+      color: #fff;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__timestamp,
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count.fc-trail__count--commentcount,
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card[class*=fc-item--pillar-].fc-item--type-comment .fc-trail__count.fc-trail__count--commentcount {
+      background-color: #3f464a;
+      color: #fff;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count--commentcount .inline-icon,
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count--commentcount .inline-icon svg {
+      fill: #fff;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count.fc-trail__count--commentcount:hover {
+      background-color: #3f464a;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-trail__count--commentcount,
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-trail__count.fc-trail__count--commentcount {
+      background-color: #33393c;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__media-meta,
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--pillar-news .fc-item__media-meta {
+      color: #222527;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__liveblog-block__time {
+      color: #fff;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__liveblog-block__text {
+      border-bottom-color: #3f464a;
+      color: #fff;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-item__liveblog-block__text {
+      border-bottom-color: #33393c;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #3f464a;
+      color: #fff;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #33393c;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .fc-item__liveblog-block:first-of-type:not(:only-child):before {
+      border-left-color: #fff;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .fc-item__liveblog-block__time:before {
+      border-color: #fff;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .fc-item__liveblog-block__text:after {
+      background-color: #3f464a;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      background-color: #33393c;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette.fc-container--has-palette .fc-item--is-dynamic-card .fc-item__byline {
+      color: #ff5943;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card[class*=fc-item--has-sublinks] .fc-sublink {
+      background-color: #222527;
+    }
+
+    @media (min-width:740px) {
+      .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card[class*=fc-item--has-sublinks] .fc-sublink {
+        background-color: rgba(34, 37, 39, .9);
+      }
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink__link,
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card.fc-item--type-live .fc-sublink__link {
+      color: #fff;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink__kicker {
+      color: #ff5943;
+    }
+
+    .dcr-vkkuzs section.fc-container--sombre-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink .fc-sublink__title:before {
+      border-top-color: #ff5943;
+    }
+
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card,
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment.fc-item--is-dynamic-card,
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment.fc-item--type-comment.fc-item--is-dynamic-card {
+      background-color: #595c5f;
+    }
+
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card .fc-item__headline,
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card .fc-item__standfirst,
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card.fc-item--live .fc-item__headline {
+      color: #fff;
+    }
+
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card .fc-item__kicker,
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card .fc-sublink__kicker,
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card.fc-item--live .fc-item__kicker {
+      color: #ffe500;
+    }
+
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover,
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card.fc-item--type-comment:not(.fc-item--pillar-special-report) .fc-item__container.u-faux-block-link--hover,
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .u-faux-block-link--hover .fc-sublink {
+      background-color: #4d4f52;
+    }
+
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card .fc-item__title {
+      color: #3f464a;
+    }
+
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card .fc-item__content--above:before,
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card .fc-item__content:before {
+      background-color: #ffe500;
+    }
+
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card .fc-item__title--quoted .inline-garnett-quote,
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card .fc-item__title--quoted .inline-quote {
+      fill: #ffe500;
+    }
+
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card .live-pulse-icon::before,
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card.fc-item--live .live-pulse-icon::before {
+      background-color: #ffe500;
+    }
+
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .fc-item__link:visited,
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .fc-sublink .fc-sublink__link,
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .fc-sublink .fc-sublink__link:visited {
+      color: #fff;
+    }
+
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card .fc-item__timestamp,
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count.fc-trail__count--commentcount,
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card[class*=fc-item--pillar-].fc-item--type-comment .fc-trail__count.fc-trail__count--commentcount {
+      background-color: #595c5f;
+      color: #fff;
+    }
+
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count--commentcount .inline-icon,
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count--commentcount .inline-icon svg {
+      fill: #fff;
+    }
+
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count.fc-trail__count--commentcount:hover {
+      background-color: #595c5f;
+    }
+
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-trail__count--commentcount,
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-trail__count.fc-trail__count--commentcount {
+      background-color: #4d4f52;
+    }
+
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card .fc-item__media-meta,
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card.fc-item--pillar-news .fc-item__media-meta {
+      color: #3f464a;
+    }
+
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card .fc-item__liveblog-block__time {
+      color: #fff;
+    }
+
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card .fc-item__liveblog-block__text {
+      border-bottom-color: #595c5f;
+      color: #fff;
+    }
+
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-item__liveblog-block__text {
+      border-bottom-color: #4d4f52;
+    }
+
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #595c5f;
+      color: #fff;
+    }
+
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #4d4f52;
+    }
+
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .fc-item__liveblog-block:first-of-type:not(:only-child):before {
+      border-left-color: #fff;
+    }
+
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .fc-item__liveblog-block__time:before {
+      border-color: #fff;
+    }
+
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .fc-item__liveblog-block__text:after {
+      background-color: #595c5f;
+    }
+
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      background-color: #4d4f52;
+    }
+
+    .dcr-vkkuzs section.fc-container--investigation-palette.fc-container--has-palette .fc-item--is-dynamic-card .fc-item__byline {
+      color: #ffe500;
+    }
+
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card[class*=fc-item--has-sublinks] .fc-sublink {
+      background-color: #3f464a;
+    }
+
+    @media (min-width:740px) {
+      .dcr-vkkuzs section.fc-container--investigation-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card[class*=fc-item--has-sublinks] .fc-sublink {
+        background-color: rgba(63, 70, 74, .9);
+      }
+    }
+
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink__link,
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card.fc-item--type-live .fc-sublink__link {
+      color: #fff;
+    }
+
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink__kicker {
+      color: #ffe500;
+    }
+
+    .dcr-vkkuzs section.fc-container--investigation-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink .fc-sublink__title:before {
+      border-top-color: #ffe500;
+    }
+
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card,
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment.fc-item--is-dynamic-card,
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment.fc-item--type-comment.fc-item--is-dynamic-card {
+      background-color: #fff;
+    }
+
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card .fc-item__headline,
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card .fc-item__standfirst,
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card.fc-item--live .fc-item__headline {
+      color: #121212;
+    }
+
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card .fc-item__kicker,
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card .fc-sublink__kicker,
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card.fc-item--live .fc-item__kicker {
+      color: #8b0000;
+    }
+
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover,
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card.fc-item--type-comment:not(.fc-item--pillar-special-report) .fc-item__container.u-faux-block-link--hover,
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .u-faux-block-link--hover .fc-sublink {
+      background-color: #f2f2f2;
+    }
+
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card .fc-item__title {
+      color: #8b0000;
+    }
+
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card .fc-item__content--above:before,
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card .fc-item__content:before {
+      background-color: #8b0000;
+    }
+
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card .fc-item__title--quoted .inline-garnett-quote,
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card .fc-item__title--quoted .inline-quote {
+      fill: #8b0000;
+    }
+
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card .live-pulse-icon::before,
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card.fc-item--live .live-pulse-icon::before {
+      background-color: #8b0000;
+    }
+
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .fc-item__link:visited,
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .fc-sublink .fc-sublink__link,
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .fc-sublink .fc-sublink__link:visited {
+      color: #121212;
+    }
+
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card .fc-item__timestamp,
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count.fc-trail__count--commentcount,
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card[class*=fc-item--pillar-].fc-item--type-comment .fc-trail__count.fc-trail__count--commentcount {
+      background-color: #fff;
+      color: #121212;
+    }
+
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count--commentcount .inline-icon,
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count--commentcount .inline-icon svg {
+      fill: #121212;
+    }
+
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count.fc-trail__count--commentcount:hover {
+      background-color: #fff;
+    }
+
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-trail__count--commentcount,
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-trail__count.fc-trail__count--commentcount {
+      background-color: #f2f2f2;
+    }
+
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card .fc-item__media-meta,
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card.fc-item--pillar-news .fc-item__media-meta {
+      color: #8b0000;
+    }
+
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card .fc-item__liveblog-block__time {
+      color: #121212;
+    }
+
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card .fc-item__liveblog-block__text {
+      border-bottom-color: #fff;
+      color: #121212;
+    }
+
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-item__liveblog-block__text {
+      border-bottom-color: #f2f2f2;
+    }
+
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #fff;
+      color: #121212;
+    }
+
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #f2f2f2;
+    }
+
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .fc-item__liveblog-block:first-of-type:not(:only-child):before {
+      border-left-color: #121212;
+    }
+
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .fc-item__liveblog-block__time:before {
+      border-color: #121212;
+    }
+
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .fc-item__liveblog-block__text:after {
+      background-color: #fff;
+    }
+
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      background-color: #f2f2f2;
+    }
+
+    .dcr-vkkuzs section.fc-container--breaking-palette.fc-container--has-palette .fc-item--is-dynamic-card .fc-item__byline {
+      color: #8b0000;
+    }
+
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card[class*=fc-item--has-sublinks] .fc-sublink {
+      background-color: #8b0000;
+    }
+
+    @media (min-width:740px) {
+      .dcr-vkkuzs section.fc-container--breaking-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card[class*=fc-item--has-sublinks] .fc-sublink {
+        background-color: rgba(139, 0, 0, .9);
+      }
+    }
+
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink__link,
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card.fc-item--type-live .fc-sublink__link {
+      color: #fff;
+    }
+
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink__kicker {
+      color: #ffbac8;
+    }
+
+    .dcr-vkkuzs section.fc-container--breaking-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink .fc-sublink__title:before {
+      border-top-color: #ffbac8;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card,
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment.fc-item--is-dynamic-card,
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment.fc-item--type-comment.fc-item--is-dynamic-card {
+      background-color: #f1f8fc;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card .fc-item__headline,
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card .fc-item__standfirst,
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card.fc-item--live .fc-item__headline {
+      color: #041f4a;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card .fc-item__kicker,
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card .fc-sublink__kicker,
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card.fc-item--live .fc-item__kicker {
+      color: #c70000;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover,
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card.fc-item--type-comment:not(.fc-item--pillar-special-report) .fc-item__container.u-faux-block-link--hover,
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .u-faux-block-link--hover .fc-sublink {
+      background-color: #dceef8;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card .fc-item__title {
+      color: #ededed;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card .fc-item__content--above:before,
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card .fc-item__content:before {
+      background-color: #c70000;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card .fc-item__title--quoted .inline-garnett-quote,
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card .fc-item__title--quoted .inline-quote {
+      fill: #c70000;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card .live-pulse-icon::before,
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card.fc-item--live .live-pulse-icon::before {
+      background-color: #c70000;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .fc-item__link:visited,
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .fc-sublink .fc-sublink__link,
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .fc-sublink .fc-sublink__link:visited {
+      color: #041f4a;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card .fc-item__timestamp,
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count.fc-trail__count--commentcount,
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card[class*=fc-item--pillar-].fc-item--type-comment .fc-trail__count.fc-trail__count--commentcount {
+      background-color: #f1f8fc;
+      color: #041f4a;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count--commentcount .inline-icon,
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count--commentcount .inline-icon svg {
+      fill: #041f4a;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count.fc-trail__count--commentcount:hover {
+      background-color: #f1f8fc;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-trail__count--commentcount,
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-trail__count.fc-trail__count--commentcount {
+      background-color: #dceef8;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card .fc-item__media-meta,
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card.fc-item--pillar-news .fc-item__media-meta {
+      color: #ededed;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card .fc-item__liveblog-block__time {
+      color: #041f4a;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card .fc-item__liveblog-block__text {
+      border-bottom-color: #f1f8fc;
+      color: #041f4a;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-item__liveblog-block__text {
+      border-bottom-color: #dceef8;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #f1f8fc;
+      color: #041f4a;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #dceef8;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .fc-item__liveblog-block:first-of-type:not(:only-child):before {
+      border-left-color: #041f4a;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .fc-item__liveblog-block__time:before {
+      border-color: #041f4a;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .fc-item__liveblog-block__text:after {
+      background-color: #f1f8fc;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      background-color: #dceef8;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette.fc-container--has-palette .fc-item--is-dynamic-card .fc-item__byline {
+      color: #c70000;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card[class*=fc-item--has-sublinks] .fc-sublink {
+      background-color: #ededed;
+    }
+
+    @media (min-width:740px) {
+      .dcr-vkkuzs section.fc-container--event-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card[class*=fc-item--has-sublinks] .fc-sublink {
+        background-color: rgba(237, 237, 237, .9);
+      }
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink__link,
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card.fc-item--type-live .fc-sublink__link {
+      color: #fff;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink .fc-sublink__link,
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink .fc-sublink__title,
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card.fc-item--type-live .fc-sublink .fc-sublink__link,
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card.fc-item--type-live .fc-sublink .fc-sublink__title {
+      color: #041f4a;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink__kicker {
+      color: #c70000;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink .fc-sublink__title:before {
+      border-top-color: #c70000;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card,
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment.fc-item--is-dynamic-card,
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment.fc-item--type-comment.fc-item--is-dynamic-card {
+      background-color: #fbf6ef;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__headline,
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__standfirst,
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--live .fc-item__headline {
+      color: #041f4a;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__kicker,
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card .fc-sublink__kicker,
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--live .fc-item__kicker {
+      color: #c70000;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover,
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--type-comment:not(.fc-item--pillar-special-report) .fc-item__container.u-faux-block-link--hover,
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .u-faux-block-link--hover .fc-sublink {
+      background-color: #f6ebdb;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__title {
+      color: #efe8dd;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__content--above:before,
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__content:before {
+      background-color: #c70000;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__title--quoted .inline-garnett-quote,
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__title--quoted .inline-quote {
+      fill: #c70000;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card .live-pulse-icon::before,
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--live .live-pulse-icon::before {
+      background-color: #c70000;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .fc-item__link:visited,
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .fc-sublink .fc-sublink__link,
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .fc-sublink .fc-sublink__link:visited {
+      color: #041f4a;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__timestamp,
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count.fc-trail__count--commentcount,
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card[class*=fc-item--pillar-].fc-item--type-comment .fc-trail__count.fc-trail__count--commentcount {
+      background-color: #fbf6ef;
+      color: #041f4a;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count--commentcount .inline-icon,
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count--commentcount .inline-icon svg {
+      fill: #041f4a;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count.fc-trail__count--commentcount:hover {
+      background-color: #fbf6ef;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-trail__count--commentcount,
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-trail__count.fc-trail__count--commentcount {
+      background-color: #f6ebdb;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__media-meta,
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--pillar-news .fc-item__media-meta {
+      color: #ededed;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__liveblog-block__time {
+      color: #041f4a;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__liveblog-block__text {
+      border-bottom-color: #fbf6ef;
+      color: #041f4a;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-item__liveblog-block__text {
+      border-bottom-color: #f6ebdb;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #fbf6ef;
+      color: #041f4a;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #f6ebdb;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .fc-item__liveblog-block:first-of-type:not(:only-child):before {
+      border-left-color: #041f4a;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .fc-item__liveblog-block__time:before {
+      border-color: #041f4a;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .fc-item__liveblog-block__text:after {
+      background-color: #fbf6ef;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      background-color: #f6ebdb;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette.fc-container--has-palette .fc-item--is-dynamic-card .fc-item__byline {
+      color: #c70000;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card[class*=fc-item--has-sublinks] .fc-sublink {
+      background-color: #efe8dd;
+    }
+
+    @media (min-width:740px) {
+      .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card[class*=fc-item--has-sublinks] .fc-sublink {
+        background-color: rgba(239, 232, 221, .9);
+      }
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink__link,
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card.fc-item--type-live .fc-sublink__link {
+      color: #fff;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink .fc-sublink__link,
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink .fc-sublink__title,
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card.fc-item--type-live .fc-sublink .fc-sublink__link,
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card.fc-item--type-live .fc-sublink .fc-sublink__title {
+      color: #041f4a;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink__kicker {
+      color: #c70000;
+    }
+
+    .dcr-vkkuzs section.fc-container--event-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink .fc-sublink__title:before {
+      border-top-color: #e2352d;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card,
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment.fc-item--is-dynamic-card,
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment.fc-item--type-comment.fc-item--is-dynamic-card {
+      background-color: #f5f0eb;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__headline,
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__standfirst,
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--live .fc-item__headline {
+      color: #2b2b2a;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__kicker,
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card .fc-sublink__kicker,
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--live .fc-item__kicker {
+      color: #121212;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover,
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--type-comment:not(.fc-item--pillar-special-report) .fc-item__container.u-faux-block-link--hover,
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .u-faux-block-link--hover .fc-sublink {
+      background-color: #ede3da;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__title {
+      color: #ebe6e1;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__content--above:before,
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__content:before {
+      background-color: #121212;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__title--quoted .inline-garnett-quote,
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__title--quoted .inline-quote {
+      fill: #121212;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card .live-pulse-icon::before,
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--live .live-pulse-icon::before {
+      background-color: #121212;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .fc-item__link:visited,
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .fc-sublink .fc-sublink__link,
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .fc-sublink .fc-sublink__link:visited {
+      color: #2b2b2a;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__timestamp,
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count.fc-trail__count--commentcount,
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card[class*=fc-item--pillar-].fc-item--type-comment .fc-trail__count.fc-trail__count--commentcount {
+      background-color: #f5f0eb;
+      color: #2b2b2a;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count--commentcount .inline-icon,
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count--commentcount .inline-icon svg {
+      fill: #2b2b2a;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count.fc-trail__count--commentcount:hover {
+      background-color: #f5f0eb;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-trail__count--commentcount,
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-trail__count.fc-trail__count--commentcount {
+      background-color: #ede3da;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__media-meta,
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--pillar-news .fc-item__media-meta {
+      color: #f5f0eb;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__liveblog-block__time {
+      color: #2b2b2a;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__liveblog-block__text {
+      border-bottom-color: #f5f0eb;
+      color: #2b2b2a;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-item__liveblog-block__text {
+      border-bottom-color: #ede3da;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #f5f0eb;
+      color: #2b2b2a;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #ede3da;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .fc-item__liveblog-block:first-of-type:not(:only-child):before {
+      border-left-color: #2b2b2a;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .fc-item__liveblog-block__time:before {
+      border-color: #2b2b2a;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .fc-item__liveblog-block__text:after {
+      background-color: #f5f0eb;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      background-color: #ede3da;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette.fc-container--has-palette .fc-item--is-dynamic-card .fc-item__byline {
+      color: #121212;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card[class*=fc-item--has-sublinks] .fc-sublink {
+      background-color: #ebe6e1;
+    }
+
+    @media (min-width:740px) {
+      .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card[class*=fc-item--has-sublinks] .fc-sublink {
+        background-color: rgba(235, 230, 225, .9);
+      }
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink__link,
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card.fc-item--type-live .fc-sublink__link {
+      color: #fff;
+      font-weight: 500;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink .fc-sublink__link,
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink .fc-sublink__title,
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card.fc-item--type-live .fc-sublink .fc-sublink__link,
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card.fc-item--type-live .fc-sublink .fc-sublink__title {
+      color: #2b2b2a;
+      font-weight: 500;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink__kicker {
+      color: #121212;
+    }
+
+    .dcr-vkkuzs section.fc-container--special-report-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink .fc-sublink__title:before {
+      border-top-color: #121212;
+    }
+
+    .dcr-vkkuzs .fc-container--investigation-palette button.fc-container__toggle {
+      color: #ededed;
+    }
+
+    .dcr-vkkuzs .fc-container--investigation-palette .fc-item--type-comment.fc-item--pillar-news.fc-item--type-comment .fc-item__container.u-faux-block-link--hover {
+      background-color: #33393c;
+    }
+
+    .dcr-1ykr3rf {
+      position: relative;
+      margin: auto;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-1ykr3rf {
+        max-width: 740px;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-1ykr3rf {
+        max-width: 980px;
+      }
+    }
+
+    @media (min-width: 1140px) {
+      .dcr-1ykr3rf {
+        max-width: 1140px;
+      }
+    }
+
+    @media (min-width: 1300px) {
+      .dcr-1ykr3rf {
+        max-width: 1300px;
+      }
+    }
+
+    .dcr-1a2uz3 {
+      overflow: hidden;
+      position: relative;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+    }
+
+    .dcr-1a2uz3 section#palette-styles-do-not-delete,
+    .dcr-1a2uz3 section#palette-styles-new-do-not-delete {
+      height: 0;
+      overflow: hidden;
+      margin: 0;
+      padding: 0;
+    }
+
+    .dcr-1a2uz3 .fc-container--long-running-palette+.fc-container__mpu--mobile {
+      background-color: #939a9d;
+      margin-top: -12px;
+      padding-bottom: 20px;
+    }
+
+    .dcr-1a2uz3 .interactive-atom {
+      margin: 0;
+      padding: 0;
+    }
+
+    .dcr-1a2uz3 section:not(.fc-container--has-palette).fc-container--story-package .fc-item--is-dynamic-card .fc-item__content--above {
+      padding-left: .3125rem;
+      padding-right: .3125rem;
+    }
+
+    .dcr-1a2uz3 section.fc-container--has-palette .fc-item--three-quarters-tall-tablet .fc-item__header {
+      padding-left: 5px;
+    }
+
+    .dcr-1a2uz3 section.fc-container--has-palette .fc-item[class*=fc-item--pillar-][class*=fc-item--standard-] .fc-item__title,
+    .dcr-1a2uz3 section.fc-container--has-palette .fc-slice-wrapper+.fc-slice-wrapper .fc-slice--q-q-q-q .fc-item[class*=fc-item--pillar-][class*=fc-item--standard-] .fc-item__title {
+      background-image: none;
+    }
+
+    .dcr-1a2uz3 section.fc-container--has-palette .fc-item .fc-item__headline,
+    .dcr-1a2uz3 section.fc-container--has-palette .fc-item.fc-item--live .fc-item__headline {
+      color: #fff;
+    }
+
+    .dcr-1a2uz3 section.fc-container--has-palette .fc-item .fc-item__meta-wrapper>.fc-item__meta,
+    .dcr-1a2uz3 section.fc-container--has-palette .fc-item .fc-item__standfirst-wrapper>.fc-item__meta {
+      color: #fff;
+      font-weight: 400;
+    }
+
+    .dcr-1a2uz3 section.fc-container--has-palette .fc-item .fc-item__link:visited,
+    .dcr-1a2uz3 section.fc-container--has-palette .fc-item .fc-sublink .fc-sublink__link,
+    .dcr-1a2uz3 section.fc-container--has-palette .fc-item .fc-sublink .fc-sublink__link:visited,
+    .dcr-1a2uz3 section.fc-container--has-palette .fc-item .fc-sublink__title {
+      color: #fff;
+    }
+
+    .dcr-1a2uz3 section.fc-container--has-palette .fc-item .fc-trail__count--commentcount .inline-icon,
+    .dcr-1a2uz3 section.fc-container--has-palette .fc-item .fc-trail__count--commentcount .inline-icon svg {
+      fill: #fff;
+    }
+
+    .dcr-1a2uz3 section.fc-container--has-palette .fc-item .fc-item__standfirst,
+    .dcr-1a2uz3 section.fc-container--has-palette .fc-item.fc-item--live .fc-item__standfirst {
+      color: #fff;
+    }
+
+    .dcr-1a2uz3 section.fc-container--has-palette .fc-item .fc-item__timestamp,
+    .dcr-1a2uz3 section.fc-container--has-palette .fc-item .fc-trail__count.fc-trail__count--commentcount,
+    .dcr-1a2uz3 section.fc-container--has-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment .fc-trail__count.fc-trail__count--commentcount {
+      color: #fff;
+      font-weight: 400;
+    }
+
+    .dcr-1a2uz3 section.fc-container--has-palette .fc-item.fc-item--type-comment.fc-item--has-cutout .fc-item__avatar {
+      background-color: transparent;
+      border-radius: unset;
+      bottom: 0;
+      top: auto;
+      width: 152px;
+      height: 152px;
+    }
+
+    @media (max-width:46.24em) {
+      .dcr-1a2uz3 section.fc-container--has-palette .fc-item.fc-item--type-comment.fc-item--has-cutout .fc-item__avatar {
+        width: 96px;
+        height: 96px;
+      }
+    }
+
+    .dcr-1a2uz3 section.fc-container--has-palette .fc-item.fc-item--type-comment.fc-item--has-cutout:hover .fc-item__avatar {
+      background: 0 0;
+    }
+
+    .dcr-1a2uz3 section.fc-container--has-palette .fc-item.fc-item--type-comment.fc-item--has-cutout .fc-item__avatar__media {
+      height: 152px;
+    }
+
+    @media (max-width:46.24em) {
+      .dcr-1a2uz3 section.fc-container--has-palette .fc-item.fc-item--type-comment.fc-item--has-cutout .fc-item__avatar__media {
+        height: 96px;
+      }
+    }
+
+    .dcr-1a2uz3 section.fc-container--has-palette .l-list--rows-4 .fc-item.fc-item--type-comment.fc-item--has-cutout .fc-item__avatar {
+      width: 98px;
+      height: 98px;
+    }
+
+    .dcr-1a2uz3 section.fc-container--has-palette .l-list--rows-4 .fc-item.fc-item--type-comment.fc-item--has-cutout .fc-item__avatar__media {
+      height: 95px;
+    }
+
+    .dcr-1a2uz3 section.fc-container--has-palette .fc-item__title {
+      color: #fff;
+    }
+
+    .dcr-1a2uz3 section.fc-container--has-palette .fc-item .youtube-media-atom__play-button .inline-play svg {
+      fill: #fff;
+    }
+
+    .dcr-1a2uz3 section.fc-container--has-palette .fc-item--pillar-news .fc-item__media-meta,
+    .dcr-1a2uz3 section.fc-container--has-palette .fc-item__media-meta {
+      color: #fff;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-palette {
+      background-color: #e4e5e8;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item--type-comment .fc-item__container:before,
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item.fc-item--live .fc-item__container:before,
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item__container:before {
+      background-color: #ff9081;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-palette+.fc-container__mpu--mobile {
+      background-color: #e4e5e8;
+      margin-top: -12px;
+      padding-bottom: 20px;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-container__header__title:after {
+      background-color: #d6d8dc;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-container__inner {
+      border-top: 1px solid #d6d8dc;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-slice {
+      overflow: visible;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-container__header__title h2,
+    .dcr-1a2uz3 section.fc-container--long-running-palette.fc-container--story-package .fc-container__header__title h2.fc-container__title__text {
+      color: #052962;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-container__header__description {
+      color: #c70000;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-palette .treats__treat {
+      background-color: #e4e5e8;
+      border-color: #052962;
+      color: #052962;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-today,
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-today .fc-today__sub {
+      color: #c70000;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item,
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment,
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment.fc-item--type-comment {
+      background-color: #052962;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item .fc-item__kicker,
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item.fc-item--live .fc-item__kicker {
+      color: #ff9081;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item .u-faux-block-link--hover .fc-sublink {
+      background-color: #041f4a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item .fc-sublink__title .fc-sublink__kicker {
+      color: #ff9081;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item .fc-item__container>.fc-item__meta {
+      background-image: repeating-linear-gradient(to bottom, , .0625rem, transparent .0625rem, transparent .25rem);
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item .fc-item__timestamp,
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item .fc-trail__count.fc-trail__count--commentcount,
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment .fc-trail__count.fc-trail__count--commentcount {
+      background-color: #052962;
+      color: #dcdcdc;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item .fc-trail__count.fc-trail__count--commentcount:hover {
+      background-color: #052962;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item .u-faux-block-link--hover,
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item .u-faux-block-link--hover .fc-trail__count--commentcount,
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item .u-faux-block-link--hover .fc-trail__count.fc-trail__count--commentcount,
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item.fc-item--type-comment:not(.fc-item--pillar-special-report) .fc-item__container.u-faux-block-link--hover {
+      background-color: #041f4a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item__title--quoted .inline-garnett-quote,
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item__title--quoted .inline-quote {
+      fill: #ff9081;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-palette.fc-container--has-palette .fc-item__byline {
+      color: #ff9081;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item--live .live-pulse-icon::before,
+    .dcr-1a2uz3 section.fc-container--long-running-palette .live-pulse-icon::before {
+      background-color: #ff9081;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item__liveblog-block__text {
+      border-bottom-color: #052962;
+      max-height: 3.57rem;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item__liveblog-block__text:hover {
+      -webkit-text-decoration: underline;
+      text-decoration: underline;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-palette .u-faux-block-link--hover .fc-item__liveblog-block__text {
+      border-bottom-color: #041f4a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #052962;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-palette .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #041f4a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item--type-live .fc-sublink .fc-sublink__title:before {
+      border-top-color: #ff9081;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item--is-commentable:not(.fc-item--type-comment) .fc-item__meta {
+      min-width: calc(4ch + 1rem);
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item .fc-item__media-meta .inline-icon {
+      background-color: #ff9081;
+      width: 1.5rem;
+      height: 1.4375rem;
+      display: inline-block;
+      border-radius: 50%;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item .fc-item__media-meta .inline-icon path,
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item .fc-item__media-meta .inline-icon svg {
+      fill: #052962;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-container__toggle {
+      color: #333;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette {
+      background-color: #f2f2f2;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item--type-comment .fc-item__container:before,
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item.fc-item--live .fc-item__container:before,
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item__container:before {
+      background-color: #8b0000;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette+.fc-container__mpu--mobile {
+      background-color: #f2f2f2;
+      margin-top: -12px;
+      padding-bottom: 20px;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-container__header__title:after {
+      background-color: #e5e5e5;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-container__inner {
+      border-top: 1px solid #e5e5e5;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-slice {
+      overflow: visible;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-container__header__title h2,
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette.fc-container--story-package .fc-container__header__title h2.fc-container__title__text {
+      color: #121212;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-container__header__description {
+      color: #8b0000;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .treats__treat {
+      background-color: #f2f2f2;
+      border-color: #121212;
+      color: #121212;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-today,
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-today .fc-today__sub {
+      color: #8b0000;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item,
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment,
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment.fc-item--type-comment {
+      background-color: #dcdcdc;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item .fc-item__headline,
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item.fc-item--live .fc-item__headline {
+      color: #121212;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item .fc-item__kicker,
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item.fc-item--live .fc-item__kicker {
+      color: #8b0000;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item .u-faux-block-link--hover .fc-sublink {
+      background-color: #cfcfcf;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item .fc-sublink__title {
+      color: #121212;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item .fc-sublink__title .fc-sublink__kicker {
+      color: #8b0000;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item .fc-item__container>.fc-item__meta {
+      background-image: repeating-linear-gradient(to bottom, , .0625rem, transparent .0625rem, transparent .25rem);
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item .fc-item__meta-wrapper>.fc-item__meta,
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item .fc-item__standfirst-wrapper>.fc-item__meta {
+      color: #121212;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item .fc-item__timestamp,
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item .fc-trail__count.fc-trail__count--commentcount,
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment .fc-trail__count.fc-trail__count--commentcount {
+      background-color: #dcdcdc;
+      color: #707070;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item .fc-trail__count.fc-trail__count--commentcount:hover {
+      background-color: #dcdcdc;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item .u-faux-block-link--hover .fc-trail__count--commentcount,
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item .u-faux-block-link--hover .fc-trail__count.fc-trail__count--commentcount {
+      background-color: #cfcfcf;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item .fc-trail__count--commentcount .inline-icon,
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item .fc-trail__count--commentcount .inline-icon svg {
+      fill: #121212;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item .u-faux-block-link--hover,
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item.fc-item--type-comment:not(.fc-item--pillar-special-report) .fc-item__container.u-faux-block-link--hover {
+      background-color: #cfcfcf;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item__title--quoted .inline-garnett-quote,
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item__title--quoted .inline-quote {
+      fill: #8b0000;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item__title {
+      color: #121212;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette.fc-container--has-palette .fc-item__byline {
+      color: #8b0000;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item .fc-item__standfirst,
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item.fc-item--live .fc-item__standfirst {
+      color: #121212;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item--live .live-pulse-icon::before,
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .live-pulse-icon::before {
+      background-color: #8b0000;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item__liveblog-block__time {
+      color: #121212;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item__liveblog-block__text {
+      border-bottom-color: #dcdcdc;
+      color: #121212;
+      max-height: 3.57rem;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item__liveblog-block__text:hover {
+      -webkit-text-decoration: underline;
+      text-decoration: underline;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .u-faux-block-link--hover .fc-item__liveblog-block__text {
+      border-bottom-color: #cfcfcf;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #dcdcdc;
+      color: #121212;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #cfcfcf;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item .fc-item__link:visited,
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item .fc-sublink .fc-sublink__link,
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item .fc-sublink .fc-sublink__link:visited {
+      color: #121212;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item--type-live .fc-sublink .fc-sublink__title:before {
+      border-top-color: #8b0000;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item--is-commentable:not(.fc-item--type-comment) .fc-item__meta {
+      min-width: calc(4ch + 1rem);
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item .fc-item__media-meta .inline-icon {
+      background-color: #8b0000;
+      width: 1.5rem;
+      height: 1.4375rem;
+      display: inline-block;
+      border-radius: 50%;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item .fc-item__media-meta .inline-icon path,
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item .fc-item__media-meta .inline-icon svg {
+      fill: #dcdcdc;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item .youtube-media-atom__play-button .inline-play svg {
+      fill: #121212;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item--pillar-news .fc-item__media-meta,
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item__media-meta {
+      color: #121212;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-container__toggle {
+      color: #333;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-palette {
+      background-color: #595c5f;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item--type-comment .fc-item__container:before,
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item.fc-item--live .fc-item__container:before,
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item__container:before {
+      background-color: #c1d8fc;
+      height: 4px;
+      top: -4px;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-palette+.fc-container__mpu--mobile {
+      background-color: #595c5f;
+      margin-top: -12px;
+      padding-bottom: 20px;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-container__header__title:after {
+      background-color: #4d4f52;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-container__inner {
+      border-top: 1px solid #4d4f52;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-slice {
+      overflow: visible;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-container__header__title h2,
+    .dcr-1a2uz3 section.fc-container--sombre-palette.fc-container--story-package .fc-container__header__title h2.fc-container__title__text {
+      color: #fff;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-container__header__description {
+      color: #c1d8fc;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-palette .treats__treat {
+      background-color: #595c5f;
+      border-color: #fff;
+      color: #fff;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-today,
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-today .fc-today__sub {
+      color: #c1d8fc;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item,
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment,
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment.fc-item--type-comment {
+      background-color: #3f464a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item .fc-item__kicker,
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item.fc-item--live .fc-item__kicker {
+      color: #c1d8fc;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item .u-faux-block-link--hover .fc-sublink {
+      background-color: #33393c;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item .fc-sublink__title .fc-sublink__kicker {
+      color: #c1d8fc;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item .fc-item__container>.fc-item__meta {
+      background-image: repeating-linear-gradient(to bottom, , .0625rem, transparent .0625rem, transparent .25rem);
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item .fc-item__timestamp,
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item .fc-trail__count.fc-trail__count--commentcount,
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment .fc-trail__count.fc-trail__count--commentcount {
+      background-color: #3f464a;
+      color: #dcdcdc;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item .fc-trail__count.fc-trail__count--commentcount:hover {
+      background-color: #3f464a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item .u-faux-block-link--hover,
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item .u-faux-block-link--hover .fc-trail__count--commentcount,
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item .u-faux-block-link--hover .fc-trail__count.fc-trail__count--commentcount,
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item.fc-item--type-comment:not(.fc-item--pillar-special-report) .fc-item__container.u-faux-block-link--hover {
+      background-color: #33393c;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item__title--quoted .inline-garnett-quote,
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item__title--quoted .inline-quote {
+      fill: #c1d8fc;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-palette.fc-container--has-palette .fc-item__byline {
+      color: #c1d8fc;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item--live .live-pulse-icon::before,
+    .dcr-1a2uz3 section.fc-container--sombre-palette .live-pulse-icon::before {
+      background-color: #c1d8fc;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item__liveblog-block__text {
+      border-bottom-color: #3f464a;
+      max-height: 3.57rem;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item__liveblog-block__text:hover {
+      -webkit-text-decoration: underline;
+      text-decoration: underline;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-palette .u-faux-block-link--hover .fc-item__liveblog-block__text {
+      border-bottom-color: #33393c;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #3f464a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-palette .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #33393c;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item--type-live .fc-sublink .fc-sublink__title:before {
+      border-top-color: #c1d8fc;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item--is-commentable:not(.fc-item--type-comment) .fc-item__meta {
+      min-width: calc(4ch + 1rem);
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item .fc-item__media-meta .inline-icon {
+      background-color: #c1d8fc;
+      width: 1.5rem;
+      height: 1.4375rem;
+      display: inline-block;
+      border-radius: 50%;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item .fc-item__media-meta .inline-icon path,
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item .fc-item__media-meta .inline-icon svg {
+      fill: #3f464a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-container__toggle {
+      color: #dcdcdc;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette {
+      background-color: #3f464a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item--type-comment .fc-item__container:before,
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item.fc-item--live .fc-item__container:before,
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item__container:before {
+      background-color: #ff5943;
+      height: 4px;
+      top: -4px;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette+.fc-container__mpu--mobile {
+      background-color: #3f464a;
+      margin-top: -12px;
+      padding-bottom: 20px;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-container__header__title:after {
+      background-color: #33393c;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-container__inner {
+      border-top: 1px solid #33393c;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-slice {
+      overflow: visible;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-container__header__title h2,
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette.fc-container--story-package .fc-container__header__title h2.fc-container__title__text {
+      color: #fff;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-container__header__description {
+      color: #ff5943;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .treats__treat {
+      background-color: #3f464a;
+      border-color: #fff;
+      color: #fff;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-today,
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-today .fc-today__sub {
+      color: #ff5943;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item,
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment,
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment.fc-item--type-comment {
+      background-color: #222527;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item .fc-item__kicker,
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item.fc-item--live .fc-item__kicker {
+      color: #ff5943;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item .u-faux-block-link--hover .fc-sublink {
+      background-color: #161819;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item .fc-sublink__title .fc-sublink__kicker {
+      color: #ff5943;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item .fc-item__container>.fc-item__meta {
+      background-image: repeating-linear-gradient(to bottom, , .0625rem, transparent .0625rem, transparent .25rem);
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item .fc-item__timestamp,
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item .fc-trail__count.fc-trail__count--commentcount,
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment .fc-trail__count.fc-trail__count--commentcount {
+      background-color: #222527;
+      color: #999;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item .fc-trail__count.fc-trail__count--commentcount:hover {
+      background-color: #222527;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item .u-faux-block-link--hover,
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item .u-faux-block-link--hover .fc-trail__count--commentcount,
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item .u-faux-block-link--hover .fc-trail__count.fc-trail__count--commentcount,
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item.fc-item--type-comment:not(.fc-item--pillar-special-report) .fc-item__container.u-faux-block-link--hover {
+      background-color: #161819;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item__title--quoted .inline-garnett-quote,
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item__title--quoted .inline-quote {
+      fill: #ff5943;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette.fc-container--has-palette .fc-item__byline {
+      color: #ff5943;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item--live .live-pulse-icon::before,
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .live-pulse-icon::before {
+      background-color: #ff5943;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item__liveblog-block__text {
+      border-bottom-color: #222527;
+      max-height: 3.57rem;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item__liveblog-block__text:hover {
+      -webkit-text-decoration: underline;
+      text-decoration: underline;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .u-faux-block-link--hover .fc-item__liveblog-block__text {
+      border-bottom-color: #161819;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #222527;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #161819;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item--type-live .fc-sublink .fc-sublink__title:before {
+      border-top-color: #ff5943;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item--is-commentable:not(.fc-item--type-comment) .fc-item__meta {
+      min-width: calc(4ch + 1rem);
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item .fc-item__media-meta .inline-icon {
+      background-color: #ff5943;
+      width: 1.5rem;
+      height: 1.4375rem;
+      display: inline-block;
+      border-radius: 50%;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item .fc-item__media-meta .inline-icon path,
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item .fc-item__media-meta .inline-icon svg {
+      fill: #222527;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-container__toggle {
+      color: #dcdcdc;
+    }
+
+    .dcr-1a2uz3 section.fc-container--investigation-palette {
+      background-color: #595c5f;
+    }
+
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item--type-comment .fc-item__container:before,
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item.fc-item--live .fc-item__container:before,
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item__container:before {
+      background-color: #ffe500;
+    }
+
+    .dcr-1a2uz3 section.fc-container--investigation-palette+.fc-container__mpu--mobile {
+      background-color: #595c5f;
+      margin-top: -12px;
+      padding-bottom: 20px;
+    }
+
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-container__header__title:after {
+      background-color: #4d4f52;
+    }
+
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-container__inner {
+      border-top: 1px solid #4d4f52;
+    }
+
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-slice {
+      overflow: visible;
+    }
+
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-container__header__title h2,
+    .dcr-1a2uz3 section.fc-container--investigation-palette.fc-container--story-package .fc-container__header__title h2.fc-container__title__text {
+      color: #fff;
+    }
+
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-container__header__description {
+      color: #ffe500;
+    }
+
+    .dcr-1a2uz3 section.fc-container--investigation-palette .treats__treat {
+      background-color: #595c5f;
+      border-color: #fff;
+      color: #fff;
+    }
+
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-today,
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-today .fc-today__sub {
+      color: #ffe500;
+    }
+
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item,
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment,
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment.fc-item--type-comment {
+      background-color: #3f464a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item .fc-item__kicker,
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item.fc-item--live .fc-item__kicker {
+      color: #ffe500;
+    }
+
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item .u-faux-block-link--hover .fc-sublink {
+      background-color: #33393c;
+    }
+
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item .fc-sublink__title .fc-sublink__kicker {
+      color: #ffe500;
+    }
+
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item .fc-item__container>.fc-item__meta {
+      background-image: repeating-linear-gradient(to bottom, , .0625rem, transparent .0625rem, transparent .25rem);
+    }
+
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item .fc-item__timestamp,
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item .fc-trail__count.fc-trail__count--commentcount,
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment .fc-trail__count.fc-trail__count--commentcount {
+      background-color: #3f464a;
+      color: #dcdcdc;
+    }
+
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item .fc-trail__count.fc-trail__count--commentcount:hover {
+      background-color: #3f464a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item .u-faux-block-link--hover,
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item .u-faux-block-link--hover .fc-trail__count--commentcount,
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item .u-faux-block-link--hover .fc-trail__count.fc-trail__count--commentcount,
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item.fc-item--type-comment:not(.fc-item--pillar-special-report) .fc-item__container.u-faux-block-link--hover {
+      background-color: #33393c;
+    }
+
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item__title--quoted .inline-garnett-quote,
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item__title--quoted .inline-quote {
+      fill: #ffe500;
+    }
+
+    .dcr-1a2uz3 section.fc-container--investigation-palette.fc-container--has-palette .fc-item__byline {
+      color: #ffe500;
+    }
+
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item--live .live-pulse-icon::before,
+    .dcr-1a2uz3 section.fc-container--investigation-palette .live-pulse-icon::before {
+      background-color: #ffe500;
+    }
+
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item__liveblog-block__text {
+      border-bottom-color: #3f464a;
+      max-height: 3.57rem;
+    }
+
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item__liveblog-block__text:hover {
+      -webkit-text-decoration: underline;
+      text-decoration: underline;
+    }
+
+    .dcr-1a2uz3 section.fc-container--investigation-palette .u-faux-block-link--hover .fc-item__liveblog-block__text {
+      border-bottom-color: #33393c;
+    }
+
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #3f464a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--investigation-palette .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #33393c;
+    }
+
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item--type-live .fc-sublink .fc-sublink__title:before {
+      border-top-color: #ffe500;
+    }
+
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item--is-commentable:not(.fc-item--type-comment) .fc-item__meta {
+      min-width: calc(4ch + 1rem);
+    }
+
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item .fc-item__media-meta .inline-icon {
+      background-color: #ffe500;
+      width: 1.5rem;
+      height: 1.4375rem;
+      display: inline-block;
+      border-radius: 50%;
+    }
+
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item .fc-item__media-meta .inline-icon path,
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item .fc-item__media-meta .inline-icon svg {
+      fill: #3f464a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-container__toggle {
+      color: #f6f6f6;
+    }
+
+    .dcr-1a2uz3 section.fc-container--breaking-palette {
+      background-color: #fff;
+    }
+
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item--type-comment .fc-item__container:before,
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item.fc-item--live .fc-item__container:before,
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item__container:before {
+      background-color: #ffbac8;
+    }
+
+    .dcr-1a2uz3 section.fc-container--breaking-palette+.fc-container__mpu--mobile {
+      background-color: #fff;
+      margin-top: -12px;
+      padding-bottom: 20px;
+    }
+
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-container__header__title:after {
+      background-color: #f2f2f2;
+    }
+
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-container__inner {
+      border-top: 1px solid #f2f2f2;
+    }
+
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-slice {
+      overflow: visible;
+    }
+
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-container__header__title h2,
+    .dcr-1a2uz3 section.fc-container--breaking-palette.fc-container--story-package .fc-container__header__title h2.fc-container__title__text {
+      color: #121212;
+    }
+
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-container__header__description {
+      color: #8b0000;
+    }
+
+    .dcr-1a2uz3 section.fc-container--breaking-palette .treats__treat {
+      background-color: #fff;
+      border-color: #121212;
+      color: #121212;
+    }
+
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-today,
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-today .fc-today__sub {
+      color: #8b0000;
+    }
+
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item,
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment,
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment.fc-item--type-comment {
+      background-color: #8b0000;
+    }
+
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item .fc-item__kicker,
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item.fc-item--live .fc-item__kicker {
+      color: #ffbac8;
+    }
+
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item .u-faux-block-link--hover .fc-sublink {
+      background-color: #720000;
+    }
+
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item .fc-sublink__title .fc-sublink__kicker {
+      color: #ffbac8;
+    }
+
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item .fc-item__container>.fc-item__meta {
+      background-image: repeating-linear-gradient(to bottom, , .0625rem, transparent .0625rem, transparent .25rem);
+    }
+
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item .fc-item__timestamp,
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item .fc-trail__count.fc-trail__count--commentcount,
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment .fc-trail__count.fc-trail__count--commentcount {
+      background-color: #8b0000;
+      color: #dcdcdc;
+    }
+
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item .fc-trail__count.fc-trail__count--commentcount:hover {
+      background-color: #8b0000;
+    }
+
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item .u-faux-block-link--hover,
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item .u-faux-block-link--hover .fc-trail__count--commentcount,
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item .u-faux-block-link--hover .fc-trail__count.fc-trail__count--commentcount,
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item.fc-item--type-comment:not(.fc-item--pillar-special-report) .fc-item__container.u-faux-block-link--hover {
+      background-color: #720000;
+    }
+
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item__title--quoted .inline-garnett-quote,
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item__title--quoted .inline-quote {
+      fill: #ffbac8;
+    }
+
+    .dcr-1a2uz3 section.fc-container--breaking-palette.fc-container--has-palette .fc-item__byline {
+      color: #ffbac8;
+    }
+
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item--live .live-pulse-icon::before,
+    .dcr-1a2uz3 section.fc-container--breaking-palette .live-pulse-icon::before {
+      background-color: #ffbac8;
+    }
+
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item__liveblog-block__text {
+      border-bottom-color: #8b0000;
+      max-height: 3.57rem;
+    }
+
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item__liveblog-block__text:hover {
+      -webkit-text-decoration: underline;
+      text-decoration: underline;
+    }
+
+    .dcr-1a2uz3 section.fc-container--breaking-palette .u-faux-block-link--hover .fc-item__liveblog-block__text {
+      border-bottom-color: #720000;
+    }
+
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #8b0000;
+    }
+
+    .dcr-1a2uz3 section.fc-container--breaking-palette .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #720000;
+    }
+
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item--type-live .fc-sublink .fc-sublink__title:before {
+      border-top-color: #ffbac8;
+    }
+
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item--is-commentable:not(.fc-item--type-comment) .fc-item__meta {
+      min-width: calc(4ch + 1rem);
+    }
+
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item .fc-item__media-meta .inline-icon {
+      background-color: #ffbac8;
+      width: 1.5rem;
+      height: 1.4375rem;
+      display: inline-block;
+      border-radius: 50%;
+    }
+
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item .fc-item__media-meta .inline-icon path,
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item .fc-item__media-meta .inline-icon svg {
+      fill: #8b0000;
+    }
+
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-container__toggle {
+      color: #707070;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette {
+      background-color: #f1f8fc;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item--type-comment .fc-item__container:before,
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item.fc-item--live .fc-item__container:before,
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item__container:before {
+      background-color: #c70000;
+      height: 4px;
+      top: -4px;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette+.fc-container__mpu--mobile {
+      background-color: #f1f8fc;
+      margin-top: -12px;
+      padding-bottom: 20px;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-container__header__title:after {
+      background-color: #dceef8;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-container__inner {
+      border-top: 1px solid #dceef8;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-slice {
+      overflow: visible;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-container__header__title h2,
+    .dcr-1a2uz3 section.fc-container--event-palette.fc-container--story-package .fc-container__header__title h2.fc-container__title__text {
+      color: #041f4a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-container__header__description {
+      color: #c70000;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .treats__treat {
+      background-color: #f1f8fc;
+      border-color: #041f4a;
+      color: #041f4a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-today,
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-today .fc-today__sub {
+      color: #c70000;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item,
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment,
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment.fc-item--type-comment {
+      background-color: #ededed;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item .fc-item__headline,
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item.fc-item--live .fc-item__headline {
+      color: #041f4a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item .fc-item__kicker,
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item.fc-item--live .fc-item__kicker {
+      color: #c70000;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item .u-faux-block-link--hover .fc-sublink {
+      background-color: #e0e0e0;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item .fc-sublink__title {
+      color: #041f4a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item .fc-sublink__title .fc-sublink__kicker {
+      color: #c70000;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item .fc-item__container>.fc-item__meta {
+      background-image: repeating-linear-gradient(to bottom, , .0625rem, transparent .0625rem, transparent .25rem);
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item .fc-item__meta-wrapper>.fc-item__meta,
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item .fc-item__standfirst-wrapper>.fc-item__meta {
+      color: #041f4a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item .fc-item__timestamp,
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item .fc-trail__count.fc-trail__count--commentcount,
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment .fc-trail__count.fc-trail__count--commentcount {
+      background-color: #ededed;
+      color: #707070;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item .fc-trail__count.fc-trail__count--commentcount:hover {
+      background-color: #ededed;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item .u-faux-block-link--hover .fc-trail__count--commentcount,
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item .u-faux-block-link--hover .fc-trail__count.fc-trail__count--commentcount {
+      background-color: #e0e0e0;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item .fc-trail__count--commentcount .inline-icon,
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item .fc-trail__count--commentcount .inline-icon svg {
+      fill: #041f4a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item .u-faux-block-link--hover,
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item.fc-item--type-comment:not(.fc-item--pillar-special-report) .fc-item__container.u-faux-block-link--hover {
+      background-color: #e0e0e0;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item__title--quoted .inline-garnett-quote,
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item__title--quoted .inline-quote {
+      fill: #c70000;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item__title {
+      color: #041f4a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette.fc-container--has-palette .fc-item__byline {
+      color: #c70000;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item .fc-item__standfirst,
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item.fc-item--live .fc-item__standfirst {
+      color: #041f4a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item--live .live-pulse-icon::before,
+    .dcr-1a2uz3 section.fc-container--event-palette .live-pulse-icon::before {
+      background-color: #c70000;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item__liveblog-block__time {
+      color: #041f4a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item__liveblog-block__text {
+      border-bottom-color: #ededed;
+      color: #041f4a;
+      max-height: 3.57rem;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item__liveblog-block__text:hover {
+      -webkit-text-decoration: underline;
+      text-decoration: underline;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .u-faux-block-link--hover .fc-item__liveblog-block__text {
+      border-bottom-color: #e0e0e0;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #ededed;
+      color: #041f4a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #e0e0e0;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item .fc-item__link:visited,
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item .fc-sublink .fc-sublink__link,
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item .fc-sublink .fc-sublink__link:visited {
+      color: #041f4a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item--type-live .fc-sublink .fc-sublink__title:before {
+      border-top-color: #c70000;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item--is-commentable:not(.fc-item--type-comment) .fc-item__meta {
+      min-width: calc(4ch + 1rem);
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item .fc-item__media-meta .inline-icon {
+      background-color: #c70000;
+      width: 1.5rem;
+      height: 1.4375rem;
+      display: inline-block;
+      border-radius: 50%;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item .fc-item__media-meta .inline-icon path,
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item .fc-item__media-meta .inline-icon svg {
+      fill: #ededed;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item .youtube-media-atom__play-button .inline-play svg {
+      fill: #041f4a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item--pillar-news .fc-item__media-meta,
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item__media-meta {
+      color: #041f4a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-container__toggle {
+      color: #707070;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette {
+      background-color: #fbf6ef;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item--type-comment .fc-item__container:before,
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item.fc-item--live .fc-item__container:before,
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item__container:before {
+      background-color: #e2352d;
+      height: 4px;
+      top: -4px;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette+.fc-container__mpu--mobile {
+      background-color: #fbf6ef;
+      margin-top: -12px;
+      padding-bottom: 20px;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-container__header__title:after {
+      background-color: #f6ebdb;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-container__inner {
+      border-top: 1px solid #f6ebdb;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-slice {
+      overflow: visible;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-container__header__title h2,
+    .dcr-1a2uz3 section.fc-container--event-alt-palette.fc-container--story-package .fc-container__header__title h2.fc-container__title__text {
+      color: #041f4a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-container__header__description {
+      color: #c70000;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .treats__treat {
+      background-color: #fbf6ef;
+      border-color: #041f4a;
+      color: #041f4a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-today,
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-today .fc-today__sub {
+      color: #c70000;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item,
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment,
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment.fc-item--type-comment {
+      background-color: #efe8dd;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item .fc-item__headline,
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item.fc-item--live .fc-item__headline {
+      color: #041f4a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item .fc-item__kicker,
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item.fc-item--live .fc-item__kicker {
+      color: #e2352d;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item .u-faux-block-link--hover .fc-sublink {
+      background-color: #e7dccc;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item .fc-sublink__title {
+      color: #041f4a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item .fc-sublink__title .fc-sublink__kicker {
+      color: #e2352d;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item .fc-item__container>.fc-item__meta {
+      background-image: repeating-linear-gradient(to bottom, , .0625rem, transparent .0625rem, transparent .25rem);
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item .fc-item__meta-wrapper>.fc-item__meta,
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item .fc-item__standfirst-wrapper>.fc-item__meta {
+      color: #041f4a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item .fc-item__timestamp,
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item .fc-trail__count.fc-trail__count--commentcount,
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment .fc-trail__count.fc-trail__count--commentcount {
+      background-color: #efe8dd;
+      color: #333;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item .fc-trail__count.fc-trail__count--commentcount:hover {
+      background-color: #efe8dd;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item .u-faux-block-link--hover .fc-trail__count--commentcount,
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item .u-faux-block-link--hover .fc-trail__count.fc-trail__count--commentcount {
+      background-color: #e7dccc;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item .fc-trail__count--commentcount .inline-icon,
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item .fc-trail__count--commentcount .inline-icon svg {
+      fill: #041f4a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item .u-faux-block-link--hover,
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item.fc-item--type-comment:not(.fc-item--pillar-special-report) .fc-item__container.u-faux-block-link--hover {
+      background-color: #e7dccc;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item__title--quoted .inline-garnett-quote,
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item__title--quoted .inline-quote {
+      fill: #e2352d;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item__title {
+      color: #041f4a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette.fc-container--has-palette .fc-item__byline {
+      color: #e2352d;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item .fc-item__standfirst,
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item.fc-item--live .fc-item__standfirst {
+      color: #041f4a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item--live .live-pulse-icon::before,
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .live-pulse-icon::before {
+      background-color: #e2352d;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item__liveblog-block__time {
+      color: #041f4a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item__liveblog-block__text {
+      border-bottom-color: #efe8dd;
+      color: #041f4a;
+      max-height: 3.57rem;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item__liveblog-block__text:hover {
+      -webkit-text-decoration: underline;
+      text-decoration: underline;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .u-faux-block-link--hover .fc-item__liveblog-block__text {
+      border-bottom-color: #e7dccc;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #efe8dd;
+      color: #041f4a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #e7dccc;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item .fc-item__link:visited,
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item .fc-sublink .fc-sublink__link,
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item .fc-sublink .fc-sublink__link:visited {
+      color: #041f4a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item--type-live .fc-sublink .fc-sublink__title:before {
+      border-top-color: #e2352d;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item--is-commentable:not(.fc-item--type-comment) .fc-item__meta {
+      min-width: calc(4ch + 1rem);
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item .fc-item__media-meta .inline-icon {
+      background-color: #e2352d;
+      width: 1.5rem;
+      height: 1.4375rem;
+      display: inline-block;
+      border-radius: 50%;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item .fc-item__media-meta .inline-icon path,
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item .fc-item__media-meta .inline-icon svg {
+      fill: #efe8dd;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item .youtube-media-atom__play-button .inline-play svg {
+      fill: #041f4a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item--pillar-news .fc-item__media-meta,
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item__media-meta {
+      color: #041f4a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-container__toggle {
+      color: #707070;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette {
+      background-color: #f5f0eb;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item--type-comment .fc-item__container:before,
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item.fc-item--live .fc-item__container:before,
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item__container:before {
+      background-color: #121212;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette+.fc-container__mpu--mobile {
+      background-color: #f5f0eb;
+      margin-top: -12px;
+      padding-bottom: 20px;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-container__header__title:after {
+      background-color: #ede3da;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-container__inner,
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-container__inner .fc-slice__item+.fc-slice__item:before {
+      border-top: 1px solid rgba(118, 118, 118, .3);
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-slice {
+      overflow: visible;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-container__header__title h2,
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette.fc-container--story-package .fc-container__header__title h2.fc-container__title__text {
+      color: #2b2b2a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-container__header__description {
+      color: #121212;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .treats__treat {
+      background-color: #f5f0eb;
+      border-color: #2b2b2a;
+      color: #2b2b2a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-today,
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-today .fc-today__sub {
+      color: #121212;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item,
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment,
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment.fc-item--type-comment {
+      background-color: #ebe6e1;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item .fc-item__headline,
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item.fc-item--live .fc-item__headline {
+      color: #2b2b2a;
+      font-weight: 500;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item .fc-item__kicker,
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item.fc-item--live .fc-item__kicker {
+      color: #121212;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item .u-faux-block-link--hover .fc-sublink {
+      background-color: #e1d9d2;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item .fc-sublink__title {
+      color: #2b2b2a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item .fc-sublink__title .fc-sublink__kicker {
+      color: #121212;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item .fc-item__container>.fc-item__meta {
+      background-image: repeating-linear-gradient(to bottom, rgba(118, 118, 118, .3), rgba(118, 118, 118, .3) .0625rem, transparent .0625rem, transparent .25rem);
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item .fc-item__meta-wrapper>.fc-item__meta,
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item .fc-item__standfirst-wrapper>.fc-item__meta {
+      color: #2b2b2a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item .fc-item__timestamp,
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item .fc-trail__count.fc-trail__count--commentcount,
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment .fc-trail__count.fc-trail__count--commentcount {
+      background-color: #ebe6e1;
+      color: #2b2b2a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item .fc-trail__count.fc-trail__count--commentcount:hover {
+      background-color: #ebe6e1;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item .u-faux-block-link--hover .fc-trail__count--commentcount,
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item .u-faux-block-link--hover .fc-trail__count.fc-trail__count--commentcount {
+      background-color: #e1d9d2;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item .fc-trail__count--commentcount .inline-icon,
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item .fc-trail__count--commentcount .inline-icon svg {
+      fill: #2b2b2a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item .u-faux-block-link--hover,
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item.fc-item--type-comment:not(.fc-item--pillar-special-report) .fc-item__container.u-faux-block-link--hover {
+      background-color: #e1d9d2;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item__title--quoted .inline-garnett-quote,
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item__title--quoted .inline-quote {
+      fill: #121212;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item__title {
+      color: #2b2b2a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette.fc-container--has-palette .fc-item__byline {
+      color: #121212;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item .fc-item__standfirst,
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item.fc-item--live .fc-item__standfirst {
+      color: #2b2b2a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item--live .live-pulse-icon::before,
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .live-pulse-icon::before {
+      background-color: #121212;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item__liveblog-block__time {
+      color: #2b2b2a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item__liveblog-block__text {
+      border-bottom-color: #ebe6e1;
+      color: #2b2b2a;
+      max-height: 3.57rem;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item__liveblog-block__text:hover {
+      -webkit-text-decoration: underline;
+      text-decoration: underline;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .u-faux-block-link--hover .fc-item__liveblog-block__text {
+      border-bottom-color: #e1d9d2;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #ebe6e1;
+      color: #2b2b2a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #e1d9d2;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item .fc-item__link:visited,
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item .fc-sublink .fc-sublink__link,
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item .fc-sublink .fc-sublink__link:visited {
+      color: #2b2b2a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item--type-live .fc-sublink .fc-sublink__title:before {
+      border-top-color: #121212;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item--is-commentable:not(.fc-item--type-comment) .fc-item__meta {
+      min-width: calc(4ch + 1rem);
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item .fc-item__media-meta .inline-icon {
+      background-color: #121212;
+      width: 1.5rem;
+      height: 1.4375rem;
+      display: inline-block;
+      border-radius: 50%;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item .fc-item__media-meta .inline-icon path,
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item .fc-item__media-meta .inline-icon svg {
+      fill: #ebe6e1;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item .vjs-big-play-button .vjs-control-text {
+      background-color: #2b2b2b;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item .youtube-media-atom__play-button .inline-play svg {
+      fill: #2b2b2a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item--pillar-news .fc-item__media-meta,
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item__media-meta {
+      color: #2b2b2a;
+    }
+
+    .dcr-1a2uz3 .fc-item--is-dynamic-card .fc-sublink {
+      z-index: 1;
+    }
+
+    .dcr-1a2uz3 .fc-item--is-dynamic-card .fc-sublink__link,
+    .dcr-1a2uz3 .fc-item--is-dynamic-card.fc-item--type-live .fc-sublink__link {
+      color: #000;
+    }
+
+    .dcr-1a2uz3 .fc-item--is-dynamic-card.fc-item--type-live .u-faux-block-link--hover {
+      background-color: #f2f2f2;
+    }
+
+    .dcr-1a2uz3 .fc-item--is-dynamic-card.fc-item--has-floating-sublinks .fc-sublink__link,
+    .dcr-1a2uz3 .fc-item--is-dynamic-card.fc-item--has-floating-sublinks.fc-item--type-live .fc-sublink__link {
+      color: #fff;
+    }
+
+    .dcr-1a2uz3 .fc-item--is-dynamic-card .fc-item__liveblog-block__time {
+      color: #000;
+    }
+
+    .dcr-1a2uz3 .fc-item--is-dynamic-card .fc-item__liveblog-block__text {
+      border-bottom-color: #fff;
+      color: #000;
+    }
+
+    .dcr-1a2uz3 .fc-item--is-dynamic-card .u-faux-block-link--hover .fc-item__liveblog-block__text {
+      border-bottom-color: #f2f2f2;
+    }
+
+    .dcr-1a2uz3 .fc-item--is-dynamic-card .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #fff;
+      color: #000;
+    }
+
+    .dcr-1a2uz3 .fc-item--is-dynamic-card .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #f2f2f2;
+    }
+
+    .dcr-1a2uz3 .fc-item--is-dynamic-card.fc-item--live-updates .fc-item__liveblog-block:first-of-type:not(:only-child):before {
+      border-left-color: #000;
+    }
+
+    .dcr-1a2uz3 .fc-item--is-dynamic-card.fc-item--live-updates .fc-item__liveblog-block__time:before {
+      border-color: #000;
+    }
+
+    .dcr-1a2uz3 .fc-item--is-dynamic-card.fc-item--live-updates .fc-item__liveblog-block__text:after {
+      background-color: #fff;
+    }
+
+    .dcr-1a2uz3 .fc-item--is-dynamic-card.fc-item--live-updates .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      background-color: #f2f2f2;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-palette.fc-container--story-package .fc-container__body:before {
+      background-color: #d6d8dc;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-palette.fc-container--story-package .fc-container__inner {
+      border-top: 1px solid #d6d8dc;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-palette.fc-container--story-package .fc-item--live-updates .fc-item__liveblog-block__text:after {
+      background-color: #052962;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-palette.fc-container--story-package .fc-item--live-updates .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      background-color: #041f4a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette.fc-container--story-package .fc-container__body:before {
+      background-color: #e5e5e5;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette.fc-container--story-package .fc-container__inner {
+      border-top: 1px solid #e5e5e5;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette.fc-container--story-package .fc-item--live-updates .fc-item__liveblog-block:first-of-type:not(:only-child):before {
+      border-left-color: #121212;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette.fc-container--story-package .fc-item--live-updates .fc-item__liveblog-block__time:before {
+      border-color: #121212;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette.fc-container--story-package .fc-item--live-updates .fc-item__liveblog-block__text:after {
+      background-color: #dcdcdc;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette.fc-container--story-package .fc-item--live-updates .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      background-color: #cfcfcf;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-palette.fc-container--story-package .fc-container__body:before {
+      background-color: #4d4f52;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-palette.fc-container--story-package .fc-container__inner {
+      border-top: 1px solid #4d4f52;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-palette.fc-container--story-package .fc-item--live-updates .fc-item__liveblog-block__text:after {
+      background-color: #3f464a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette.fc-container--story-package .fc-container__body:before,
+    .dcr-1a2uz3 section.fc-container--sombre-palette.fc-container--story-package .fc-item--live-updates .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      background-color: #33393c;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette.fc-container--story-package .fc-container__inner {
+      border-top: 1px solid #33393c;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette.fc-container--story-package .fc-item--live-updates .fc-item__liveblog-block__text:after {
+      background-color: #222527;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette.fc-container--story-package .fc-item--live-updates .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      background-color: #161819;
+    }
+
+    .dcr-1a2uz3 section.fc-container--investigation-palette.fc-container--story-package .fc-container__body:before {
+      background-color: #4d4f52;
+    }
+
+    .dcr-1a2uz3 section.fc-container--investigation-palette.fc-container--story-package .fc-container__inner {
+      border-top: 1px solid #4d4f52;
+    }
+
+    .dcr-1a2uz3 section.fc-container--investigation-palette.fc-container--story-package .fc-item--live-updates .fc-item__liveblog-block__text:after {
+      background-color: #3f464a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--investigation-palette.fc-container--story-package .fc-item--live-updates .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      background-color: #33393c;
+    }
+
+    .dcr-1a2uz3 section.fc-container--breaking-palette.fc-container--story-package .fc-container__body:before {
+      background-color: #f2f2f2;
+    }
+
+    .dcr-1a2uz3 section.fc-container--breaking-palette.fc-container--story-package .fc-container__inner {
+      border-top: 1px solid #f2f2f2;
+    }
+
+    .dcr-1a2uz3 section.fc-container--breaking-palette.fc-container--story-package .fc-item--live-updates .fc-item__liveblog-block__text:after {
+      background-color: #8b0000;
+    }
+
+    .dcr-1a2uz3 section.fc-container--breaking-palette.fc-container--story-package .fc-item--live-updates .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      background-color: #720000;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette.fc-container--story-package .fc-container__body:before {
+      background-color: #dceef8;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette.fc-container--story-package .fc-container__inner {
+      border-top: 1px solid #dceef8;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette.fc-container--story-package .fc-item--live-updates .fc-item__liveblog-block:first-of-type:not(:only-child):before {
+      border-left-color: #041f4a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette.fc-container--story-package .fc-item--live-updates .fc-item__liveblog-block__time:before {
+      border-color: #041f4a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette.fc-container--story-package .fc-item--live-updates .fc-item__liveblog-block__text:after {
+      background-color: #ededed;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette.fc-container--story-package .fc-item--live-updates .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      background-color: #e0e0e0;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette.fc-container--story-package .fc-container__body:before {
+      background-color: #f6ebdb;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette.fc-container--story-package .fc-container__inner {
+      border-top: 1px solid #f6ebdb;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette.fc-container--story-package .fc-item--live-updates .fc-item__liveblog-block:first-of-type:not(:only-child):before {
+      border-left-color: #041f4a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette.fc-container--story-package .fc-item--live-updates .fc-item__liveblog-block__time:before {
+      border-color: #041f4a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette.fc-container--story-package .fc-item--live-updates .fc-item__liveblog-block__text:after {
+      background-color: #efe8dd;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette.fc-container--story-package .fc-item--live-updates .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      background-color: #e7dccc;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette.fc-container--story-package .fc-container__body:before {
+      background-color: rgba(118, 118, 118, .3);
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette.fc-container--story-package .fc-container__inner,
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette.fc-container--story-package .fc-container__inner .fc-slice__item+.fc-slice__item:before {
+      border-top: 1px solid rgba(118, 118, 118, .3);
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette.fc-container--story-package .fc-item--live-updates .fc-item__liveblog-block:first-of-type:not(:only-child):before {
+      border-left-color: #2b2b2a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette.fc-container--story-package .fc-item--live-updates .fc-item__liveblog-block__time:before {
+      border-color: #2b2b2a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette.fc-container--story-package .fc-item--live-updates .fc-item__liveblog-block__text:after {
+      background-color: #ebe6e1;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette.fc-container--story-package .fc-item--live-updates .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      background-color: #e1d9d2;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card,
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment.fc-item--is-dynamic-card,
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment.fc-item--type-comment.fc-item--is-dynamic-card {
+      background-color: #e4e5e8;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card .fc-item__headline,
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card .fc-item__standfirst,
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card.fc-item--live .fc-item__headline {
+      color: #052962;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card .fc-item__kicker,
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card .fc-sublink__kicker,
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card.fc-item--live .fc-item__kicker {
+      color: #c70000;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover,
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card.fc-item--type-comment:not(.fc-item--pillar-special-report) .fc-item__container.u-faux-block-link--hover,
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .u-faux-block-link--hover .fc-sublink {
+      background-color: #d6d8dc;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card .fc-item__title {
+      color: #052962;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card .fc-item__content--above:before,
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card .fc-item__content:before {
+      background-color: #c70000;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card .fc-item__title--quoted .inline-garnett-quote,
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card .fc-item__title--quoted .inline-quote {
+      fill: #c70000;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card .live-pulse-icon::before,
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card.fc-item--live .live-pulse-icon::before {
+      background-color: #c70000;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .fc-item__link:visited,
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .fc-sublink .fc-sublink__link,
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .fc-sublink .fc-sublink__link:visited {
+      color: #052962;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card .fc-item__timestamp,
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count.fc-trail__count--commentcount,
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card[class*=fc-item--pillar-].fc-item--type-comment .fc-trail__count.fc-trail__count--commentcount {
+      background-color: #e4e5e8;
+      color: #052962;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count--commentcount .inline-icon,
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count--commentcount .inline-icon svg {
+      fill: #052962;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count.fc-trail__count--commentcount:hover {
+      background-color: #e4e5e8;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-trail__count--commentcount,
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-trail__count.fc-trail__count--commentcount {
+      background-color: #d6d8dc;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card .fc-item__liveblog-block__time,
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card .fc-item__media-meta,
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card.fc-item--pillar-news .fc-item__media-meta {
+      color: #052962;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card .fc-item__liveblog-block__text {
+      border-bottom-color: #e4e5e8;
+      color: #052962;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-item__liveblog-block__text {
+      border-bottom-color: #d6d8dc;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #e4e5e8;
+      color: #052962;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #d6d8dc;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .fc-item__liveblog-block:first-of-type:not(:only-child):before {
+      border-left-color: #052962;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .fc-item__liveblog-block__time:before {
+      border-color: #052962;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .fc-item__liveblog-block__text:after {
+      background-color: #e4e5e8;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      background-color: #d6d8dc;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-palette.fc-container--has-palette .fc-item--is-dynamic-card .fc-item__byline {
+      color: #c70000;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card[class*=fc-item--has-sublinks] .fc-sublink {
+      background-color: #052962;
+    }
+
+    @media (min-width:740px) {
+      .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card[class*=fc-item--has-sublinks] .fc-sublink {
+        background-color: rgba(5, 41, 98, .9);
+      }
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink__link,
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card.fc-item--type-live .fc-sublink__link {
+      color: #fff;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink__kicker {
+      color: #ff9081;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink .fc-sublink__title:before {
+      border-top-color: #ff9081;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card,
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment.fc-item--is-dynamic-card,
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment.fc-item--type-comment.fc-item--is-dynamic-card {
+      background-color: #f2f2f2;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__headline,
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__standfirst,
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--live .fc-item__headline {
+      color: #121212;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__kicker,
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card .fc-sublink__kicker,
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--live .fc-item__kicker {
+      color: #8b0000;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover,
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--type-comment:not(.fc-item--pillar-special-report) .fc-item__container.u-faux-block-link--hover,
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .u-faux-block-link--hover .fc-sublink {
+      background-color: #e5e5e5;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__title {
+      color: #dcdcdc;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__content--above:before,
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__content:before {
+      background-color: #8b0000;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__title--quoted .inline-garnett-quote,
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__title--quoted .inline-quote {
+      fill: #8b0000;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card .live-pulse-icon::before,
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--live .live-pulse-icon::before {
+      background-color: #8b0000;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .fc-item__link:visited,
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .fc-sublink .fc-sublink__link,
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .fc-sublink .fc-sublink__link:visited {
+      color: #121212;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__timestamp,
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count.fc-trail__count--commentcount,
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card[class*=fc-item--pillar-].fc-item--type-comment .fc-trail__count.fc-trail__count--commentcount {
+      background-color: #f2f2f2;
+      color: #121212;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count--commentcount .inline-icon,
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count--commentcount .inline-icon svg {
+      fill: #121212;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count.fc-trail__count--commentcount:hover {
+      background-color: #f2f2f2;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-trail__count--commentcount,
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-trail__count.fc-trail__count--commentcount {
+      background-color: #e5e5e5;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__media-meta,
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--pillar-news .fc-item__media-meta {
+      color: #dcdcdc;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__liveblog-block__time {
+      color: #121212;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__liveblog-block__text {
+      border-bottom-color: #f2f2f2;
+      color: #121212;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-item__liveblog-block__text {
+      border-bottom-color: #e5e5e5;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #f2f2f2;
+      color: #121212;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #e5e5e5;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .fc-item__liveblog-block:first-of-type:not(:only-child):before {
+      border-left-color: #121212;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .fc-item__liveblog-block__time:before {
+      border-color: #121212;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .fc-item__liveblog-block__text:after {
+      background-color: #f2f2f2;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      background-color: #e5e5e5;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette.fc-container--has-palette .fc-item--is-dynamic-card .fc-item__byline {
+      color: #8b0000;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card[class*=fc-item--has-sublinks] .fc-sublink {
+      background-color: #dcdcdc;
+    }
+
+    @media (min-width:740px) {
+      .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card[class*=fc-item--has-sublinks] .fc-sublink {
+        background-color: rgba(220, 220, 220, .9);
+      }
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink__link,
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card.fc-item--type-live .fc-sublink__link {
+      color: #fff;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink .fc-sublink__link,
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink .fc-sublink__title,
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card.fc-item--type-live .fc-sublink .fc-sublink__link,
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card.fc-item--type-live .fc-sublink .fc-sublink__title {
+      color: #121212;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink__kicker {
+      color: #8b0000;
+    }
+
+    .dcr-1a2uz3 section.fc-container--long-running-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink .fc-sublink__title:before {
+      border-top-color: #8b0000;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card,
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment.fc-item--is-dynamic-card,
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment.fc-item--type-comment.fc-item--is-dynamic-card {
+      background-color: #595c5f;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card .fc-item__headline,
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card .fc-item__standfirst,
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card.fc-item--live .fc-item__headline {
+      color: #fff;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card .fc-item__kicker,
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card .fc-sublink__kicker,
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card.fc-item--live .fc-item__kicker {
+      color: #c1d8fc;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover,
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card.fc-item--type-comment:not(.fc-item--pillar-special-report) .fc-item__container.u-faux-block-link--hover,
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .u-faux-block-link--hover .fc-sublink {
+      background-color: #4d4f52;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card .fc-item__title {
+      color: #3f464a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card .fc-item__content--above:before,
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card .fc-item__content:before {
+      background-color: #c1d8fc;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card .fc-item__title--quoted .inline-garnett-quote,
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card .fc-item__title--quoted .inline-quote {
+      fill: #c1d8fc;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card .live-pulse-icon::before,
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card.fc-item--live .live-pulse-icon::before {
+      background-color: #c1d8fc;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .fc-item__link:visited,
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .fc-sublink .fc-sublink__link,
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .fc-sublink .fc-sublink__link:visited {
+      color: #fff;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card .fc-item__timestamp,
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count.fc-trail__count--commentcount,
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card[class*=fc-item--pillar-].fc-item--type-comment .fc-trail__count.fc-trail__count--commentcount {
+      background-color: #595c5f;
+      color: #fff;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count--commentcount .inline-icon,
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count--commentcount .inline-icon svg {
+      fill: #fff;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count.fc-trail__count--commentcount:hover {
+      background-color: #595c5f;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-trail__count--commentcount,
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-trail__count.fc-trail__count--commentcount {
+      background-color: #4d4f52;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card .fc-item__media-meta,
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card.fc-item--pillar-news .fc-item__media-meta {
+      color: #3f464a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card .fc-item__liveblog-block__time {
+      color: #fff;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card .fc-item__liveblog-block__text {
+      border-bottom-color: #595c5f;
+      color: #fff;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-item__liveblog-block__text {
+      border-bottom-color: #4d4f52;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #595c5f;
+      color: #fff;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #4d4f52;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .fc-item__liveblog-block:first-of-type:not(:only-child):before {
+      border-left-color: #fff;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .fc-item__liveblog-block__time:before {
+      border-color: #fff;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .fc-item__liveblog-block__text:after {
+      background-color: #595c5f;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      background-color: #4d4f52;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-palette.fc-container--has-palette .fc-item--is-dynamic-card .fc-item__byline {
+      color: #c1d8fc;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card[class*=fc-item--has-sublinks] .fc-sublink {
+      background-color: #3f464a;
+    }
+
+    @media (min-width:740px) {
+      .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card[class*=fc-item--has-sublinks] .fc-sublink {
+        background-color: rgba(63, 70, 74, .9);
+      }
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink__link,
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card.fc-item--type-live .fc-sublink__link {
+      color: #fff;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink__kicker {
+      color: #c1d8fc;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink .fc-sublink__title:before {
+      border-top-color: #c1d8fc;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card,
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment.fc-item--is-dynamic-card,
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment.fc-item--type-comment.fc-item--is-dynamic-card {
+      background-color: #3f464a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__headline,
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__standfirst,
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--live .fc-item__headline {
+      color: #fff;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__kicker,
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card .fc-sublink__kicker,
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--live .fc-item__kicker {
+      color: #ff5943;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover,
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--type-comment:not(.fc-item--pillar-special-report) .fc-item__container.u-faux-block-link--hover,
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .u-faux-block-link--hover .fc-sublink {
+      background-color: #33393c;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__title {
+      color: #222527;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__content--above:before,
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__content:before {
+      background-color: #ff5943;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__title--quoted .inline-garnett-quote,
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__title--quoted .inline-quote {
+      fill: #ff5943;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card .live-pulse-icon::before,
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--live .live-pulse-icon::before {
+      background-color: #ff5943;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .fc-item__link:visited,
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .fc-sublink .fc-sublink__link,
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .fc-sublink .fc-sublink__link:visited {
+      color: #fff;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__timestamp,
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count.fc-trail__count--commentcount,
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card[class*=fc-item--pillar-].fc-item--type-comment .fc-trail__count.fc-trail__count--commentcount {
+      background-color: #3f464a;
+      color: #fff;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count--commentcount .inline-icon,
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count--commentcount .inline-icon svg {
+      fill: #fff;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count.fc-trail__count--commentcount:hover {
+      background-color: #3f464a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-trail__count--commentcount,
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-trail__count.fc-trail__count--commentcount {
+      background-color: #33393c;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__media-meta,
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--pillar-news .fc-item__media-meta {
+      color: #222527;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__liveblog-block__time {
+      color: #fff;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__liveblog-block__text {
+      border-bottom-color: #3f464a;
+      color: #fff;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-item__liveblog-block__text {
+      border-bottom-color: #33393c;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #3f464a;
+      color: #fff;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #33393c;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .fc-item__liveblog-block:first-of-type:not(:only-child):before {
+      border-left-color: #fff;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .fc-item__liveblog-block__time:before {
+      border-color: #fff;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .fc-item__liveblog-block__text:after {
+      background-color: #3f464a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      background-color: #33393c;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette.fc-container--has-palette .fc-item--is-dynamic-card .fc-item__byline {
+      color: #ff5943;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card[class*=fc-item--has-sublinks] .fc-sublink {
+      background-color: #222527;
+    }
+
+    @media (min-width:740px) {
+      .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card[class*=fc-item--has-sublinks] .fc-sublink {
+        background-color: rgba(34, 37, 39, .9);
+      }
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink__link,
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card.fc-item--type-live .fc-sublink__link {
+      color: #fff;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink__kicker {
+      color: #ff5943;
+    }
+
+    .dcr-1a2uz3 section.fc-container--sombre-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink .fc-sublink__title:before {
+      border-top-color: #ff5943;
+    }
+
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card,
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment.fc-item--is-dynamic-card,
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment.fc-item--type-comment.fc-item--is-dynamic-card {
+      background-color: #595c5f;
+    }
+
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card .fc-item__headline,
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card .fc-item__standfirst,
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card.fc-item--live .fc-item__headline {
+      color: #fff;
+    }
+
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card .fc-item__kicker,
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card .fc-sublink__kicker,
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card.fc-item--live .fc-item__kicker {
+      color: #ffe500;
+    }
+
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover,
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card.fc-item--type-comment:not(.fc-item--pillar-special-report) .fc-item__container.u-faux-block-link--hover,
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .u-faux-block-link--hover .fc-sublink {
+      background-color: #4d4f52;
+    }
+
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card .fc-item__title {
+      color: #3f464a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card .fc-item__content--above:before,
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card .fc-item__content:before {
+      background-color: #ffe500;
+    }
+
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card .fc-item__title--quoted .inline-garnett-quote,
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card .fc-item__title--quoted .inline-quote {
+      fill: #ffe500;
+    }
+
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card .live-pulse-icon::before,
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card.fc-item--live .live-pulse-icon::before {
+      background-color: #ffe500;
+    }
+
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .fc-item__link:visited,
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .fc-sublink .fc-sublink__link,
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .fc-sublink .fc-sublink__link:visited {
+      color: #fff;
+    }
+
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card .fc-item__timestamp,
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count.fc-trail__count--commentcount,
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card[class*=fc-item--pillar-].fc-item--type-comment .fc-trail__count.fc-trail__count--commentcount {
+      background-color: #595c5f;
+      color: #fff;
+    }
+
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count--commentcount .inline-icon,
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count--commentcount .inline-icon svg {
+      fill: #fff;
+    }
+
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count.fc-trail__count--commentcount:hover {
+      background-color: #595c5f;
+    }
+
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-trail__count--commentcount,
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-trail__count.fc-trail__count--commentcount {
+      background-color: #4d4f52;
+    }
+
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card .fc-item__media-meta,
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card.fc-item--pillar-news .fc-item__media-meta {
+      color: #3f464a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card .fc-item__liveblog-block__time {
+      color: #fff;
+    }
+
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card .fc-item__liveblog-block__text {
+      border-bottom-color: #595c5f;
+      color: #fff;
+    }
+
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-item__liveblog-block__text {
+      border-bottom-color: #4d4f52;
+    }
+
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #595c5f;
+      color: #fff;
+    }
+
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #4d4f52;
+    }
+
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .fc-item__liveblog-block:first-of-type:not(:only-child):before {
+      border-left-color: #fff;
+    }
+
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .fc-item__liveblog-block__time:before {
+      border-color: #fff;
+    }
+
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .fc-item__liveblog-block__text:after {
+      background-color: #595c5f;
+    }
+
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      background-color: #4d4f52;
+    }
+
+    .dcr-1a2uz3 section.fc-container--investigation-palette.fc-container--has-palette .fc-item--is-dynamic-card .fc-item__byline {
+      color: #ffe500;
+    }
+
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card[class*=fc-item--has-sublinks] .fc-sublink {
+      background-color: #3f464a;
+    }
+
+    @media (min-width:740px) {
+      .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card[class*=fc-item--has-sublinks] .fc-sublink {
+        background-color: rgba(63, 70, 74, .9);
+      }
+    }
+
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink__link,
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card.fc-item--type-live .fc-sublink__link {
+      color: #fff;
+    }
+
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink__kicker {
+      color: #ffe500;
+    }
+
+    .dcr-1a2uz3 section.fc-container--investigation-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink .fc-sublink__title:before {
+      border-top-color: #ffe500;
+    }
+
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card,
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment.fc-item--is-dynamic-card,
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment.fc-item--type-comment.fc-item--is-dynamic-card {
+      background-color: #fff;
+    }
+
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card .fc-item__headline,
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card .fc-item__standfirst,
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card.fc-item--live .fc-item__headline {
+      color: #121212;
+    }
+
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card .fc-item__kicker,
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card .fc-sublink__kicker,
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card.fc-item--live .fc-item__kicker {
+      color: #8b0000;
+    }
+
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover,
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card.fc-item--type-comment:not(.fc-item--pillar-special-report) .fc-item__container.u-faux-block-link--hover,
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .u-faux-block-link--hover .fc-sublink {
+      background-color: #f2f2f2;
+    }
+
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card .fc-item__title {
+      color: #8b0000;
+    }
+
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card .fc-item__content--above:before,
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card .fc-item__content:before {
+      background-color: #8b0000;
+    }
+
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card .fc-item__title--quoted .inline-garnett-quote,
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card .fc-item__title--quoted .inline-quote {
+      fill: #8b0000;
+    }
+
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card .live-pulse-icon::before,
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card.fc-item--live .live-pulse-icon::before {
+      background-color: #8b0000;
+    }
+
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .fc-item__link:visited,
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .fc-sublink .fc-sublink__link,
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .fc-sublink .fc-sublink__link:visited {
+      color: #121212;
+    }
+
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card .fc-item__timestamp,
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count.fc-trail__count--commentcount,
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card[class*=fc-item--pillar-].fc-item--type-comment .fc-trail__count.fc-trail__count--commentcount {
+      background-color: #fff;
+      color: #121212;
+    }
+
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count--commentcount .inline-icon,
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count--commentcount .inline-icon svg {
+      fill: #121212;
+    }
+
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count.fc-trail__count--commentcount:hover {
+      background-color: #fff;
+    }
+
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-trail__count--commentcount,
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-trail__count.fc-trail__count--commentcount {
+      background-color: #f2f2f2;
+    }
+
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card .fc-item__media-meta,
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card.fc-item--pillar-news .fc-item__media-meta {
+      color: #8b0000;
+    }
+
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card .fc-item__liveblog-block__time {
+      color: #121212;
+    }
+
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card .fc-item__liveblog-block__text {
+      border-bottom-color: #fff;
+      color: #121212;
+    }
+
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-item__liveblog-block__text {
+      border-bottom-color: #f2f2f2;
+    }
+
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #fff;
+      color: #121212;
+    }
+
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #f2f2f2;
+    }
+
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .fc-item__liveblog-block:first-of-type:not(:only-child):before {
+      border-left-color: #121212;
+    }
+
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .fc-item__liveblog-block__time:before {
+      border-color: #121212;
+    }
+
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .fc-item__liveblog-block__text:after {
+      background-color: #fff;
+    }
+
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      background-color: #f2f2f2;
+    }
+
+    .dcr-1a2uz3 section.fc-container--breaking-palette.fc-container--has-palette .fc-item--is-dynamic-card .fc-item__byline {
+      color: #8b0000;
+    }
+
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card[class*=fc-item--has-sublinks] .fc-sublink {
+      background-color: #8b0000;
+    }
+
+    @media (min-width:740px) {
+      .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card[class*=fc-item--has-sublinks] .fc-sublink {
+        background-color: rgba(139, 0, 0, .9);
+      }
+    }
+
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink__link,
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card.fc-item--type-live .fc-sublink__link {
+      color: #fff;
+    }
+
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink__kicker {
+      color: #ffbac8;
+    }
+
+    .dcr-1a2uz3 section.fc-container--breaking-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink .fc-sublink__title:before {
+      border-top-color: #ffbac8;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card,
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment.fc-item--is-dynamic-card,
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment.fc-item--type-comment.fc-item--is-dynamic-card {
+      background-color: #f1f8fc;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card .fc-item__headline,
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card .fc-item__standfirst,
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card.fc-item--live .fc-item__headline {
+      color: #041f4a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card .fc-item__kicker,
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card .fc-sublink__kicker,
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card.fc-item--live .fc-item__kicker {
+      color: #c70000;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover,
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card.fc-item--type-comment:not(.fc-item--pillar-special-report) .fc-item__container.u-faux-block-link--hover,
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .u-faux-block-link--hover .fc-sublink {
+      background-color: #dceef8;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card .fc-item__title {
+      color: #ededed;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card .fc-item__content--above:before,
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card .fc-item__content:before {
+      background-color: #c70000;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card .fc-item__title--quoted .inline-garnett-quote,
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card .fc-item__title--quoted .inline-quote {
+      fill: #c70000;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card .live-pulse-icon::before,
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card.fc-item--live .live-pulse-icon::before {
+      background-color: #c70000;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .fc-item__link:visited,
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .fc-sublink .fc-sublink__link,
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .fc-sublink .fc-sublink__link:visited {
+      color: #041f4a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card .fc-item__timestamp,
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count.fc-trail__count--commentcount,
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card[class*=fc-item--pillar-].fc-item--type-comment .fc-trail__count.fc-trail__count--commentcount {
+      background-color: #f1f8fc;
+      color: #041f4a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count--commentcount .inline-icon,
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count--commentcount .inline-icon svg {
+      fill: #041f4a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count.fc-trail__count--commentcount:hover {
+      background-color: #f1f8fc;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-trail__count--commentcount,
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-trail__count.fc-trail__count--commentcount {
+      background-color: #dceef8;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card .fc-item__media-meta,
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card.fc-item--pillar-news .fc-item__media-meta {
+      color: #ededed;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card .fc-item__liveblog-block__time {
+      color: #041f4a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card .fc-item__liveblog-block__text {
+      border-bottom-color: #f1f8fc;
+      color: #041f4a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-item__liveblog-block__text {
+      border-bottom-color: #dceef8;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #f1f8fc;
+      color: #041f4a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #dceef8;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .fc-item__liveblog-block:first-of-type:not(:only-child):before {
+      border-left-color: #041f4a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .fc-item__liveblog-block__time:before {
+      border-color: #041f4a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .fc-item__liveblog-block__text:after {
+      background-color: #f1f8fc;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      background-color: #dceef8;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette.fc-container--has-palette .fc-item--is-dynamic-card .fc-item__byline {
+      color: #c70000;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card[class*=fc-item--has-sublinks] .fc-sublink {
+      background-color: #ededed;
+    }
+
+    @media (min-width:740px) {
+      .dcr-1a2uz3 section.fc-container--event-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card[class*=fc-item--has-sublinks] .fc-sublink {
+        background-color: rgba(237, 237, 237, .9);
+      }
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink__link,
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card.fc-item--type-live .fc-sublink__link {
+      color: #fff;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink .fc-sublink__link,
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink .fc-sublink__title,
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card.fc-item--type-live .fc-sublink .fc-sublink__link,
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card.fc-item--type-live .fc-sublink .fc-sublink__title {
+      color: #041f4a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink__kicker {
+      color: #c70000;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink .fc-sublink__title:before {
+      border-top-color: #c70000;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card,
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment.fc-item--is-dynamic-card,
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment.fc-item--type-comment.fc-item--is-dynamic-card {
+      background-color: #fbf6ef;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__headline,
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__standfirst,
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--live .fc-item__headline {
+      color: #041f4a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__kicker,
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card .fc-sublink__kicker,
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--live .fc-item__kicker {
+      color: #c70000;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover,
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--type-comment:not(.fc-item--pillar-special-report) .fc-item__container.u-faux-block-link--hover,
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .u-faux-block-link--hover .fc-sublink {
+      background-color: #f6ebdb;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__title {
+      color: #efe8dd;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__content--above:before,
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__content:before {
+      background-color: #c70000;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__title--quoted .inline-garnett-quote,
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__title--quoted .inline-quote {
+      fill: #c70000;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card .live-pulse-icon::before,
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--live .live-pulse-icon::before {
+      background-color: #c70000;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .fc-item__link:visited,
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .fc-sublink .fc-sublink__link,
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .fc-sublink .fc-sublink__link:visited {
+      color: #041f4a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__timestamp,
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count.fc-trail__count--commentcount,
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card[class*=fc-item--pillar-].fc-item--type-comment .fc-trail__count.fc-trail__count--commentcount {
+      background-color: #fbf6ef;
+      color: #041f4a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count--commentcount .inline-icon,
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count--commentcount .inline-icon svg {
+      fill: #041f4a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count.fc-trail__count--commentcount:hover {
+      background-color: #fbf6ef;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-trail__count--commentcount,
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-trail__count.fc-trail__count--commentcount {
+      background-color: #f6ebdb;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__media-meta,
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--pillar-news .fc-item__media-meta {
+      color: #ededed;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__liveblog-block__time {
+      color: #041f4a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__liveblog-block__text {
+      border-bottom-color: #fbf6ef;
+      color: #041f4a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-item__liveblog-block__text {
+      border-bottom-color: #f6ebdb;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #fbf6ef;
+      color: #041f4a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #f6ebdb;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .fc-item__liveblog-block:first-of-type:not(:only-child):before {
+      border-left-color: #041f4a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .fc-item__liveblog-block__time:before {
+      border-color: #041f4a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .fc-item__liveblog-block__text:after {
+      background-color: #fbf6ef;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      background-color: #f6ebdb;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette.fc-container--has-palette .fc-item--is-dynamic-card .fc-item__byline {
+      color: #c70000;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card[class*=fc-item--has-sublinks] .fc-sublink {
+      background-color: #efe8dd;
+    }
+
+    @media (min-width:740px) {
+      .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card[class*=fc-item--has-sublinks] .fc-sublink {
+        background-color: rgba(239, 232, 221, .9);
+      }
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink__link,
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card.fc-item--type-live .fc-sublink__link {
+      color: #fff;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink .fc-sublink__link,
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink .fc-sublink__title,
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card.fc-item--type-live .fc-sublink .fc-sublink__link,
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card.fc-item--type-live .fc-sublink .fc-sublink__title {
+      color: #041f4a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink__kicker {
+      color: #c70000;
+    }
+
+    .dcr-1a2uz3 section.fc-container--event-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink .fc-sublink__title:before {
+      border-top-color: #e2352d;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card,
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment.fc-item--is-dynamic-card,
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item[class*=fc-item--pillar-].fc-item--type-comment.fc-item--type-comment.fc-item--is-dynamic-card {
+      background-color: #f5f0eb;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__headline,
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__standfirst,
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--live .fc-item__headline {
+      color: #2b2b2a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__kicker,
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card .fc-sublink__kicker,
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--live .fc-item__kicker {
+      color: #121212;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover,
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--type-comment:not(.fc-item--pillar-special-report) .fc-item__container.u-faux-block-link--hover,
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .u-faux-block-link--hover .fc-sublink {
+      background-color: #ede3da;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__title {
+      color: #ebe6e1;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__content--above:before,
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__content:before {
+      background-color: #121212;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__title--quoted .inline-garnett-quote,
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__title--quoted .inline-quote {
+      fill: #121212;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card .live-pulse-icon::before,
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--live .live-pulse-icon::before {
+      background-color: #121212;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .fc-item__link:visited,
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .fc-sublink .fc-sublink__link,
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card:not(.fc-item--has-floating-sublinks) .fc-sublink .fc-sublink__link:visited {
+      color: #2b2b2a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__timestamp,
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count.fc-trail__count--commentcount,
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card[class*=fc-item--pillar-].fc-item--type-comment .fc-trail__count.fc-trail__count--commentcount {
+      background-color: #f5f0eb;
+      color: #2b2b2a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count--commentcount .inline-icon,
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count--commentcount .inline-icon svg {
+      fill: #2b2b2a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card .fc-trail__count.fc-trail__count--commentcount:hover {
+      background-color: #f5f0eb;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-trail__count--commentcount,
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-trail__count.fc-trail__count--commentcount {
+      background-color: #ede3da;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__media-meta,
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--pillar-news .fc-item__media-meta {
+      color: #f5f0eb;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__liveblog-block__time {
+      color: #2b2b2a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__liveblog-block__text {
+      border-bottom-color: #f5f0eb;
+      color: #2b2b2a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-item__liveblog-block__text {
+      border-bottom-color: #ede3da;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #f5f0eb;
+      color: #2b2b2a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      box-shadow: -.3125rem 0 .3125rem -.125rem #ede3da;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .fc-item__liveblog-block:first-of-type:not(:only-child):before {
+      border-left-color: #2b2b2a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .fc-item__liveblog-block__time:before {
+      border-color: #2b2b2a;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .fc-item__liveblog-block__text:after {
+      background-color: #f5f0eb;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item.fc-item--is-dynamic-card.fc-item--live-updates .u-faux-block-link--hover .fc-item__liveblog-block__text:after {
+      background-color: #ede3da;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette.fc-container--has-palette .fc-item--is-dynamic-card .fc-item__byline {
+      color: #121212;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card[class*=fc-item--has-sublinks] .fc-sublink {
+      background-color: #ebe6e1;
+    }
+
+    @media (min-width:740px) {
+      .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card[class*=fc-item--has-sublinks] .fc-sublink {
+        background-color: rgba(235, 230, 225, .9);
+      }
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink__link,
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card.fc-item--type-live .fc-sublink__link {
+      color: #fff;
+      font-weight: 500;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink .fc-sublink__link,
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink .fc-sublink__title,
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card.fc-item--type-live .fc-sublink .fc-sublink__link,
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card.fc-item--type-live .fc-sublink .fc-sublink__title {
+      color: #2b2b2a;
+      font-weight: 500;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink__kicker {
+      color: #121212;
+    }
+
+    .dcr-1a2uz3 section.fc-container--special-report-alt-palette .fc-item--has-floating-sublinks.fc-item--is-dynamic-card .fc-sublink .fc-sublink__title:before {
+      border-top-color: #121212;
+    }
+
+    .dcr-1a2uz3 .fc-container--investigation-palette button.fc-container__toggle {
+      color: #ededed;
+    }
+
+    .dcr-1a2uz3 .fc-container--investigation-palette .fc-item--type-comment.fc-item--pillar-news.fc-item--type-comment .fc-item__container.u-faux-block-link--hover {
+      background-color: #33393c;
+    }
+
+    .dcr-r91ehr {
+      display: grid;
+      grid-template-rows: [headline-start show-hide-start] auto [show-hide-end headline-end content-toggleable-start content-start] auto [content-end content-toggleable-end show-more-start] auto [show-more-end];
+      grid-template-columns: [decoration-start] 0px [content-start title-start] repeat(3, minmax(0, 1fr)) [hide-start] minmax(0, 1fr) [content-end title-end hide-end] 0px [decoration-end];
+      grid-auto-flow: dense;
+      -webkit-column-gap: 10px;
+      column-gap: 10px;
+    }
+
+    @supports not (display: grid) {
+      .dcr-r91ehr {
+        padding: 0 12px;
+        margin: 0 auto;
+      }
+
+      @media (min-width: 480px) {
+        .dcr-r91ehr {
+          padding: 0 20px;
+        }
+      }
+
+      @media (min-width: 740px) {
+        .dcr-r91ehr {
+          width: 700px;
+        }
+      }
+
+      @media (min-width: 980px) {
+        .dcr-r91ehr {
+          width: 940px;
+        }
+      }
+
+      @media (min-width: 1140px) {
+        .dcr-r91ehr {
+          width: 1100px;
+        }
+      }
+
+      @media (min-width: 1300px) {
+        .dcr-r91ehr {
+          width: 1260px;
+        }
+      }
+    }
+
+    @media (min-width: 480px) {
+      .dcr-r91ehr {
+        -webkit-column-gap: 20px;
+        column-gap: 20px;
+      }
+    }
+
+    @media (min-width: 740px) {
+      .dcr-r91ehr {
+        grid-template-columns: minmax(0, 1fr) [decoration-start content-start title-start] repeat(11, 40px) [hide-start] 40px [decoration-end content-end title-end hide-end] minmax(0, 1fr);
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-r91ehr {
+        grid-template-columns: minmax(0, 1fr) [decoration-start content-start title-start] repeat(11, 60px) [hide-start] 60px [decoration-end content-end title-end hide-end] minmax(0, 1fr);
+      }
+    }
+
+    @media (min-width: 1140px) {
+      .dcr-r91ehr {
+        grid-template-rows: [headline-start show-hide-start content-start] auto [show-hide-end content-toggleable-start] auto [headline-end treats-start] auto [content-end content-toggleable-end treats-end show-more-start] auto [show-more-end];
+        grid-template-columns: minmax(0, 1fr) [decoration-start title-start] repeat(2, 60px) [title-end content-start] repeat(11, 60px) [hide-start] 60px [decoration-end hide-end content-end] minmax(0, 1fr);
+      }
+    }
+
+    @media (min-width: 1300px) {
+      .dcr-r91ehr {
+        grid-template-rows: [headline-start content-start content-toggleable-start show-hide-start] auto [show-hide-end] auto [headline-end treats-start] auto [content-end content-toggleable-end treats-end show-more-start] auto [show-more-end];
+        grid-template-columns: minmax(0, 1fr) [decoration-start title-start] repeat(3, 60px) [title-end content-start] repeat(12, 60px) [content-end hide-start] 60px [decoration-end hide-end] minmax(0, 1fr);
+      }
+    }
+
+    .dcr-b25wgn {
+      grid-row: 1/-1;
+      grid-column: decoration;
+      border-width: 1px;
+      border-color: #DCDCDC;
+      border-style: none;
+      border-top-style: solid;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-b25wgn {
+        margin: 0 -20px;
+        border-left-style: solid;
+        border-right-style: solid;
+      }
+    }
+
+    .dcr-1kx60rc {
+      grid-row: headline;
+      grid-column: title;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+    }
+
+    @media (min-width: 1140px) {
+      .dcr-1kx60rc {
+        position: relative;
+      }
+
+      .dcr-1kx60rc::after {
+        content: '';
+        display: block;
+        width: 1px;
+        top: 0;
+        height: 1.875rem;
+        right: -10px;
+        position: absolute;
+        background-color: #DCDCDC;
+      }
+    }
+
+    @media (max-width: 1139px) {
+      .dcr-1n8hb96 {
+        display: none;
+      }
+    }
+
+    @media (max-width: 1139px) {
+      .dcr-15t9kli {
+        max-width: 74%;
+      }
+    }
+
+    @media (min-width: 1140px) {
+      .dcr-1iz7gbk {
+        display: none;
+      }
+    }
+
+    .dcr-1atljbz {
+      margin-left: 0;
+    }
+
+    .dcr-eubdc {
+      font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+      font-size: 1.5rem;
+      line-height: 1.15;
+      font-weight: 700;
+      --source-text-decoration-thickness: 3px;
+      color: #121212;
+      padding-bottom: 4px;
+      padding-top: 6px;
+      overflow-wrap: break-word;
+    }
+
+    .dcr-owfrse {
+      grid-row: show-hide;
+      grid-column: hide;
+      justify-self: end;
+    }
+
+    .dcr-kfs8io {
+      position: relative;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 1.0625rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      cursor: pointer;
+      -webkit-text-decoration: underline;
+      text-decoration: underline;
+      text-underline-position: under;
+      text-underline-offset: 5%;
+      display: inline;
+      -webkit-align-items: center;
+      -webkit-box-align: center;
+      -ms-flex-align: center;
+      align-items: center;
+      border: none;
+      background: transparent;
+      padding: 0;
+      color: #121212;
+      color: #707070;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.875rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      margin-top: 8px;
+      margin-right: 10px;
+      margin-bottom: 8px;
+      position: relative;
+      -webkit-align-items: bottom;
+      -webkit-box-align: bottom;
+      -ms-flex-align: bottom;
+      align-items: bottom;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+    }
+
+    .dcr-kfs8io:focus {
+      outline: 0;
+    }
+
+    html:not(.src-focus-disabled) .dcr-kfs8io:focus {
+      box-shadow: 0 0 0 5px #0077B6;
+    }
+
+    .dcr-kfs8io:hover {
+      text-decoration-thickness: var(--source-text-decoration-thickness, auto);
+    }
+
+    .dcr-kfs8io:hover {
+      color: #121212;
+    }
+
+    .dcr-1lex7d6 {
+      margin: 0;
+      grid-column: content;
+      grid-row: content-toggleable;
+      padding-top: 8px;
+    }
+
+    .hidden>.dcr-1lex7d6 {
+      display: none;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-1lex7d6 {
+        margin-left: -10px;
+        margin-right: -10px;
+      }
+    }
+
+    .dcr-1mi5u71 {
+      position: relative;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: row;
+      -ms-flex-direction: row;
+      flex-direction: row;
+      row-gap: 12px;
+      margin-bottom: 12px;
+    }
+
+    @media (max-width: 739px) {
+      .dcr-1mi5u71 {
+        -webkit-flex-direction: column;
+        -ms-flex-direction: column;
+        flex-direction: column;
+        width: 100%;
+      }
+    }
+
+    .dcr-w3rkaf {
+      position: relative;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      row-gap: 12px;
+      -webkit-flex-basis: 75%;
+      -ms-flex-preferred-size: 75%;
+      flex-basis: 75%;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-w3rkaf {
+        padding-left: 10px;
+        padding-right: 10px;
+      }
+    }
+
+    .dcr-6vr3s5 {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+      -webkit-box-pack: justify;
+      -webkit-justify-content: space-between;
+      justify-content: space-between;
+      width: 100%;
+      position: relative;
+      color: inherit;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      background-color: #F6F6F6;
+    }
+
+    .dcr-6vr3s5:hover .image-overlay {
+      position: absolute;
+      top: 0;
+      width: 100%;
+      height: 100%;
+      left: 0;
+      background-color: #121212;
+      opacity: 0.1;
+    }
+
+    .dcr-6vr3s5:hover {
+      background-color: #EDEDED;
+    }
+
+    .dcr-6vr3s5:before {
+      background-color: #0077B6;
+      content: '';
+      height: 1px;
+      z-index: 2;
+      width: 100%;
+    }
+
+    .dcr-pkharf {
+      position: absolute;
+      z-index: 1;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
+      background-color: transparent;
+    }
+
+    .dcr-pkharf:focus {
+      outline: 0;
+    }
+
+    html:not(.src-focus-disabled) .dcr-pkharf:focus {
+      box-shadow: 0 0 0 5px #0077B6;
+    }
+
+    .dcr-1eb5jgw {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-basis: 100%;
+      -ms-flex-preferred-size: 100%;
+      flex-basis: 100%;
+      width: 100%;
+      -webkit-flex-direction: row-reverse;
+      -ms-flex-direction: row-reverse;
+      flex-direction: row-reverse;
+    }
+
+    @media (max-width: 739px) {
+      .dcr-1eb5jgw {
+        -webkit-flex-direction: column;
+        -ms-flex-direction: column;
+        flex-direction: column;
+      }
+    }
+
+    .dcr-1pe3pea {
+      -webkit-flex-basis: 66%;
+      -ms-flex-preferred-size: 66%;
+      flex-basis: 66%;
+      position: relative;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-1pe3pea {
+        -webkit-align-self: flex-start;
+        -ms-flex-item-align: flex-start;
+        align-self: flex-start;
+      }
+    }
+
+    .dcr-1pe3pea img {
+      width: 100%;
+      display: block;
+    }
+
+    .dcr-yosj9c {
+      display: block;
+      padding-top: 60%;
+      position: relative;
+    }
+
+    .dcr-yosj9c>* {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+    }
+
+    .dcr-evn1e9 {
+      display: block;
+    }
+
+    .dcr-rrcudz {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+      -webkit-box-pack: justify;
+      -webkit-justify-content: space-between;
+      justify-content: space-between;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-rrcudz {
+        -webkit-flex-basis: 34%;
+        -ms-flex-preferred-size: 34%;
+        flex-basis: 34%;
+      }
+    }
+
+    .dcr-dbozpd {
+      padding-bottom: 8px;
+      padding-left: 5px;
+      padding-right: 5px;
+      padding-top: 1px;
+      -webkit-box-flex: 1;
+      -webkit-flex-grow: 1;
+      -ms-flex-positive: 1;
+      flex-grow: 1;
+    }
+
+    @media (min-width: 660px) {
+      .dcr-dbozpd {
+        padding-top: 1px;
+      }
+    }
+
+    @media (min-width: 740px) {
+      .dcr-dbozpd {
+        padding-top: 1px;
+      }
+    }
+
+    .dcr-14gfmlq {
+      font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+      font-size: 1.5rem;
+      line-height: 1.15;
+      font-weight: 500;
+      --source-text-decoration-thickness: 3px;
+    }
+
+    @media (max-width: 979px) {
+      .dcr-14gfmlq {
+        font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+        font-size: 1.25rem;
+        line-height: 1.15;
+        font-weight: 500;
+        --source-text-decoration-thickness: 3px;
+      }
+    }
+
+    .dcr-zdnpsd {
+      color: #0077B6;
+      font-weight: 700;
+      margin-right: 4px;
+    }
+
+    .dcr-adlhb4 {
+      color: #121212;
+    }
+
+    .dcr-hcib8t {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+      color: #121212;
+      font-family: GuardianTextEgyptian, Guardian Text Egyptian Web, Georgia, serif;
+      font-size: 0.9375rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      font-size: 14px;
+      padding-left: 5px;
+      padding-right: 5px;
+      padding-bottom: 8px;
+    }
+
+    @media (max-width: 979px) {
+      .dcr-hcib8t {
+        display: none;
+      }
+    }
+
+    .dcr-4xb9x1 {
+      margin-top: 3px;
+      margin-bottom: 3px;
+    }
+
+    .dcr-j8q3ty {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-box-pack: end;
+      -ms-flex-pack: end;
+      -webkit-justify-content: flex-end;
+      justify-content: flex-end;
+    }
+
+    .dcr-gf0nnr {
+      position: relative;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      margin-left: 5px;
+      margin-right: 5px;
+      margin-bottom: 5px;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-gf0nnr {
+        -webkit-flex-direction: row;
+        -ms-flex-direction: row;
+        flex-direction: row;
+      }
+    }
+
+    .dcr-z7lzm0 {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+      -webkit-flex: 1;
+      -ms-flex: 1;
+      flex: 1;
+      padding-top: 2px;
+      position: relative;
+      margin-top: 8px;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-z7lzm0 {
+        margin-bottom: 4px;
+      }
+    }
+
+    .dcr-wi48h0 {
+      font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+      font-size: 1.0625rem;
+      line-height: 1.15;
+      font-weight: 500;
+      --source-text-decoration-thickness: 2px;
+      font-size: 14px;
+      padding-top: 1px;
+    }
+
+    .dcr-wi48h0:before {
+      display: block;
+      position: absolute;
+      top: 0;
+      left: 0;
+      content: '';
+      border-top: 1px solid #DCDCDC;
+      width: 120px;
+    }
+
+    @media (min-width: 740px) and (max-width: 979px) {
+      .dcr-wi48h0:before {
+        width: 100px;
+      }
+    }
+
+    .dcr-os58m2 {
+      position: relative;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 1.0625rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      cursor: pointer;
+      -webkit-text-decoration: underline;
+      text-decoration: underline;
+      text-underline-position: under;
+      text-underline-offset: 5%;
+      display: inline;
+      -webkit-align-items: center;
+      -webkit-box-align: center;
+      -ms-flex-align: center;
+      align-items: center;
+      color: #0077B6;
+      z-index: 2;
+      color: inherit;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      font-family: inherit;
+      font-size: inherit;
+      font-weight: 500;
+      line-height: inherit;
+    }
+
+    .dcr-os58m2:focus {
+      outline: 0;
+    }
+
+    html:not(.src-focus-disabled) .dcr-os58m2:focus {
+      box-shadow: 0 0 0 5px #0077B6;
+    }
+
+    .dcr-os58m2:hover {
+      text-decoration-thickness: var(--source-text-decoration-thickness, auto);
+    }
+
+    .dcr-os58m2:hover {
+      color: #0077B6;
+    }
+
+    .dcr-os58m2:hover {
+      color: inherit;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+    }
+
+    .dcr-os58m2:hover .show-underline {
+      -webkit-text-decoration: underline;
+      text-decoration: underline;
+    }
+
+    .dcr-15f6w0y {
+      color: #0077B6;
+      font-weight: 700;
+      margin-right: 4px;
+      display: inline-block;
+    }
+
+    .dcr-ibz96v {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+      -webkit-flex: 1;
+      -ms-flex: 1;
+      flex: 1;
+      padding-top: 2px;
+      position: relative;
+      margin-top: 8px;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-ibz96v {
+        margin-bottom: 4px;
+      }
+    }
+
+    @media (min-width: 740px) {
+      .dcr-ibz96v {
+        margin-left: 10px;
+      }
+    }
+
+    .dcr-1ttos39 {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+      -webkit-flex: 1;
+      -ms-flex: 1;
+      flex: 1;
+      padding-top: 2px;
+      position: relative;
+      margin-top: 8px;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-1ttos39 {
+        margin-bottom: 4px;
+      }
+    }
+
+    @media (min-width: 740px) {
+      .dcr-1ttos39 {
+        margin-left: 10px;
+      }
+    }
+
+    @media (max-width: 739px) {
+      .dcr-1ttos39 {
+        margin-bottom: 8px;
+      }
+    }
+
+    .dcr-8cyqm2 {
+      font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+      font-size: 1.0625rem;
+      line-height: 1.15;
+      font-weight: 500;
+      --source-text-decoration-thickness: 2px;
+      font-size: 14px;
+      padding-top: 1px;
+    }
+
+    .dcr-8cyqm2:before {
+      display: block;
+      position: absolute;
+      top: 0;
+      left: 0;
+      content: '';
+      border-top: 1px solid #707070;
+      width: 120px;
+    }
+
+    @media (min-width: 740px) and (max-width: 979px) {
+      .dcr-8cyqm2:before {
+        width: 100px;
+      }
+    }
+
+    .dcr-1cgn3lv {
+      position: relative;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      row-gap: 12px;
+      -webkit-flex-basis: 25%;
+      -ms-flex-preferred-size: 25%;
+      flex-basis: 25%;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-1cgn3lv:before {
+        content: '';
+        display: block;
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        left: 0;
+        width: 1px;
+        height: 100%;
+        border-left: 1px solid #DCDCDC;
+      }
+    }
+
+    @media (min-width: 740px) {
+      .dcr-1cgn3lv {
+        padding-left: 10px;
+        padding-right: 10px;
+      }
+    }
+
+    .dcr-17h8ziz {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-basis: 100%;
+      -ms-flex-preferred-size: 100%;
+      flex-basis: 100%;
+      width: 100%;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+    }
+
+    @media (max-width: 739px) {
+      .dcr-17h8ziz {
+        -webkit-flex-direction: row;
+        -ms-flex-direction: row;
+        flex-direction: row;
+      }
+    }
+
+    .dcr-1pb5o7w {
+      position: relative;
+    }
+
+    @media (max-width: 739px) {
+      .dcr-1pb5o7w {
+        width: 125px;
+        -webkit-flex-shrink: 0;
+        -ms-flex-negative: 0;
+        flex-shrink: 0;
+        margin-top: 4px;
+        margin-right: 0;
+        margin-bottom: 4px;
+        margin-left: 4px;
+        -webkit-flex-basis: unset;
+        -ms-flex-preferred-size: unset;
+        flex-basis: unset;
+        -webkit-align-self: flex-start;
+        -ms-flex-item-align: flex-start;
+        align-self: flex-start;
+      }
+    }
+
+    .dcr-1pb5o7w img {
+      width: 100%;
+      display: block;
+    }
+
+    .dcr-1y2cu33 {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+      -webkit-box-pack: justify;
+      -webkit-justify-content: space-between;
+      justify-content: space-between;
+      -webkit-box-flex: 1;
+      -webkit-flex-grow: 1;
+      -ms-flex-positive: 1;
+      flex-grow: 1;
+    }
+
+    .dcr-p1dvl6 {
+      font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+      font-size: 1.25rem;
+      line-height: 1.15;
+      font-weight: 500;
+      --source-text-decoration-thickness: 3px;
+    }
+
+    @media (max-width: 979px) {
+      .dcr-p1dvl6 {
+        font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+        font-size: 1.0625rem;
+        line-height: 1.15;
+        font-weight: 500;
+        --source-text-decoration-thickness: 2px;
+      }
+    }
+
+    .dcr-14ukgk6 {
+      height: 1em;
+      width: 1.5em;
+      margin-right: 3px;
+      vertical-align: baseline;
+      fill: #0077B6;
+    }
+
+    .dcr-wwzlz2 {
+      display: block;
+      font-style: italic;
+      font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+      font-size: 1.25rem;
+      line-height: 1.15;
+      font-weight: 500;
+      --source-text-decoration-thickness: 3px;
+      color: #0077B6;
+    }
+
+    @media (max-width: 979px) {
+      .dcr-wwzlz2 {
+        font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+        font-size: 1.0625rem;
+        line-height: 1.15;
+        font-weight: 500;
+        --source-text-decoration-thickness: 2px;
+      }
+    }
+
+    .dcr-kz9nqe {
+      position: relative;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      margin-left: 5px;
+      margin-right: 5px;
+      margin-bottom: 5px;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+    }
+
+    .dcr-1hipxkh {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+      -webkit-flex: 1;
+      -ms-flex: 1;
+      flex: 1;
+      padding-top: 2px;
+      position: relative;
+      margin-top: 8px;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-1hipxkh {
+        margin-bottom: 4px;
+      }
+    }
+
+    @media (max-width: 739px) {
+      .dcr-1hipxkh {
+        margin-bottom: 8px;
+      }
+    }
+
+    .dcr-ect2dm {
+      color: #C70000;
+      font-weight: 700;
+      margin-right: 4px;
+      display: inline-block;
+    }
+
+    .dcr-y4cf8a {
+      position: relative;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: row;
+      -ms-flex-direction: row;
+      flex-direction: row;
+      row-gap: 12px;
+    }
+
+    @media (max-width: 739px) {
+      .dcr-y4cf8a {
+        -webkit-flex-direction: column;
+        -ms-flex-direction: column;
+        flex-direction: column;
+        width: 100%;
+      }
+    }
+
+    @media (min-width: 740px) {
+      .dcr-y4cf8a {
+        -webkit-box-flex-wrap: wrap;
+        -webkit-flex-wrap: wrap;
+        -ms-flex-wrap: wrap;
+        flex-wrap: wrap;
+      }
+    }
+
+    .dcr-elbm7f {
+      position: relative;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      row-gap: 12px;
+      -webkit-flex-basis: 25%;
+      -ms-flex-preferred-size: 25%;
+      flex-basis: 25%;
+    }
+
+      {
+      padding-left: 10px;
+      padding-right: 10px;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-elbm7f {
+        padding-left: 10px;
+        padding-right: 10px;
+      }
+    }
+
+    .dcr-1e9i83y {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+      -webkit-box-pack: justify;
+      -webkit-justify-content: space-between;
+      justify-content: space-between;
+      width: 100%;
+      position: relative;
+      color: inherit;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      background-color: #FEF9F5;
+    }
+
+    .dcr-1e9i83y:hover .image-overlay {
+      position: absolute;
+      top: 0;
+      width: 100%;
+      height: 100%;
+      left: 0;
+      background-color: #121212;
+      opacity: 0.1;
+    }
+
+    .dcr-1e9i83y:hover {
+      background-color: #fdf0e8;
+    }
+
+    .dcr-1e9i83y:before {
+      background-color: #0077B6;
+      content: '';
+      height: 1px;
+      z-index: 2;
+      width: 100%;
+    }
+
+    .dcr-17yg843 {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-box-pack: justify;
+      -webkit-justify-content: space-between;
+      justify-content: space-between;
+      -webkit-align-items: center;
+      -webkit-box-align: center;
+      -ms-flex-align: center;
+      align-items: center;
+    }
+
+    .dcr-tttgpl {
+      -webkit-flex: 1;
+      -ms-flex: 1;
+      flex: 1;
+      -webkit-align-self: flex-end;
+      -ms-flex-item-align: flex-end;
+      align-self: flex-end;
+    }
+
+    .dcr-16fqzm2 {
+      position: relative;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      row-gap: 12px;
+      -webkit-flex-basis: 50%;
+      -ms-flex-preferred-size: 50%;
+      flex-basis: 50%;
+    }
+
+    .dcr-1lcaowc {
+      position: relative;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: row;
+      -ms-flex-direction: row;
+      flex-direction: row;
+      row-gap: 12px;
+    }
+
+    @media (max-width: 739px) {
+      .dcr-1lcaowc {
+        -webkit-flex-direction: column;
+        -ms-flex-direction: column;
+        flex-direction: column;
+        width: 100%;
+      }
+    }
+
+    @media (min-width: 740px) {
+      .dcr-1lcaowc:before {
+        content: '';
+        display: block;
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        left: 0;
+        width: 1px;
+        height: 100%;
+        border-left: 1px solid #DCDCDC;
+      }
+    }
+
+    @media (min-width: 740px) {
+      .dcr-1lcaowc {
+        -webkit-box-flex-wrap: wrap;
+        -webkit-flex-wrap: wrap;
+        -ms-flex-wrap: wrap;
+        flex-wrap: wrap;
+      }
+    }
+
+    .dcr-avaain {
+      position: relative;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      row-gap: 12px;
+      -webkit-flex-basis: 50%;
+      -ms-flex-preferred-size: 50%;
+      flex-basis: 50%;
+      -webkit-box-flex: 1;
+      -webkit-flex-grow: 1;
+      -ms-flex-positive: 1;
+      flex-grow: 1;
+    }
+
+      {
+      padding-left: 10px;
+      padding-right: 10px;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-avaain {
+        padding-left: 10px;
+        padding-right: 10px;
+      }
+    }
+
+    .dcr-12hccii {
+      font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+      font-size: 1.0625rem;
+      line-height: 1.15;
+      font-weight: 500;
+      --source-text-decoration-thickness: 2px;
+    }
+
+    .dcr-y8nd8l {
+      position: relative;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      row-gap: 12px;
+      -webkit-flex-basis: 50%;
+      -ms-flex-preferred-size: 50%;
+      flex-basis: 50%;
+      -webkit-box-flex: 1;
+      -webkit-flex-grow: 1;
+      -ms-flex-positive: 1;
+      flex-grow: 1;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-y8nd8l:before {
+        content: '';
+        display: block;
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        left: 0;
+        width: 1px;
+        height: 100%;
+        height: calc(100% + 12px);
+        border-left: 1px solid #DCDCDC;
+      }
+    }
+
+      {
+      padding-left: 10px;
+      padding-right: 10px;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-y8nd8l {
+        padding-left: 10px;
+        padding-right: 10px;
+      }
+    }
+
+    .dcr-9e78hl {
+      position: relative;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      row-gap: 12px;
+      -webkit-flex-basis: 50%;
+      -ms-flex-preferred-size: 50%;
+      flex-basis: 50%;
+      -webkit-box-flex: 1;
+      -webkit-flex-grow: 1;
+      -ms-flex-positive: 1;
+      flex-grow: 1;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-9e78hl:before {
+        content: '';
+        display: block;
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        left: 0;
+        width: 1px;
+        height: 100%;
+        border-left: 1px solid #DCDCDC;
+      }
+    }
+
+    @media (min-width: 740px) {
+      .dcr-9e78hl {
+        padding-left: 10px;
+        padding-right: 10px;
+      }
+    }
+
+    .dcr-glvxc9 {
+      grid-row: show-more;
+      grid-column: content;
+      padding-bottom: 36px;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-glvxc9 {
+        margin-left: -10px;
+        margin-right: -10px;
+      }
+    }
+
+    .dcr-rdw702 {
+      display: none;
+      padding-top: 8px;
+    }
+
+    @media (min-width: 1140px) {
+      .dcr-rdw702 {
+        display: block;
+        -webkit-align-self: end;
+        -ms-flex-item-align: end;
+        align-self: end;
+        grid-row: treats;
+        grid-column: title;
+      }
+    }
+
+    .hidden>.dcr-rdw702 {
+      display: none;
+    }
+
+    .dcr-1mbvac {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+    }
+
+    .dcr-109rq7o {
+      margin-top: 12px;
+      border-left: 1px solid #DCDCDC;
+      border-top: 1px solid #DCDCDC;
+      padding-top: 4px;
+      padding-left: 8px;
+    }
+
+    .dcr-3tlap1 {
+      position: relative;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 1.0625rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      cursor: pointer;
+      -webkit-text-decoration: underline;
+      text-decoration: underline;
+      text-underline-position: under;
+      text-underline-offset: 5%;
+      display: inline;
+      -webkit-align-items: center;
+      -webkit-box-align: center;
+      -ms-flex-align: center;
+      align-items: center;
+      color: #121212;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+    }
+
+    .dcr-3tlap1:focus {
+      outline: 0;
+    }
+
+    html:not(.src-focus-disabled) .dcr-3tlap1:focus {
+      box-shadow: 0 0 0 5px #0077B6;
+    }
+
+    .dcr-3tlap1:hover {
+      text-decoration-thickness: var(--source-text-decoration-thickness, auto);
+    }
+
+    .dcr-3tlap1:hover {
+      color: #121212;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-12r3co1 {
+        display: none;
+      }
+    }
+
+    .dcr-1uz1ca8 .ad-slot__scroll {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      max-height: 24px;
+      background-color: #F6F6F6;
+      padding: 0 8px;
+      border-top: 1px solid #DCDCDC;
+      color: #707070;
+      text-align: left;
+      box-sizing: border-box;
+      position: relative;
+    }
+
+    .dcr-1uz1ca8 .ad-slot__scroll.visible {
+      visibility: initial;
+    }
+
+    .dcr-1uz1ca8 .ad-slot__scroll.hidden {
+      visibility: hidden;
+    }
+
+    .dcr-1uz1ca8 .ad-slot__close-button {
+      display: none;
+    }
+
+    .dcr-1uz1ca8 .ad-slot__scroll {
+      position: fixed;
+      bottom: 0;
+      width: 100%;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      max-height: 24px;
+      background-color: #F6F6F6;
+      padding: 0 8px;
+      border-top: 1px solid #DCDCDC;
+      color: #707070;
+      text-align: left;
+      box-sizing: border-box;
+    }
+
+    .dcr-1uz1ca8 .ad-slot:not[data-label-show='true']::before {
+      content: '';
+      display: block;
+      height: 24px;
+      visibility: hidden;
+    }
+
+    .dcr-1uz1ca8 .ad-slot[data-label-show='true']:not(.ad-slot--interscroller):not(.ad-slot--merchandising):not(.ad-slot--merchandising-high)::before {
+      content: attr(ad-label-text);
+      display: block;
+      position: relative;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      max-height: 24px;
+      background-color: #F6F6F6;
+      padding: 0 8px;
+      border-top: 1px solid #DCDCDC;
+      color: #707070;
+      text-align: left;
+      box-sizing: border-box;
+    }
+
+    .dcr-1uz1ca8 .ad-slot--merchandising[data-label-show='true']::before,
+    .dcr-1uz1ca8 .ad-slot--merchandising-high[data-label-show='true']::before {
+      content: attr(ad-label-text);
+      display: block;
+      position: relative;
+      max-width: 970px;
+      margin: auto;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      max-height: 24px;
+      background-color: #F6F6F6;
+      padding: 0 8px;
+      border-top: 1px solid #DCDCDC;
+      color: #707070;
+      text-align: left;
+      box-sizing: border-box;
+    }
+
+    .dcr-1uz1ca8 .ad-slot__adtest-cookie-clear-link {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      text-align: left;
+      position: absolute;
+      left: 268px;
+      top: 1px;
+      z-index: 10;
+      padding: 0;
+      border: 0;
+    }
+
+    .dcr-1uz1ca8.ad-slot--fluid {
+      min-height: 250px;
+      line-height: 10px;
+      padding: 0;
+      margin: 0;
+    }
+
+    .dcr-1uz1ca8 .ad-slot.ad-slot--collapse {
+      display: none;
+    }
+
+    .dcr-1r4i92e {
+      position: relative;
+      min-height: 274px;
+      min-width: 300px;
+      width: 300px;
+      margin: 12px auto;
+    }
+
+    .dcr-1r4i92e .ad-slot__scroll {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      max-height: 24px;
+      background-color: #F6F6F6;
+      padding: 0 8px;
+      border-top: 1px solid #DCDCDC;
+      color: #707070;
+      text-align: left;
+      box-sizing: border-box;
+      position: relative;
+    }
+
+    .dcr-1r4i92e .ad-slot__scroll.visible {
+      visibility: initial;
+    }
+
+    .dcr-1r4i92e .ad-slot__scroll.hidden {
+      visibility: hidden;
+    }
+
+    .dcr-1r4i92e .ad-slot__close-button {
+      display: none;
+    }
+
+    .dcr-1r4i92e .ad-slot__scroll {
+      position: fixed;
+      bottom: 0;
+      width: 100%;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      max-height: 24px;
+      background-color: #F6F6F6;
+      padding: 0 8px;
+      border-top: 1px solid #DCDCDC;
+      color: #707070;
+      text-align: left;
+      box-sizing: border-box;
+    }
+
+    .dcr-1r4i92e .ad-slot:not[data-label-show='true']::before {
+      content: '';
+      display: block;
+      height: 24px;
+      visibility: hidden;
+    }
+
+    .dcr-1r4i92e .ad-slot[data-label-show='true']:not(.ad-slot--interscroller):not(.ad-slot--merchandising):not(.ad-slot--merchandising-high)::before {
+      content: attr(ad-label-text);
+      display: block;
+      position: relative;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      max-height: 24px;
+      background-color: #F6F6F6;
+      padding: 0 8px;
+      border-top: 1px solid #DCDCDC;
+      color: #707070;
+      text-align: left;
+      box-sizing: border-box;
+    }
+
+    .dcr-1r4i92e .ad-slot--merchandising[data-label-show='true']::before,
+    .dcr-1r4i92e .ad-slot--merchandising-high[data-label-show='true']::before {
+      content: attr(ad-label-text);
+      display: block;
+      position: relative;
+      max-width: 970px;
+      margin: auto;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      max-height: 24px;
+      background-color: #F6F6F6;
+      padding: 0 8px;
+      border-top: 1px solid #DCDCDC;
+      color: #707070;
+      text-align: left;
+      box-sizing: border-box;
+    }
+
+    .dcr-1r4i92e .ad-slot__adtest-cookie-clear-link {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      text-align: left;
+      position: absolute;
+      left: 268px;
+      top: 1px;
+      z-index: 10;
+      padding: 0;
+      border: 0;
+    }
+
+    .dcr-1r4i92e.ad-slot--fluid {
+      min-height: 250px;
+      line-height: 10px;
+      padding: 0;
+      margin: 0;
+    }
+
+    .dcr-1r4i92e .ad-slot.ad-slot--collapse {
+      display: none;
+    }
+
+    .dcr-klul57 {
+      position: relative;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      row-gap: 12px;
+      -webkit-flex-basis: 33.333%;
+      -ms-flex-preferred-size: 33.333%;
+      flex-basis: 33.333%;
+    }
+
+      {
+      padding-left: 10px;
+      padding-right: 10px;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-klul57 {
+        padding-left: 10px;
+        padding-right: 10px;
+      }
+    }
+
+    .dcr-1a53cuj {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-basis: 100%;
+      -ms-flex-preferred-size: 100%;
+      flex-basis: 100%;
+      width: 100%;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+    }
+
+    @media (max-width: 739px) {
+      .dcr-1a53cuj {
+        -webkit-flex-direction: column;
+        -ms-flex-direction: column;
+        flex-direction: column;
+      }
+    }
+
+    .dcr-1shzr3u {
+      position: relative;
+    }
+
+    .dcr-1shzr3u img {
+      width: 100%;
+      display: block;
+    }
+
+    .dcr-tosbt8 {
+      font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+      font-size: 1.25rem;
+      line-height: 1.15;
+      font-weight: 500;
+      --source-text-decoration-thickness: 3px;
+    }
+
+    @media (max-width: 979px) {
+      .dcr-tosbt8 {
+        font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+        font-size: 1.25rem;
+        line-height: 1.15;
+        font-weight: 500;
+        --source-text-decoration-thickness: 3px;
+      }
+    }
+
+    .dcr-isu8nh {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+      color: #121212;
+      font-family: GuardianTextEgyptian, Guardian Text Egyptian Web, Georgia, serif;
+      font-size: 0.9375rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      font-size: 14px;
+      padding-left: 5px;
+      padding-right: 5px;
+      padding-bottom: 8px;
+    }
+
+    @media (max-width: 739px) {
+      .dcr-isu8nh {
+        display: none;
+      }
+    }
+
+    .dcr-1xir693 {
+      position: relative;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 1.0625rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      cursor: pointer;
+      -webkit-text-decoration: underline;
+      text-decoration: underline;
+      text-underline-position: under;
+      text-underline-offset: 5%;
+      display: inline;
+      -webkit-align-items: center;
+      -webkit-box-align: center;
+      -ms-flex-align: center;
+      align-items: center;
+      color: #0077B6;
+      z-index: 2;
+      color: inherit;
+      font-family: inherit;
+      font-size: inherit;
+      line-height: inherit;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+    }
+
+    .dcr-1xir693:focus {
+      outline: 0;
+    }
+
+    html:not(.src-focus-disabled) .dcr-1xir693:focus {
+      box-shadow: 0 0 0 5px #0077B6;
+    }
+
+    .dcr-1xir693:hover {
+      text-decoration-thickness: var(--source-text-decoration-thickness, auto);
+    }
+
+    .dcr-1xir693:hover {
+      color: #0077B6;
+    }
+
+    .dcr-vkpbou {
+      position: relative;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      row-gap: 12px;
+      -webkit-flex-basis: 33.333%;
+      -ms-flex-preferred-size: 33.333%;
+      flex-basis: 33.333%;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-vkpbou:before {
+        content: '';
+        display: block;
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        left: 0;
+        width: 1px;
+        height: 100%;
+        border-left: 1px solid #DCDCDC;
+      }
+    }
+
+      {
+      padding-left: 10px;
+      padding-right: 10px;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-vkpbou {
+        padding-left: 10px;
+        padding-right: 10px;
+      }
+    }
+
+    .dcr-1wwe1mi {
+      position: relative;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: row;
+      -ms-flex-direction: row;
+      flex-direction: row;
+      row-gap: 12px;
+    }
+
+    @media (max-width: 739px) {
+      .dcr-1wwe1mi {
+        -webkit-flex-direction: column;
+        -ms-flex-direction: column;
+        flex-direction: column;
+        width: 100%;
+      }
+    }
+
+    .dcr-11xe9bu {
+      position: relative;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      row-gap: 12px;
+      -webkit-flex-basis: 66.666%;
+      -ms-flex-preferred-size: 66.666%;
+      flex-basis: 66.666%;
+    }
+
+    .dcr-1p6anfw {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+      -webkit-box-pack: justify;
+      -webkit-justify-content: space-between;
+      justify-content: space-between;
+      width: 100%;
+      position: relative;
+      color: inherit;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      background-color: #F6F6F6;
+    }
+
+    .dcr-1p6anfw:hover .image-overlay {
+      position: absolute;
+      top: 0;
+      width: 100%;
+      height: 100%;
+      left: 0;
+      background-color: #121212;
+      opacity: 0.1;
+    }
+
+    .dcr-1p6anfw:hover {
+      background-color: #EDEDED;
+    }
+
+    .dcr-1p6anfw:before {
+      background-color: #C70000;
+      content: '';
+      height: 1px;
+      z-index: 2;
+      width: 100%;
+    }
+
+    .dcr-1o7trcs {
+      color: #C70000;
+      font-weight: 700;
+      margin-right: 4px;
+    }
+
+    .dcr-er9oa0 {
+      position: relative;
+    }
+
+    .dcr-er9oa0 .ad-slot__scroll {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      max-height: 24px;
+      background-color: #F6F6F6;
+      padding: 0 8px;
+      border-top: 1px solid #DCDCDC;
+      color: #707070;
+      text-align: left;
+      box-sizing: border-box;
+      position: relative;
+    }
+
+    .dcr-er9oa0 .ad-slot__scroll.visible {
+      visibility: initial;
+    }
+
+    .dcr-er9oa0 .ad-slot__scroll.hidden {
+      visibility: hidden;
+    }
+
+    .dcr-er9oa0 .ad-slot__close-button {
+      display: none;
+    }
+
+    .dcr-er9oa0 .ad-slot__scroll {
+      position: fixed;
+      bottom: 0;
+      width: 100%;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      max-height: 24px;
+      background-color: #F6F6F6;
+      padding: 0 8px;
+      border-top: 1px solid #DCDCDC;
+      color: #707070;
+      text-align: left;
+      box-sizing: border-box;
+    }
+
+    .dcr-er9oa0 .ad-slot:not[data-label-show='true']::before {
+      content: '';
+      display: block;
+      height: 24px;
+      visibility: hidden;
+    }
+
+    .dcr-er9oa0 .ad-slot[data-label-show='true']:not(.ad-slot--interscroller):not(.ad-slot--merchandising):not(.ad-slot--merchandising-high)::before {
+      content: attr(ad-label-text);
+      display: block;
+      position: relative;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      max-height: 24px;
+      background-color: #F6F6F6;
+      padding: 0 8px;
+      border-top: 1px solid #DCDCDC;
+      color: #707070;
+      text-align: left;
+      box-sizing: border-box;
+    }
+
+    .dcr-er9oa0 .ad-slot--merchandising[data-label-show='true']::before,
+    .dcr-er9oa0 .ad-slot--merchandising-high[data-label-show='true']::before {
+      content: attr(ad-label-text);
+      display: block;
+      position: relative;
+      max-width: 970px;
+      margin: auto;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      max-height: 24px;
+      background-color: #F6F6F6;
+      padding: 0 8px;
+      border-top: 1px solid #DCDCDC;
+      color: #707070;
+      text-align: left;
+      box-sizing: border-box;
+    }
+
+    .dcr-er9oa0 .ad-slot__adtest-cookie-clear-link {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      text-align: left;
+      position: absolute;
+      left: 268px;
+      top: 1px;
+      z-index: 10;
+      padding: 0;
+      border: 0;
+    }
+
+    .dcr-er9oa0.ad-slot--fluid {
+      min-height: 250px;
+      line-height: 10px;
+      padding: 0;
+      margin: 0;
+    }
+
+    .dcr-er9oa0 .ad-slot.ad-slot--collapse {
+      display: none;
+    }
+
+    .dcr-11vxpqc {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+    }
+
+    .dcr-w6hc5l {
+      display: -webkit-inline-box;
+      display: -webkit-inline-flex;
+      display: -ms-inline-flexbox;
+      display: inline-flex;
+      -webkit-box-pack: justify;
+      -webkit-justify-content: space-between;
+      justify-content: space-between;
+      -webkit-align-items: center;
+      -webkit-box-align: center;
+      -ms-flex-align: center;
+      align-items: center;
+      box-sizing: border-box;
+      border: none;
+      background: transparent;
+      cursor: pointer;
+      -webkit-transition: .3s ease-in-out;
+      transition: .3s ease-in-out;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      white-space: nowrap;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.9375rem;
+      line-height: 1.35;
+      font-weight: 700;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      min-height: 24px;
+      padding: 0 12px;
+      border-radius: 24px;
+      padding-bottom: 2px;
+      background-color: #052962;
+      color: #FFFFFF;
+      -webkit-flex-direction: row-reverse;
+      -ms-flex-direction: row-reverse;
+      flex-direction: row-reverse;
+      margin-top: 16px;
+      margin-right: 10px;
+      color: #FFFFFF;
+      background-color: #121212;
+      border-color: #121212;
+    }
+
+    .dcr-w6hc5l:disabled {
+      cursor: not-allowed;
+    }
+
+    .dcr-w6hc5l:focus {
+      outline: 0;
+    }
+
+    html:not(.src-focus-disabled) .dcr-w6hc5l:focus {
+      outline: 5px solid #0077B6;
+      outline-offset: 3px;
+    }
+
+    .dcr-w6hc5l:hover {
+      background-color: #234B8A;
+    }
+
+    .dcr-w6hc5l svg {
+      -webkit-flex: 0 0 auto;
+      -ms-flex: 0 0 auto;
+      flex: 0 0 auto;
+      display: block;
+      fill: currentColor;
+      position: relative;
+      width: 20px;
+      height: auto;
+    }
+
+    .dcr-w6hc5l .src-button-space {
+      width: 4px;
+    }
+
+    .dcr-w6hc5l svg {
+      margin-left: -4px;
+    }
+
+    .dcr-w6hc5l:hover {
+      background-color: #707070;
+      border-color: #707070;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-w6hc5l {
+        margin-left: 10px;
+      }
+    }
+
+    .dcr-194i6pr {
+      position: absolute;
+      overflow: hidden;
+      white-space: nowrap;
+      width: 1px;
+      height: 1px;
+      margin: -1px;
+      padding: 0;
+      border: 0;
+      clip: rect(1px, 1px, 1px, 1px);
+      -webkit-clip-path: inset(50%);
+      -webkit-clip-path: inset(50%);
+      clip-path: inset(50%);
+    }
+
+    .dcr-10hq5cq {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-box-pack: center;
+      -ms-flex-pack: center;
+      -webkit-justify-content: center;
+      justify-content: center;
+    }
+
+    .dcr-10hq5cq .ad-slot__scroll {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      max-height: 24px;
+      background-color: #F6F6F6;
+      padding: 0 8px;
+      border-top: 1px solid #DCDCDC;
+      color: #707070;
+      text-align: left;
+      box-sizing: border-box;
+      position: relative;
+    }
+
+    .dcr-10hq5cq .ad-slot__scroll.visible {
+      visibility: initial;
+    }
+
+    .dcr-10hq5cq .ad-slot__scroll.hidden {
+      visibility: hidden;
+    }
+
+    .dcr-10hq5cq .ad-slot__close-button {
+      display: none;
+    }
+
+    .dcr-10hq5cq .ad-slot__scroll {
+      position: fixed;
+      bottom: 0;
+      width: 100%;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      max-height: 24px;
+      background-color: #F6F6F6;
+      padding: 0 8px;
+      border-top: 1px solid #DCDCDC;
+      color: #707070;
+      text-align: left;
+      box-sizing: border-box;
+    }
+
+    .dcr-10hq5cq .ad-slot:not[data-label-show='true']::before {
+      content: '';
+      display: block;
+      height: 24px;
+      visibility: hidden;
+    }
+
+    .dcr-10hq5cq .ad-slot[data-label-show='true']:not(.ad-slot--interscroller):not(.ad-slot--merchandising):not(.ad-slot--merchandising-high)::before {
+      content: attr(ad-label-text);
+      display: block;
+      position: relative;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      max-height: 24px;
+      background-color: #F6F6F6;
+      padding: 0 8px;
+      border-top: 1px solid #DCDCDC;
+      color: #707070;
+      text-align: left;
+      box-sizing: border-box;
+    }
+
+    .dcr-10hq5cq .ad-slot--merchandising[data-label-show='true']::before,
+    .dcr-10hq5cq .ad-slot--merchandising-high[data-label-show='true']::before {
+      content: attr(ad-label-text);
+      display: block;
+      position: relative;
+      max-width: 970px;
+      margin: auto;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      max-height: 24px;
+      background-color: #F6F6F6;
+      padding: 0 8px;
+      border-top: 1px solid #DCDCDC;
+      color: #707070;
+      text-align: left;
+      box-sizing: border-box;
+    }
+
+    .dcr-10hq5cq .ad-slot__adtest-cookie-clear-link {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      text-align: left;
+      position: absolute;
+      left: 268px;
+      top: 1px;
+      z-index: 10;
+      padding: 0;
+      border: 0;
+    }
+
+    .dcr-10hq5cq.ad-slot--fluid {
+      min-height: 250px;
+      line-height: 10px;
+      padding: 0;
+      margin: 0;
+    }
+
+    .dcr-10hq5cq .ad-slot.ad-slot--collapse {
+      display: none;
+    }
+
+    .dcr-5zzwsk {
+      position: relative;
+      min-height: 250px;
+    }
+
+    .dcr-5zzwsk .ad-slot__scroll {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      max-height: 24px;
+      background-color: #F6F6F6;
+      padding: 0 8px;
+      border-top: 1px solid #DCDCDC;
+      color: #707070;
+      text-align: left;
+      box-sizing: border-box;
+      position: relative;
+    }
+
+    .dcr-5zzwsk .ad-slot__scroll.visible {
+      visibility: initial;
+    }
+
+    .dcr-5zzwsk .ad-slot__scroll.hidden {
+      visibility: hidden;
+    }
+
+    .dcr-5zzwsk .ad-slot__close-button {
+      display: none;
+    }
+
+    .dcr-5zzwsk .ad-slot__scroll {
+      position: fixed;
+      bottom: 0;
+      width: 100%;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      max-height: 24px;
+      background-color: #F6F6F6;
+      padding: 0 8px;
+      border-top: 1px solid #DCDCDC;
+      color: #707070;
+      text-align: left;
+      box-sizing: border-box;
+    }
+
+    .dcr-5zzwsk .ad-slot:not[data-label-show='true']::before {
+      content: '';
+      display: block;
+      height: 24px;
+      visibility: hidden;
+    }
+
+    .dcr-5zzwsk .ad-slot[data-label-show='true']:not(.ad-slot--interscroller):not(.ad-slot--merchandising):not(.ad-slot--merchandising-high)::before {
+      content: attr(ad-label-text);
+      display: block;
+      position: relative;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      max-height: 24px;
+      background-color: #F6F6F6;
+      padding: 0 8px;
+      border-top: 1px solid #DCDCDC;
+      color: #707070;
+      text-align: left;
+      box-sizing: border-box;
+    }
+
+    .dcr-5zzwsk .ad-slot--merchandising[data-label-show='true']::before,
+    .dcr-5zzwsk .ad-slot--merchandising-high[data-label-show='true']::before {
+      content: attr(ad-label-text);
+      display: block;
+      position: relative;
+      max-width: 970px;
+      margin: auto;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      max-height: 24px;
+      background-color: #F6F6F6;
+      padding: 0 8px;
+      border-top: 1px solid #DCDCDC;
+      color: #707070;
+      text-align: left;
+      box-sizing: border-box;
+    }
+
+    .dcr-5zzwsk .ad-slot__adtest-cookie-clear-link {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      text-align: left;
+      position: absolute;
+      left: 268px;
+      top: 1px;
+      z-index: 10;
+      padding: 0;
+      border: 0;
+    }
+
+    .dcr-5zzwsk.ad-slot--fluid {
+      min-height: 250px;
+      line-height: 10px;
+      padding: 0;
+      margin: 0;
+    }
+
+    .dcr-5zzwsk .ad-slot.ad-slot--collapse {
+      display: none;
+    }
+
+    .dcr-5zzwsk.ad-slot--fluid {
+      width: 100%;
+    }
+
+    .dcr-1x0hldo {
+      position: relative;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      row-gap: 12px;
+      -webkit-flex-basis: 50%;
+      -ms-flex-preferred-size: 50%;
+      flex-basis: 50%;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-1x0hldo {
+        padding-left: 10px;
+        padding-right: 10px;
+      }
+    }
+
+    .dcr-1w0fo28 {
+      display: block;
+      font-style: italic;
+      font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+      font-size: 1.5rem;
+      line-height: 1.15;
+      font-weight: 500;
+      --source-text-decoration-thickness: 3px;
+      color: #0077B6;
+    }
+
+    @media (max-width: 979px) {
+      .dcr-1w0fo28 {
+        font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+        font-size: 1.25rem;
+        line-height: 1.15;
+        font-weight: 500;
+        --source-text-decoration-thickness: 3px;
+      }
+    }
+
+    .dcr-heqd82 {
+      position: relative;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+      row-gap: 12px;
+    }
+
+    @media (max-width: 739px) {
+      .dcr-heqd82 {
+        -webkit-flex-direction: column;
+        -ms-flex-direction: column;
+        flex-direction: column;
+        width: 100%;
+      }
+    }
+
+    .dcr-17t8q7b {
+      -webkit-flex-basis: 75%;
+      -ms-flex-preferred-size: 75%;
+      flex-basis: 75%;
+      position: relative;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-17t8q7b {
+        -webkit-align-self: flex-start;
+        -ms-flex-item-align: flex-start;
+        align-self: flex-start;
+      }
+    }
+
+    .dcr-17t8q7b img {
+      width: 100%;
+      display: block;
+    }
+
+    .dcr-1m23nk7 {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+      -webkit-box-pack: justify;
+      -webkit-justify-content: space-between;
+      justify-content: space-between;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-1m23nk7 {
+        -webkit-flex-basis: 25%;
+        -ms-flex-preferred-size: 25%;
+        flex-basis: 25%;
+      }
+    }
+
+    .dcr-1lbbgad {
+      font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+      font-size: 1.75rem;
+      line-height: 1.15;
+      font-weight: 500;
+      --source-text-decoration-thickness: 3px;
+    }
+
+    @media (max-width: 979px) {
+      .dcr-1lbbgad {
+        font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+        font-size: 1.25rem;
+        line-height: 1.15;
+        font-weight: 500;
+        --source-text-decoration-thickness: 3px;
+      }
+    }
+
+    .dcr-pocf23 {
+      stroke: red;
+    }
+
+    .dcr-zu1fd9 {
+      position: relative;
+      margin: auto;
+      border-top: 1px solid #DCDCDC;
+      padding-left: 10px;
+      padding-right: 10px;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-zu1fd9 {
+        max-width: 740px;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-zu1fd9 {
+        max-width: 980px;
+      }
+    }
+
+    @media (min-width: 1140px) {
+      .dcr-zu1fd9 {
+        max-width: 1140px;
+      }
+    }
+
+    @media (min-width: 1300px) {
+      .dcr-zu1fd9 {
+        max-width: 1300px;
+      }
+    }
+
+    @media (min-width: 740px) {
+      .dcr-zu1fd9 {
+        border-left: 1px solid #DCDCDC;
+        border-right: 1px solid #DCDCDC;
+      }
+    }
+
+    @media (min-width: 480px) {
+      .dcr-zu1fd9 {
+        padding-left: 20px;
+        padding-right: 20px;
+      }
+    }
+
+    .dcr-1pp81zm {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: row;
+      -ms-flex-direction: row;
+      flex-direction: row;
+      -webkit-box-pack: justify;
+      -webkit-justify-content: space-between;
+      justify-content: space-between;
+      gap: initial;
+      -ms-flex-positive: 1;
+    }
+
+    .dcr-pu1sy6 {
+      position: relative;
+      padding-right: 10px;
+    }
+
+    @media (max-width: 1139px) {
+      .dcr-pu1sy6 {
+        display: none;
+      }
+    }
+
+    @media (min-width: 1140px) and (max-width: 1299px) {
+      .dcr-pu1sy6 {
+        -webkit-flex-basis: 151px;
+        -ms-flex-preferred-size: 151px;
+        flex-basis: 151px;
+        -webkit-box-flex: 0;
+        -webkit-flex-grow: 0;
+        -ms-flex-positive: 0;
+        flex-grow: 0;
+        -webkit-flex-shrink: 0;
+        -ms-flex-negative: 0;
+        flex-shrink: 0;
+      }
+    }
+
+    @media (min-width: 1300px) {
+      .dcr-pu1sy6 {
+        -webkit-flex-basis: 230px;
+        -ms-flex-preferred-size: 230px;
+        flex-basis: 230px;
+        -webkit-box-flex: 0;
+        -webkit-flex-grow: 0;
+        -ms-flex-positive: 0;
+        flex-grow: 0;
+        -webkit-flex-shrink: 0;
+        -ms-flex-negative: 0;
+        flex-shrink: 0;
+      }
+    }
+
+    .dcr-yg4zrc {
+      height: 100%;
+    }
+
+    .dcr-k1vhee {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      height: 100%;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+      -webkit-box-pack: justify;
+      -webkit-justify-content: space-between;
+      justify-content: space-between;
+    }
+
+    .dcr-fossqd {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-box-flex: 1;
+      -webkit-flex-grow: 1;
+      -ms-flex-positive: 1;
+      flex-grow: 1;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+      width: 100%;
+    }
+
+    @media (min-width: 1300px) {
+      .dcr-fossqd {
+        margin-right: 68px;
+      }
+    }
+
+    .dcr-j3w6wb {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-box-pack: end;
+      -ms-flex-pack: end;
+      -webkit-justify-content: flex-end;
+      justify-content: flex-end;
+    }
+
+    @media (max-width: 1139px) {
+      .dcr-j3w6wb {
+        -webkit-box-pack: justify;
+        -webkit-justify-content: space-between;
+        justify-content: space-between;
+      }
+    }
+
+    @media (min-width: 1140px) {
+      .dcr-1giivcq {
+        display: none;
+      }
+    }
+
+    .dcr-ddf1wi {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+    }
+
+    @media (min-width: 980px) {
+      .dcr-ddf1wi {
+        -webkit-flex-direction: row;
+        -ms-flex-direction: row;
+        flex-direction: row;
+      }
+    }
+
+    .dcr-xf43jl {
+      width: 100%;
+    }
+
+    @media (min-width: 980px) and (max-width: 1299px) {
+      .dcr-xf43jl {
+        min-width: 627px;
+      }
+    }
+
+    @media (min-width: 1300px) {
+      .dcr-xf43jl {
+        min-width: 718px;
+      }
+    }
+
+    .dcr-3x1x0z {
+      width: 100%;
+    }
+
+    .dcr-1h1ezso {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      position: relative;
+      border-left: 1px solid #DCDCDC;
+      border-right: 1px solid #DCDCDC;
+      border-bottom: 1px solid #DCDCDC;
+    }
+
+    @media (max-width: 1139px) {
+      .dcr-1h1ezso {
+        border-top: 1px solid #DCDCDC;
+        border-bottom: 0;
+      }
+    }
+
+    .dcr-18411a1 {
+      font-weight: 700;
+      line-height: 1.1;
+      background-color: transparent;
+      text-transform: capitalize;
+      padding: 0 0 0;
+      margin-bottom: 16px;
+      width: 240px;
+      height: 28px;
+      box-shadow: inset 0px 4px 0px 0px #000000;
+      -webkit-transition: box-shadow 0.3s ease-in-out;
+      transition: box-shadow 0.3s ease-in-out;
+      border-right: 1px solid #DCDCDC;
+    }
+
+    .dcr-21isvz {
+      font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+      font-size: 1.0625rem;
+      line-height: 1.15;
+      font-weight: 500;
+      --source-text-decoration-thickness: 2px;
+      color: #121212;
+      margin: 0;
+      border: 0;
+      background: transparent;
+      padding: 6px 6px 0 10px;
+      text-align: left;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      font-weight: 600;
+      min-height: 36px;
+      display: block;
+      width: 100%;
+    }
+
+    .dcr-21isvz:hover {
+      cursor: default;
+    }
+
+    .dcr-vi7os3 {
+      position: absolute;
+      overflow: hidden;
+      white-space: nowrap;
+      width: 1px;
+      height: 1px;
+      margin: -1px;
+      padding: 0;
+      border: 0;
+      clip: rect(1px, 1px, 1px, 1px);
+      -webkit-clip-path: inset(50%);
+      -webkit-clip-path: inset(50%);
+      clip-path: inset(50%);
+    }
+
+    .dcr-1q2dk60 {
+      text-transform: capitalize;
+    }
+
+    .dcr-fo4w6z {
+      font-weight: 700;
+      line-height: 1.1;
+      background-color: transparent;
+      text-transform: capitalize;
+      padding: 0 0 0;
+      margin-bottom: 16px;
+      width: 240px;
+      height: 28px;
+    }
+
+    .dcr-fo4w6z:hover {
+      box-shadow: inset 0px 4px 0px 0px #DCDCDC;
+      -webkit-transition: box-shadow 0.3s ease-in-out;
+      transition: box-shadow 0.3s ease-in-out;
+    }
+
+    .dcr-ygjxgh {
+      font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+      font-size: 1.0625rem;
+      line-height: 1.15;
+      font-weight: 500;
+      --source-text-decoration-thickness: 2px;
+      color: #121212;
+      margin: 0;
+      border: 0;
+      background: transparent;
+      padding: 6px 6px 0 10px;
+      text-align: left;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      font-weight: 600;
+      min-height: 36px;
+      display: block;
+      width: 100%;
+    }
+
+    .dcr-ygjxgh:hover {
+      cursor: pointer;
+    }
+
+    .dcr-102ctxe {
+      position: absolute;
+      overflow: hidden;
+      white-space: nowrap;
+      width: 1px;
+      height: 1px;
+      margin: -1px;
+      padding: 0;
+      border: 0;
+      clip: rect(1px, 1px, 1px, 1px);
+      -webkit-clip-path: inset(50%);
+      -webkit-clip-path: inset(50%);
+      clip-path: inset(50%);
+    }
+
+    .dcr-hqoq27 {
+      display: grid;
+      grid-auto-flow: column;
+      grid-template-columns: 1fr;
+      grid-template-rows: auto auto auto auto auto auto auto auto auto auto;
+      border-left: 1px solid #DCDCDC;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-hqoq27 {
+        grid-template-columns: 1fr 1fr;
+        grid-template-rows: auto auto auto auto auto;
+      }
+    }
+
+    .dcr-9e1ukq {
+      position: relative;
+      border-right: 1px solid #DCDCDC;
+      min-height: 3.25rem;
+    }
+
+    @media (max-width: 1139px) {
+      .dcr-9e1ukq {
+        border-top: 1px solid #DCDCDC;
+      }
+    }
+
+    .dcr-9e1ukq:hover {
+      cursor: pointer;
+    }
+
+    .dcr-9e1ukq:hover,
+    .dcr-9e1ukq:focus {
+      background: #F6F6F6;
+    }
+
+    .dcr-xyss4m {
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      color: #121212;
+      font-weight: 500;
+      font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+      font-size: 1.0625rem;
+      line-height: 1.15;
+      font-weight: 500;
+      --source-text-decoration-thickness: 2px;
+      display: block;
+    }
+
+    .dcr-q76bkn {
+      position: absolute;
+      top: 0.375rem;
+      left: 0.625rem;
+      fill: #121212;
+    }
+
+    .dcr-14gme47 {
+      padding: 0.1875rem 0.625rem 1.125rem 4.6875rem;
+      word-wrap: break-word;
+      overflow: hidden;
+    }
+
+    .dcr-n4owjk {
+      font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+      font-size: 1.0625rem;
+      line-height: 1.15;
+      font-weight: 500;
+      --source-text-decoration-thickness: 2px;
+    }
+
+    .dcr-1haxrmz {
+      position: relative;
+      border-top: 1px solid #DCDCDC;
+      border-right: 1px solid #DCDCDC;
+      min-height: 3.25rem;
+    }
+
+    @media (max-width: 1139px) {
+      .dcr-1haxrmz {
+        border-top: 1px solid #DCDCDC;
+      }
+    }
+
+    .dcr-1haxrmz:hover {
+      cursor: pointer;
+    }
+
+    .dcr-1haxrmz:hover,
+    .dcr-1haxrmz:focus {
+      background: #F6F6F6;
+    }
+
+    .dcr-t2dtan {
+      display: none;
+    }
+
+    .dcr-1ij4tou {
+      color: #C70000;
+    }
+
+    .dcr-1ij4tou:before {
+      border-radius: 62.5rem;
+      display: inline-block;
+      position: relative;
+      background-color: currentColor;
+      width: 0.75em;
+      height: 0.75em;
+      content: '';
+      margin-right: 0.1875rem;
+      vertical-align: initial;
+    }
+
+    .dcr-1ij4tou[data-animate='true'] {
+      -webkit-animation: animation-111ynch 1s infinite;
+      animation: animation-111ynch 1s infinite;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .dcr-1ij4tou[data-animate='true'] {
+        -webkit-animation: none;
+        animation: none;
+      }
+    }
+
+    .dcr-10j4v47 {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+      border-left: 1px solid #DCDCDC;
+      border-right: 1px solid #DCDCDC;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-10j4v47 {
+        -webkit-flex-direction: row;
+        -ms-flex-direction: row;
+        flex-direction: row;
+      }
+    }
+
+    @media (min-width: 740px) {
+      .dcr-10j4v47 {
+        padding-top: 24px;
+      }
+    }
+
+    .dcr-1o3p705 {
+      position: relative;
+      padding-left: 10px;
+      padding-right: 10px;
+      padding-bottom: 12px;
+      border-top: 1px solid #DCDCDC;
+      min-height: 3.25rem;
+      -webkit-flex-basis: 100%;
+      -ms-flex-preferred-size: 100%;
+      flex-basis: 100%;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-1o3p705 {
+        border-right: 1px solid #DCDCDC;
+      }
+    }
+
+    .dcr-1o3p705:hover {
+      cursor: pointer;
+    }
+
+    .dcr-1o3p705:hover,
+    .dcr-1o3p705:focus {
+      background: #F6F6F6;
+    }
+
+    .dcr-1wxws1r {
+      word-wrap: break-word;
+      overflow: hidden;
+    }
+
+    .dcr-19eam1p {
+      font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+      font-size: 1.0625rem;
+      line-height: 1.15;
+      font-weight: 700;
+      --source-text-decoration-thickness: 2px;
+      padding-top: 4px;
+    }
+
+    .dcr-yi9s71 {
+      display: block;
+      font-style: italic;
+      font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+      font-size: 1.0625rem;
+      line-height: 1.15;
+      font-weight: 500;
+      --source-text-decoration-thickness: 2px;
+      color: #C74600;
+    }
+
+    .dcr-1lbz6ez {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: row-reverse;
+      -ms-flex-direction: row-reverse;
+      flex-direction: row-reverse;
+      margin-left: 5px;
+      margin-top: 24px;
+    }
+
+    .dcr-vibzgs {
+      height: 90px;
+      width: 90px;
+    }
+
+    .dcr-qprpng {
+      display: block;
+      border-radius: 100%;
+      height: 100%;
+      width: 100%;
+      overflow: hidden;
+      background-color: #C74600;
+    }
+
+    .dcr-1yduq3m {
+      display: block;
+      object-fit: cover;
+      height: 100%;
+      width: 100%;
+    }
+
+    .dcr-1ngqhfk {
+      position: relative;
+      padding-left: 10px;
+      padding-right: 10px;
+      padding-bottom: 12px;
+      border-top: 1px solid #DCDCDC;
+      min-height: 3.25rem;
+      -webkit-flex-basis: 100%;
+      -ms-flex-preferred-size: 100%;
+      flex-basis: 100%;
+    }
+
+    .dcr-1ngqhfk:hover {
+      cursor: pointer;
+    }
+
+    .dcr-1ngqhfk:hover,
+    .dcr-1ngqhfk:focus {
+      background: #F6F6F6;
+    }
+
+    .dcr-10kck6o {
+      display: block;
+      border-radius: 100%;
+      height: 100%;
+      width: 100%;
+      overflow: hidden;
+      background-color: #FF5943;
+    }
+
+    .dcr-i5gfxx {
+      margin: 6px 0 0 10px;
+    }
+
+    .dcr-ge5xgp {
+      position: relative;
+      min-height: 274px;
+      min-width: 300px;
+      width: 300px;
+      margin: 12px auto;
+      text-align: center;
+    }
+
+    .dcr-ge5xgp .ad-slot__scroll {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      max-height: 24px;
+      background-color: #F6F6F6;
+      padding: 0 8px;
+      border-top: 1px solid #DCDCDC;
+      color: #707070;
+      text-align: left;
+      box-sizing: border-box;
+      position: relative;
+    }
+
+    .dcr-ge5xgp .ad-slot__scroll.visible {
+      visibility: initial;
+    }
+
+    .dcr-ge5xgp .ad-slot__scroll.hidden {
+      visibility: hidden;
+    }
+
+    .dcr-ge5xgp .ad-slot__close-button {
+      display: none;
+    }
+
+    .dcr-ge5xgp .ad-slot__scroll {
+      position: fixed;
+      bottom: 0;
+      width: 100%;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      max-height: 24px;
+      background-color: #F6F6F6;
+      padding: 0 8px;
+      border-top: 1px solid #DCDCDC;
+      color: #707070;
+      text-align: left;
+      box-sizing: border-box;
+    }
+
+    .dcr-ge5xgp .ad-slot:not[data-label-show='true']::before {
+      content: '';
+      display: block;
+      height: 24px;
+      visibility: hidden;
+    }
+
+    .dcr-ge5xgp .ad-slot[data-label-show='true']:not(.ad-slot--interscroller):not(.ad-slot--merchandising):not(.ad-slot--merchandising-high)::before {
+      content: attr(ad-label-text);
+      display: block;
+      position: relative;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      max-height: 24px;
+      background-color: #F6F6F6;
+      padding: 0 8px;
+      border-top: 1px solid #DCDCDC;
+      color: #707070;
+      text-align: left;
+      box-sizing: border-box;
+    }
+
+    .dcr-ge5xgp .ad-slot--merchandising[data-label-show='true']::before,
+    .dcr-ge5xgp .ad-slot--merchandising-high[data-label-show='true']::before {
+      content: attr(ad-label-text);
+      display: block;
+      position: relative;
+      max-width: 970px;
+      margin: auto;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      max-height: 24px;
+      background-color: #F6F6F6;
+      padding: 0 8px;
+      border-top: 1px solid #DCDCDC;
+      color: #707070;
+      text-align: left;
+      box-sizing: border-box;
+    }
+
+    .dcr-ge5xgp .ad-slot__adtest-cookie-clear-link {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      text-align: left;
+      position: absolute;
+      left: 268px;
+      top: 1px;
+      z-index: 10;
+      padding: 0;
+      border: 0;
+    }
+
+    .dcr-ge5xgp.ad-slot--fluid {
+      min-height: 250px;
+      line-height: 10px;
+      padding: 0;
+      margin: 0;
+    }
+
+    .dcr-ge5xgp .ad-slot.ad-slot--collapse {
+      display: none;
+    }
+
+    @media (min-width: 980px) {
+      .dcr-ge5xgp {
+        margin: 0;
+        width: auto;
+      }
+    }
+
+    .dcr-1v397f0 {
+      position: relative;
+      margin: auto;
+      padding-left: 10px;
+      padding-right: 10px;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-1v397f0 {
+        max-width: 740px;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-1v397f0 {
+        max-width: 980px;
+      }
+    }
+
+    @media (min-width: 1140px) {
+      .dcr-1v397f0 {
+        max-width: 1140px;
+      }
+    }
+
+    @media (min-width: 1300px) {
+      .dcr-1v397f0 {
+        max-width: 1300px;
+      }
+    }
+
+    @media (min-width: 740px) {
+      .dcr-1v397f0 {
+        border-left: 1px solid #DCDCDC;
+        border-right: 1px solid #DCDCDC;
+      }
+    }
+
+    @media (min-width: 480px) {
+      .dcr-1v397f0 {
+        padding-left: 20px;
+        padding-right: 20px;
+      }
+    }
+
+    .dcr-1hy529c {
+      padding-top: 30px;
+      padding-bottom: 20px;
+    }
+
+    .dcr-kammsl {
+      display: block;
+    }
+
+    .dcr-c4kygy {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      color: #999999;
+    }
+
+    .dcr-91lgpk {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.875rem;
+      line-height: 1.5;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      top: 0;
+      color: #121212;
+    }
+
+    .dcr-91lgpk:after {
+      color: #DCDCDC;
+      pointer-events: none;
+      margin: 2.56px;
+      content: '/';
+    }
+
+    .dcr-91lgpk:last-of-type:after {
+      content: '';
+    }
+
+    .dcr-nosp2s {
+      background-color: #EDEDED;
+    }
+
+    .dcr-10rqwzg {
+      background-color: #052962;
+      color: #FFFFFF;
+      padding-bottom: 6px;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 1.0625rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+    }
+
+    .dcr-1w2x6ij {
+      border-left: 1px solid #506991;
+      border-right: 1px solid #506991;
+      padding-bottom: 12px;
+      position: relative;
+      height: 43px;
+    }
+
+    .dcr-1w2x6ij:after {
+      content: '';
+      display: table;
+      clear: both;
+    }
+
+    .dcr-1w2x6ij>ul {
+      clear: none;
+    }
+
+    .dcr-1w2x6ij>ul:after {
+      display: none;
+    }
+
+    .dcr-11rhxc6 {
+      font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+      font-size: 1.0625rem;
+      line-height: 1.15;
+      font-weight: 500;
+      --source-text-decoration-thickness: 2px;
+      box-sizing: border-box;
+      font-weight: 900;
+      color: #FFFFFF;
+      cursor: pointer;
+      display: block;
+      font-size: 15.4px;
+      height: 36px;
+      padding-top: 9px;
+      padding-right: 5px;
+      padding-bottom: 0;
+      padding-left: 5px;
+      position: relative;
+      overflow: hidden;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      z-index: 1;
+    }
+
+    @media (min-width: 375px) {
+      .dcr-11rhxc6 {
+        font-size: 15.7px;
+        padding-top: 9px;
+        padding-right: 5px;
+        padding-bottom: 0;
+        padding-left: 5px;
+      }
+    }
+
+    @media (min-width: 480px) {
+      .dcr-11rhxc6 {
+        font-size: 18px;
+        padding-top: 9px;
+        padding-right: 5px;
+        padding-bottom: 0;
+        padding-left: 5px;
+      }
+    }
+
+    @media (min-width: 740px) {
+      .dcr-11rhxc6 {
+        font-size: 22px;
+        height: 48px;
+        padding-top: 9px;
+        padding-right: 20px;
+        padding-bottom: 0;
+        padding-left: 9px;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-11rhxc6 {
+        padding-top: 5px;
+        height: 42px;
+      }
+    }
+
+    @media (min-width: 1300px) {
+      .dcr-11rhxc6 {
+        padding-top: 7px;
+        font-size: 24px;
+      }
+    }
+
+    .dcr-11rhxc6:focus:after {
+      -webkit-transform: translateY(4px);
+      -moz-transform: translateY(4px);
+      -ms-transform: translateY(4px);
+      transform: translateY(4px);
+    }
+
+    .dcr-11rhxc6:hover {
+      -webkit-text-decoration: none;
+      text-decoration: none;
+    }
+
+    .dcr-11rhxc6:hover:after {
+      -webkit-transform: translateY(4px);
+      -moz-transform: translateY(4px);
+      -ms-transform: translateY(4px);
+      transform: translateY(4px);
+    }
+
+    .dcr-11rhxc6:after {
+      border-top: 4px solid #FF5943;
+      left: 0;
+      right: 1px;
+      top: -4px;
+      content: '';
+      display: block;
+      position: absolute;
+      -webkit-transition: -webkit-transform 0.3s ease-in-out;
+      transition: transform 0.3s ease-in-out;
+    }
+
+    .dcr-11rhxc6:after {
+      -webkit-transform: translateY(4px);
+      -moz-transform: translateY(4px);
+      -ms-transform: translateY(4px);
+      transform: translateY(4px);
+    }
+
+    .dcr-11rhxc6:focus:after {
+      -webkit-transform: translateY(4px);
+      -moz-transform: translateY(4px);
+      -ms-transform: translateY(4px);
+      transform: translateY(4px);
+    }
+
+    .dcr-11rhxc6:hover {
+      -webkit-text-decoration: none;
+      text-decoration: none;
+    }
+
+    .dcr-11rhxc6:hover:after {
+      -webkit-transform: translateY(4px);
+      -moz-transform: translateY(4px);
+      -ms-transform: translateY(4px);
+      transform: translateY(4px);
+    }
+
+    .dcr-11rhxc6:before {
+      content: '';
+      display: block;
+      position: absolute;
+      right: 0;
+      top: 0;
+      bottom: 0;
+      width: 1px;
+      background-color: #506991;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-11rhxc6:before {
+        bottom: 17px;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-11rhxc6:before {
+        bottom: 0.6em;
+      }
+    }
+
+    .dcr-yqz51q {
+      font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+      font-size: 1.0625rem;
+      line-height: 1.15;
+      font-weight: 500;
+      --source-text-decoration-thickness: 2px;
+      box-sizing: border-box;
+      font-weight: 900;
+      color: #FFFFFF;
+      cursor: pointer;
+      display: block;
+      font-size: 15.4px;
+      height: 36px;
+      padding-top: 9px;
+      padding-right: 5px;
+      padding-bottom: 0;
+      padding-left: 5px;
+      position: relative;
+      overflow: hidden;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      z-index: 1;
+    }
+
+    @media (min-width: 375px) {
+      .dcr-yqz51q {
+        font-size: 15.7px;
+        padding-top: 9px;
+        padding-right: 5px;
+        padding-bottom: 0;
+        padding-left: 5px;
+      }
+    }
+
+    @media (min-width: 480px) {
+      .dcr-yqz51q {
+        font-size: 18px;
+        padding-top: 9px;
+        padding-right: 5px;
+        padding-bottom: 0;
+        padding-left: 5px;
+      }
+    }
+
+    @media (min-width: 740px) {
+      .dcr-yqz51q {
+        font-size: 22px;
+        height: 48px;
+        padding-top: 9px;
+        padding-right: 20px;
+        padding-bottom: 0;
+        padding-left: 9px;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-yqz51q {
+        padding-top: 5px;
+        height: 42px;
+      }
+    }
+
+    @media (min-width: 1300px) {
+      .dcr-yqz51q {
+        padding-top: 7px;
+        font-size: 24px;
+      }
+    }
+
+    .dcr-yqz51q:focus:after {
+      -webkit-transform: translateY(4px);
+      -moz-transform: translateY(4px);
+      -ms-transform: translateY(4px);
+      transform: translateY(4px);
+    }
+
+    .dcr-yqz51q:hover {
+      -webkit-text-decoration: none;
+      text-decoration: none;
+    }
+
+    .dcr-yqz51q:hover:after {
+      -webkit-transform: translateY(4px);
+      -moz-transform: translateY(4px);
+      -ms-transform: translateY(4px);
+      transform: translateY(4px);
+    }
+
+    .dcr-yqz51q:after {
+      border-top: 4px solid #FF7F0F;
+      left: 0;
+      right: 1px;
+      top: -4px;
+      content: '';
+      display: block;
+      position: absolute;
+      -webkit-transition: -webkit-transform 0.3s ease-in-out;
+      transition: transform 0.3s ease-in-out;
+    }
+
+    .dcr-yqz51q:before {
+      content: '';
+      display: block;
+      position: absolute;
+      right: 0;
+      top: 0;
+      bottom: 0;
+      width: 1px;
+      background-color: #506991;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-yqz51q:before {
+        bottom: 17px;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-yqz51q:before {
+        bottom: 0.6em;
+      }
+    }
+
+    .dcr-1dijbt5 {
+      font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+      font-size: 1.0625rem;
+      line-height: 1.15;
+      font-weight: 500;
+      --source-text-decoration-thickness: 2px;
+      box-sizing: border-box;
+      font-weight: 900;
+      color: #FFFFFF;
+      cursor: pointer;
+      display: block;
+      font-size: 15.4px;
+      height: 36px;
+      padding-top: 9px;
+      padding-right: 5px;
+      padding-bottom: 0;
+      padding-left: 5px;
+      position: relative;
+      overflow: hidden;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      z-index: 1;
+    }
+
+    @media (min-width: 375px) {
+      .dcr-1dijbt5 {
+        font-size: 15.7px;
+        padding-top: 9px;
+        padding-right: 5px;
+        padding-bottom: 0;
+        padding-left: 5px;
+      }
+    }
+
+    @media (min-width: 480px) {
+      .dcr-1dijbt5 {
+        font-size: 18px;
+        padding-top: 9px;
+        padding-right: 5px;
+        padding-bottom: 0;
+        padding-left: 5px;
+      }
+    }
+
+    @media (min-width: 740px) {
+      .dcr-1dijbt5 {
+        font-size: 22px;
+        height: 48px;
+        padding-top: 9px;
+        padding-right: 20px;
+        padding-bottom: 0;
+        padding-left: 9px;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-1dijbt5 {
+        padding-top: 5px;
+        height: 42px;
+      }
+    }
+
+    @media (min-width: 1300px) {
+      .dcr-1dijbt5 {
+        padding-top: 7px;
+        font-size: 24px;
+      }
+    }
+
+    .dcr-1dijbt5:focus:after {
+      -webkit-transform: translateY(4px);
+      -moz-transform: translateY(4px);
+      -ms-transform: translateY(4px);
+      transform: translateY(4px);
+    }
+
+    .dcr-1dijbt5:hover {
+      -webkit-text-decoration: none;
+      text-decoration: none;
+    }
+
+    .dcr-1dijbt5:hover:after {
+      -webkit-transform: translateY(4px);
+      -moz-transform: translateY(4px);
+      -ms-transform: translateY(4px);
+      transform: translateY(4px);
+    }
+
+    .dcr-1dijbt5:after {
+      border-top: 4px solid #00B2FF;
+      left: 0;
+      right: 1px;
+      top: -4px;
+      content: '';
+      display: block;
+      position: absolute;
+      -webkit-transition: -webkit-transform 0.3s ease-in-out;
+      transition: transform 0.3s ease-in-out;
+    }
+
+    .dcr-1dijbt5:before {
+      content: '';
+      display: block;
+      position: absolute;
+      right: 0;
+      top: 0;
+      bottom: 0;
+      width: 1px;
+      background-color: #506991;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-1dijbt5:before {
+        bottom: 17px;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-1dijbt5:before {
+        bottom: 0.6em;
+      }
+    }
+
+    .dcr-qjynpy {
+      font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+      font-size: 1.0625rem;
+      line-height: 1.15;
+      font-weight: 500;
+      --source-text-decoration-thickness: 2px;
+      box-sizing: border-box;
+      font-weight: 900;
+      color: #FFFFFF;
+      cursor: pointer;
+      display: block;
+      font-size: 15.4px;
+      height: 36px;
+      padding-top: 9px;
+      padding-right: 5px;
+      padding-bottom: 0;
+      padding-left: 5px;
+      position: relative;
+      overflow: hidden;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      z-index: 1;
+    }
+
+    @media (min-width: 375px) {
+      .dcr-qjynpy {
+        font-size: 15.7px;
+        padding-top: 9px;
+        padding-right: 5px;
+        padding-bottom: 0;
+        padding-left: 5px;
+      }
+    }
+
+    @media (min-width: 480px) {
+      .dcr-qjynpy {
+        font-size: 18px;
+        padding-top: 9px;
+        padding-right: 5px;
+        padding-bottom: 0;
+        padding-left: 5px;
+      }
+    }
+
+    @media (min-width: 740px) {
+      .dcr-qjynpy {
+        font-size: 22px;
+        height: 48px;
+        padding-top: 9px;
+        padding-right: 20px;
+        padding-bottom: 0;
+        padding-left: 9px;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-qjynpy {
+        padding-top: 5px;
+        height: 42px;
+      }
+    }
+
+    @media (min-width: 1300px) {
+      .dcr-qjynpy {
+        padding-top: 7px;
+        font-size: 24px;
+      }
+    }
+
+    .dcr-qjynpy:focus:after {
+      -webkit-transform: translateY(4px);
+      -moz-transform: translateY(4px);
+      -ms-transform: translateY(4px);
+      transform: translateY(4px);
+    }
+
+    .dcr-qjynpy:hover {
+      -webkit-text-decoration: none;
+      text-decoration: none;
+    }
+
+    .dcr-qjynpy:hover:after {
+      -webkit-transform: translateY(4px);
+      -moz-transform: translateY(4px);
+      -ms-transform: translateY(4px);
+      transform: translateY(4px);
+    }
+
+    .dcr-qjynpy:after {
+      border-top: 4px solid #EACCA0;
+      left: 0;
+      right: 1px;
+      top: -4px;
+      content: '';
+      display: block;
+      position: absolute;
+      -webkit-transition: -webkit-transform 0.3s ease-in-out;
+      transition: transform 0.3s ease-in-out;
+    }
+
+    .dcr-qjynpy:before {
+      content: '';
+      display: block;
+      position: absolute;
+      right: 0;
+      top: 0;
+      bottom: 0;
+      width: 1px;
+      background-color: #506991;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-qjynpy:before {
+        bottom: 17px;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-qjynpy:before {
+        bottom: 0.6em;
+      }
+    }
+
+    .dcr-1vrrbyb {
+      font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+      font-size: 1.0625rem;
+      line-height: 1.15;
+      font-weight: 500;
+      --source-text-decoration-thickness: 2px;
+      box-sizing: border-box;
+      font-weight: 900;
+      color: #FFFFFF;
+      cursor: pointer;
+      display: block;
+      font-size: 15.4px;
+      height: 36px;
+      padding-top: 9px;
+      padding-right: 5px;
+      padding-bottom: 0;
+      padding-left: 5px;
+      position: relative;
+      overflow: hidden;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      z-index: 1;
+    }
+
+    @media (min-width: 375px) {
+      .dcr-1vrrbyb {
+        font-size: 15.7px;
+        padding-top: 9px;
+        padding-right: 5px;
+        padding-bottom: 0;
+        padding-left: 5px;
+      }
+    }
+
+    @media (min-width: 480px) {
+      .dcr-1vrrbyb {
+        font-size: 18px;
+        padding-top: 9px;
+        padding-right: 5px;
+        padding-bottom: 0;
+        padding-left: 5px;
+      }
+    }
+
+    @media (min-width: 740px) {
+      .dcr-1vrrbyb {
+        font-size: 22px;
+        height: 48px;
+        padding-top: 9px;
+        padding-right: 20px;
+        padding-bottom: 0;
+        padding-left: 9px;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-1vrrbyb {
+        padding-top: 5px;
+        height: 42px;
+      }
+    }
+
+    @media (min-width: 1300px) {
+      .dcr-1vrrbyb {
+        padding-top: 7px;
+        font-size: 24px;
+      }
+    }
+
+    .dcr-1vrrbyb:focus:after {
+      -webkit-transform: translateY(4px);
+      -moz-transform: translateY(4px);
+      -ms-transform: translateY(4px);
+      transform: translateY(4px);
+    }
+
+    .dcr-1vrrbyb:hover {
+      -webkit-text-decoration: none;
+      text-decoration: none;
+    }
+
+    .dcr-1vrrbyb:hover:after {
+      -webkit-transform: translateY(4px);
+      -moz-transform: translateY(4px);
+      -ms-transform: translateY(4px);
+      transform: translateY(4px);
+    }
+
+    .dcr-1vrrbyb:after {
+      border-top: 4px solid #FFABDB;
+      left: 0;
+      right: 1px;
+      top: -4px;
+      content: '';
+      display: block;
+      position: absolute;
+      -webkit-transition: -webkit-transform 0.3s ease-in-out;
+      transition: transform 0.3s ease-in-out;
+    }
+
+    .dcr-1xyi04h {
+      display: grid;
+      -webkit-column-gap: 12px;
+      column-gap: 12px;
+      grid-template-areas: 'signup' 'links' 'acknowledgment';
+      clear: both;
+      width: 100%;
+      padding: 0 10px;
+      position: relative;
+      border: 1px solid #506991;
+    }
+
+    @media (min-width: 980px) {
+      .dcr-1xyi04h {
+        grid-template-columns: min-content;
+        grid-template-areas: 'signup          links' 'acknowledgment  links';
+      }
+    }
+
+    @media (min-width: 480px) {
+      .dcr-1xyi04h {
+        padding: 0 20px;
+      }
+    }
+
+    .dcr-1wf840d {
+      grid-area: signup;
+      padding-top: 8px;
+      margin-bottom: 12px;
+    }
+
+    @media (min-width: 980px) {
+      .dcr-1wf840d {
+        width: 247px;
+      }
+    }
+
+    @media (min-width: 1140px) {
+      .dcr-1wf840d {
+        width: 298px;
+      }
+    }
+
+    @media (min-width: 1300px) {
+      .dcr-1wf840d {
+        width: 458px;
+      }
+    }
+
+    .dcr-1creg26 {
+      display: -webkit-inline-box;
+      display: -webkit-inline-flex;
+      display: -ms-inline-flexbox;
+      display: inline-flex;
+      -webkit-box-pack: justify;
+      -webkit-justify-content: space-between;
+      justify-content: space-between;
+      -webkit-align-items: center;
+      -webkit-box-align: center;
+      -ms-flex-align: center;
+      align-items: center;
+      box-sizing: border-box;
+      border: none;
+      background: transparent;
+      cursor: pointer;
+      -webkit-transition: .3s ease-in-out;
+      transition: .3s ease-in-out;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      white-space: nowrap;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 1.0625rem;
+      line-height: 1.35;
+      font-weight: 700;
+      --source-text-decoration-thickness: 2px;
+      height: 36px;
+      min-height: 36px;
+      padding: 0 16px;
+      border-radius: 36px;
+      padding-bottom: 2px;
+      background-color: #052962;
+      color: #FFFFFF;
+      color: #052962;
+      background-color: #FFFFFF;
+      margin-top: 12px;
+    }
+
+    .dcr-1creg26:disabled {
+      cursor: not-allowed;
+    }
+
+    .dcr-1creg26:focus {
+      outline: 0;
+    }
+
+    html:not(.src-focus-disabled) .dcr-1creg26:focus {
+      outline: 5px solid #0077B6;
+      outline-offset: 3px;
+    }
+
+    .dcr-1creg26:hover {
+      background-color: #234B8A;
+    }
+
+    .dcr-1creg26 svg {
+      -webkit-flex: 0 0 auto;
+      -ms-flex: 0 0 auto;
+      flex: 0 0 auto;
+      display: block;
+      fill: currentColor;
+      position: relative;
+      width: 26px;
+      height: auto;
+    }
+
+    .dcr-1creg26 .src-button-space {
+      width: 8px;
+    }
+
+    .dcr-1creg26 svg {
+      margin-right: -4px;
+    }
+
+    .dcr-1creg26:hover {
+      background-color: #DCDCDC;
+    }
+
+    .dcr-ygowzy {
+      grid-area: links;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-box-flex-wrap: wrap;
+      -webkit-flex-wrap: wrap;
+      -ms-flex-wrap: wrap;
+      flex-wrap: wrap;
+      -webkit-flex-direction: row;
+      -ms-flex-direction: row;
+      flex-direction: row;
+    }
+
+    @media (max-width: 979px) {
+      .dcr-ygowzy {
+        border-top: 1px solid #506991;
+      }
+    }
+
+    .dcr-ygowzy ul {
+      width: 50%;
+      border-left: 1px solid #506991;
+      padding: 12px 0 0 10px;
+    }
+
+    .dcr-ygowzy ul:nth-of-type(1) {
+      border-left: 0 none;
+    }
+
+    @media (max-width: 739px) {
+      .dcr-ygowzy ul {
+        clear: left;
+      }
+
+      .dcr-ygowzy ul:nth-of-type(odd) {
+        border-left: 0;
+        padding-left: 0;
+      }
+
+      .dcr-ygowzy ul:nth-of-type(3) {
+        padding-top: 0;
+      }
+
+      .dcr-ygowzy ul:nth-of-type(4) {
+        padding-top: 0;
+      }
+    }
+
+    @media (min-width: 740px) {
+      .dcr-ygowzy ul {
+        margin: 0 10px 36px 0;
+        width: 150px;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-ygowzy ul:nth-of-type(1) {
+        border-left: 1px solid #506991;
+      }
+    }
+
+    .dcr-5hi9qv {
+      color: inherit;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      padding-bottom: 12px;
+      display: block;
+      line-height: 19px;
+    }
+
+    .dcr-5hi9qv:hover {
+      -webkit-text-decoration: underline;
+      text-decoration: underline;
+      color: #FFE500;
+    }
+
+    .dcr-sts64 {
+      color: inherit;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      padding-bottom: 12px;
+      display: block;
+      line-height: 19px;
+    }
+
+    .dcr-sts64:hover {
+      -webkit-text-decoration: underline;
+      text-decoration: underline;
+      color: #FFE500;
+    }
+
+    .dcr-1g9k069 {
+      border-left: 1px solid #506991;
+      -webkit-flex: 1;
+      -ms-flex: 1;
+      flex: 1;
+      padding: 12px 0 0 10px;
+      margin: 0 10px 36px 0;
+      width: calc(50% - 10px);
+    }
+
+    @media (max-width: 739px) {
+      .dcr-1g9k069 {
+        width: 50%;
+        border-top: 1px solid #506991;
+      }
+    }
+
+    .dcr-1xnlu54 {
+      background-color: #052962;
+      padding: 0 5px;
+      position: absolute;
+      bottom: -21px;
+      right: 20px;
+    }
+
+    .dcr-1bljy3y {
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      color: #FFFFFF;
+      font-weight: bold;
+      line-height: 42px;
+    }
+
+    .dcr-1bljy3y:hover {
+      color: #FFE500;
+    }
+
+    .dcr-1bljy3y:hover .icon-container {
+      background-color: #FFE500;
+    }
+
+    .dcr-4rr662 {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.9375rem;
+      line-height: 1.35;
+      font-weight: 700;
+      --source-text-decoration-thickness: 2px;
+      padding-right: 5px;
+    }
+
+    .dcr-18yycfp {
+      position: relative;
+      float: right;
+      border-radius: 100%;
+      background-color: #FFFFFF;
+      cursor: pointer;
+      height: 42px;
+      min-width: 42px;
+    }
+
+    .dcr-13lm9u3:before {
+      position: absolute;
+      top: 6px;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      margin: auto;
+      border: 2px solid #052962;
+      border-bottom: 0;
+      border-right: 0;
+      content: '';
+      height: 12px;
+      width: 12px;
+      -webkit-transform: rotate(45deg);
+      -moz-transform: rotate(45deg);
+      -ms-transform: rotate(45deg);
+      transform: rotate(45deg);
+    }
+
+    .dcr-1qbs42f {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      padding: 12px;
+      padding-left: 20px;
+    }
+
+    @media (max-width: 739px) {
+      .dcr-1qbs42f {
+        margin-top: 11px;
+      }
+    }
+  </style>
+  <link rel="stylesheet" media="print" href="https://assets.guim.co.uk/static/frontend/css/print.css">
+
+
+</head>
+
+<body>
+  <a href="#maincontent" class="dcr-vg6br7">Skip to main content</a><a href="#navigation" class="dcr-vg6br7">Skip to
+    navigation</a><gu-island name="AlreadyVisited" deferUntil="idle" props="{}" clientOnly></gu-island><gu-island
+    name="AnimatePulsingDots" deferUntil="idle" props="{}" clientOnly></gu-island><gu-island name="FocusStyles"
+    deferUntil="idle" props="{}" clientOnly></gu-island><gu-island name="Metrics" deferUntil="idle"
+    props="{&quot;commercialMetricsEnabled&quot;:true}" clientOnly></gu-island><gu-island name="FetchCommentCounts"
+    deferUntil="idle" props="{&quot;repeat&quot;:true}" clientOnly></gu-island><gu-island name="ShowHideContainers"
+    props="{}" clientOnly></gu-island><gu-island name="SetABTests"
+    props="{&quot;abTestSwitches&quot;:{&quot;abSignInGateMainVariant&quot;:true,&quot;abSignInGateCopyTestJan2023&quot;:false,&quot;abDeeplyReadArticleFooter&quot;:false,&quot;abRemoveBusinessLiveblogEpics&quot;:true,&quot;abConsentlessAds&quot;:true,&quot;abIntegrateIma&quot;:true,&quot;abSignInGateMainControl&quot;:true,&quot;abBillboardsInMerch&quot;:false,&quot;abLimitInlineMerch&quot;:true,&quot;abAdblockAsk&quot;:true,&quot;abElementsManager&quot;:true},&quot;pageIsSensitive&quot;:false,&quot;isDev&quot;:false}"
+    clientOnly></gu-island>
+  <div data-print-layout="hide" id="bannerandheader">
+    <div class="dcr-8h2mpe">
+      <section class="dcr-v339xn">
+        <div class="dcr-1s8spa1">
+          <div class="dcr-1u9kji9"><span class="dcr-1bn3p0w">
+              <div class="top-banner-ad-container dcr-zzftu">
+                <div class="ad-slot-container dcr-fks95w">
+                  <div id="dfp-ad--top-above-nav" data-link-name="ad slot top-above-nav" data-name="top-above-nav"
+                    aria-hidden="true"
+                    class="js-ad-slot ad-slot ad-slot--top-above-nav ad-slot--mpu-banner-ad ad-slot--rendered dcr-12433rp">
+                  </div>
+                </div>
+              </div>
+            </span></div>
+        </div>
+      </section>
+    </div>
+    <header class="dcr-1uyetce">
+      <div class="dcr-1s8spa1">
+        <div class="dcr-henwc"><gu-island name="HeaderTopBar"
+            props="{&quot;editionId&quot;:&quot;UK&quot;,&quot;dataLinkName&quot;:&quot;nav3 : topbar : edition-picker: toggle&quot;,&quot;idUrl&quot;:&quot;https://profile.theguardian.com&quot;,&quot;mmaUrl&quot;:&quot;https://manage.theguardian.com&quot;,&quot;discussionApiUrl&quot;:&quot;https://discussion.theguardian.com/discussion-api&quot;,&quot;idApiUrl&quot;:&quot;https://idapi.theguardian.com/&quot;,&quot;headerTopBarSearchCapiSwitch&quot;:false,&quot;isInEuropeTest&quot;:false}">
+            <div class="dcr-1kfeu4u">
+              <div class="dcr-1kvcc9o">
+                <div class="dcr-1492oy5"><a
+                    href="https://support.theguardian.com/subscribe?REFPVID=&amp;INTCMP=undefined&amp;acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentId%22%3A%22PrintSubscriptionsHeaderLink%22%2C%22componentType%22%3A%22ACQUISITIONS_HEADER%22%2C%22referrerPageviewId%22%3A%22%22%2C%22referrerUrl%22%3A%22%22%7D"
+                    data-link-name="nav3 : topbar : printsubs" class="dcr-1086n7e"><svg width="18" height="18"
+                      viewBox="-4 -4 32 32" xmlns="http://www.w3.org/2000/svg">
+                      <path
+                        d="M12,-4 a15,15 0,0,0 0,32 15,15 0,0,0 0,-32     M20 21L19 21H5L4 21V3L5 2H16L20 6V21Z     M18 8H6V9.5H18V8Z     M18 11H6V12.5H18V11Z     M13 14H6V15.5H13V14Z" />
+                    </svg>Print subscriptions</a></div>
+                <div class="dcr-bi2aot"><a
+                    href="https://profile.theguardian.com/signin?INTCMP=DOTCOM_NEWHEADER_SIGNIN&amp;ABCMP=ab-sign-in&amp;componentEventParams=componentType%3Didentityauthentication%26componentId%3Dguardian_signin_header"
+                    data-link-name="nav3 : topbar : signin" class="dcr-xg94hc"><svg width="14" height="14"
+                      viewBox="0 0 14 14">
+                      <path
+                        d="M7 0C3.1 0 0 3.1 0 7c0 2 .9 3.9 2.4 5.2C3.6 13.4 5.3 14 7 14c1.7 0 3.4-.6 4.7-1.8C13.2 10.9 14 9 14 7c0-3.9-3.1-7-7-7zm0 1.8c1.3 0 2.1.8 2.1 2.1S8 6.3 7 6.3c-.8 0-2-1.1-2-2.4 0-1.4.7-2.1 2-2.1zm0 11.6c-1.7 0-3.3-.7-4.5-1.8l.8-3.2.5-.5c1-.4 2.1-.5 3.1-.5 1.1 0 2.1.2 3.1.5l.5.5.9 3.2c-1.1 1.2-2.7 1.8-4.4 1.8z" />
+                    </svg> Sign in</a></div>
+                <div class="dcr-1gd007l"><a href="https://jobs.theguardian.com" data-link-name="nav3 : job-cta"
+                    class="dcr-1yaip4y">Search jobs</a></div>
+                <div class="dcr-1gd007l"><a href="https://www.google.co.uk/advanced_search?q=site:www.theguardian.com"
+                    data-link-name="nav3 : search" class="dcr-j7jlyl"><svg width="18" height="18" viewBox="0 0 18 18">
+                      <path
+                        d="M6.5 1.6c2.7 0 4.9 2.2 4.9 4.9s-2.2 4.9-4.9 4.9-4.9-2.2-4.9-4.9 2.2-4.9 4.9-4.9m0-1.6c-3.6 0-6.5 2.9-6.5 6.5s2.9 6.5 6.5 6.5 6.5-2.9 6.5-6.5-2.9-6.5-6.5-6.5zm6.6 11.5l4.9 4.9-1.6 1.6-4.9-4.9v-.8l.8-.8h.8z" />
+                    </svg>Search</a></div><span class="dcr-14f8c26">
+                  <div class="dcr-h39xrs">
+                    <div class="dcr-g8r8o3"><label for="checkbox-id-edition" class="dcr-pzbwhq">UK edition</label><input
+                        type="checkbox" id="checkbox-id-edition" aria-checked="false" tabIndex="-1" />
+                      <ul id="dropbox-id-edition" class="dcr-1w7ojan">
+                        <li><a href="/preference/edition/uk" data-link-name="nav3 : topbar : edition-picker: UK"
+                            class="dcr-1irynrj">UK edition</a></li>
+                        <li><a href="/preference/edition/us" data-link-name="nav3 : topbar : edition-picker: US"
+                            class="dcr-16rjsjj">US edition</a></li>
+                        <li><a href="/preference/edition/au" data-link-name="nav3 : topbar : edition-picker: AU"
+                            class="dcr-16rjsjj">Australia edition</a></li>
+                        <li><a href="/preference/edition/int" data-link-name="nav3 : topbar : edition-picker: INT"
+                            class="dcr-16rjsjj">International edition</a></li>
+                      </ul>
+                    </div>
+                  </div>
+                </span>
+              </div>
+            </div>
+          </gu-island>
+          <div class="dcr-127sebo"><gu-island name="Snow" deferUntil="hash" props="{}" clientOnly></gu-island><a
+              href="/" data-link-name="nav3 : logo" class="dcr-12xduix"><span class="dcr-1ppwqv1">The Guardian - Back to
+                home</span><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 116" aria-hidden="true" fill="none">
+                <path fill="#FFE500"
+                  d="M74 99.926h2.294l3.008 5.1c.233.401.466.834.698 1.3.244.455.46.877.649 1.267.221.466.437.926.648 1.381h.05c-.033-.477-.061-.959-.083-1.446-.022-.412-.045-.856-.067-1.332a60.14 60.14 0 0 1-.016-1.365v-4.905h1.861v11.712h-2.011l-3.308-5.669a33.815 33.815 0 0 1-.714-1.3 81.944 81.944 0 0 1-1.28-2.696h-.067l.1 1.478c.022.422.044.877.066 1.364.023.488.034.937.034 1.348v5.475H74V99.926ZM89.244 111.8c-1.463 0-2.543-.352-3.241-1.056-.687-.704-1.03-1.732-1.03-3.086v-.796c0-.715.099-1.332.298-1.852.2-.53.477-.964.831-1.299.355-.347.77-.601 1.247-.764.477-.173.997-.26 1.563-.26 1.307 0 2.249.331 2.825.991.576.661.865 1.679.865 3.054v1.088h-5.569c.011.488.072.888.183 1.202.11.304.272.542.482.715.222.173.493.292.815.357a5.76 5.76 0 0 0 1.13.098c.587 0 1.08-.054 1.48-.163.41-.119.808-.27 1.196-.454v1.413c-.3.184-.698.368-1.197.552-.487.173-1.114.26-1.878.26Zm-.35-7.651c-.232 0-.459.033-.68.098a1.29 1.29 0 0 0-.582.341c-.178.162-.322.395-.433.698-.11.293-.171.677-.182 1.154h3.59c0-.878-.144-1.479-.432-1.803-.288-.325-.715-.488-1.28-.488ZM93.42 102.85H95.5l.797 3.248c.09.347.178.759.266 1.235.09.466.167.91.233 1.332.078.498.155 1.007.233 1.527h.066c.067-.509.144-1.013.233-1.511.078-.422.16-.866.25-1.332.1-.476.199-.893.299-1.251l.897-3.248h1.795l.898 3.248c.089.347.183.759.282 1.235l.283 1.332c.1.498.188 1.007.266 1.527h.066l.233-1.511c.067-.422.139-.866.216-1.332.089-.476.178-.893.266-1.251l.781-3.248h1.812l-2.41 8.788h-2.028l-1.014-3.574a10.239 10.239 0 0 1-.266-1.121c-.066-.422-.127-.823-.183-1.202-.055-.433-.11-.882-.166-1.348h-.066c-.045.466-.094.915-.15 1.348a33.5 33.5 0 0 1-.2 1.202c-.077.422-.16.796-.249 1.121l-1.014 3.574h-2.077l-2.427-8.788ZM109.469 111.784a8.357 8.357 0 0 1-1.596-.146 5.052 5.052 0 0 1-1.297-.423v-1.559c.189.076.372.146.549.211.177.065.366.125.565.179.211.043.438.081.682.113.243.022.52.033.831.033.598 0 1.025-.081 1.28-.244a.824.824 0 0 0 .399-.731c0-.292-.073-.514-.217-.666-.133-.162-.443-.303-.93-.422l-.981-.227a4.134 4.134 0 0 1-.898-.309 2.395 2.395 0 0 1-.681-.487 2.1 2.1 0 0 1-.432-.731 3.17 3.17 0 0 1-.15-1.024c0-.812.26-1.456.781-1.933.532-.487 1.352-.731 2.46-.731.599 0 1.097.049 1.496.147.41.086.759.2 1.047.341v1.527a5.483 5.483 0 0 0-.997-.293 5.922 5.922 0 0 0-1.363-.146c-1.019 0-1.529.314-1.529.942 0 .292.078.514.233.666.166.141.443.255.831.341l.98.228c.854.195 1.452.487 1.796.877.343.39.515.969.515 1.738 0 .909-.288 1.592-.864 2.047-.577.454-1.413.682-2.51.682ZM114.412 102.85h1.928v.909h.083c.255-.314.599-.568 1.031-.763.432-.206.925-.309 1.479-.309.455 0 .887.071 1.297.211.41.13.77.352 1.08.666.31.315.554.731.732 1.251.188.509.282 1.148.282 1.917v.715c0 .779-.089 1.445-.266 1.998-.177.552-.432 1.001-.764 1.348a2.992 2.992 0 0 1-1.214.763 4.702 4.702 0 0 1-1.562.244c-.521 0-.953-.07-1.297-.211a4.212 4.212 0 0 1-.814-.471v3.817h-1.995V102.85Zm3.74 7.472c.344 0 .643-.043.898-.13.266-.087.487-.233.664-.439.178-.205.311-.476.399-.812.089-.336.133-.753.133-1.251v-.828c0-.498-.044-.91-.133-1.235-.077-.335-.199-.601-.365-.796a1.308 1.308 0 0 0-.632-.406 3.125 3.125 0 0 0-.881-.113c-.421 0-.792.059-1.114.178-.31.109-.548.222-.714.341v4.971c.166.13.404.249.714.357.311.109.654.163 1.031.163ZM126.149 111.8c-.798 0-1.44-.206-1.928-.617-.488-.412-.731-1.045-.731-1.901 0-.812.243-1.418.731-1.819.488-.412 1.169-.671 2.045-.78l1.994-.26v-.666c0-.281-.033-.514-.1-.698a.8.8 0 0 0-.332-.422c-.144-.109-.344-.185-.598-.228a5.401 5.401 0 0 0-.915-.065c-.421 0-.82.027-1.196.081-.366.055-.682.109-.948.163v-1.413c.809-.325 1.784-.488 2.926-.488 1.008 0 1.784.206 2.327.618.554.411.831 1.082.831 2.014v6.319h-1.646l-.166-.878h-.1c-.21.282-.487.526-.831.731-.343.206-.798.309-1.363.309Zm.615-1.413c.31 0 .593-.044.848-.13a1.94 1.94 0 0 0 .648-.374v-2.225l-1.546.146c-.82.076-1.23.536-1.23 1.381 0 .422.117.731.349.926.233.184.543.276.931.276ZM132.349 102.85h1.928v.909h.083c.255-.314.598-.568 1.031-.763.432-.206.925-.309 1.479-.309.454 0 .886.071 1.296.211.41.13.771.352 1.081.666.31.315.554.731.731 1.251.189.509.283 1.148.283 1.917v.715c0 .779-.089 1.445-.266 1.998-.178.552-.432 1.001-.765 1.348a2.988 2.988 0 0 1-1.213.763 4.708 4.708 0 0 1-1.563.244c-.521 0-.953-.07-1.296-.211a4.223 4.223 0 0 1-.815-.471v3.817h-1.994V102.85Zm3.74 7.472c.343 0 .642-.043.897-.13.266-.087.488-.233.665-.439.177-.205.31-.476.399-.812.089-.336.133-.753.133-1.251v-.828c0-.498-.044-.91-.133-1.235-.078-.335-.199-.601-.366-.796a1.3 1.3 0 0 0-.631-.406 3.13 3.13 0 0 0-.881-.113c-.421 0-.793.059-1.114.178-.31.109-.548.222-.715.341v4.971c.167.13.405.249.715.357.31.109.654.163 1.031.163ZM145.765 111.8c-1.463 0-2.544-.352-3.242-1.056-.687-.704-1.03-1.732-1.03-3.086v-.796c0-.715.1-1.332.299-1.852.199-.53.476-.964.831-1.299.355-.347.77-.601 1.247-.764.476-.173.997-.26 1.562-.26 1.308 0 2.25.331 2.826.991.576.661.864 1.679.864 3.054v1.088h-5.568c.011.488.072.888.183 1.202.111.304.271.542.482.715.221.173.493.292.814.357.322.065.698.098 1.131.098.587 0 1.08-.054 1.479-.163a7.98 7.98 0 0 0 1.197-.454v1.413c-.3.184-.698.368-1.197.552-.488.173-1.114.26-1.878.26Zm-.349-7.651c-.233 0-.46.033-.682.098-.21.054-.404.168-.582.341-.177.162-.321.395-.432.698-.111.293-.172.677-.183 1.154h3.591c0-.878-.144-1.479-.433-1.803-.288-.325-.714-.488-1.279-.488ZM150.673 102.85h1.911v1.202h.1c.111-.184.25-.358.416-.52a3.156 3.156 0 0 1 1.23-.698c.232-.076.465-.114.698-.114.277 0 .454.027.532.081v1.787a2.208 2.208 0 0 0-.349-.049 4.074 4.074 0 0 0-1.529.163 3.769 3.769 0 0 0-1.014.422v6.514h-1.995v-8.788ZM164.704 111.8c-1.297 0-2.305-.352-3.025-1.056-.721-.704-1.081-1.732-1.081-3.086v-.747c0-.693.105-1.3.316-1.82a3.81 3.81 0 0 1 .864-1.332 3.465 3.465 0 0 1 1.297-.796 4.81 4.81 0 0 1 1.645-.276c1.275 0 2.266.352 2.976 1.056.72.693 1.08 1.722 1.08 3.086v.748c0 .704-.105 1.321-.316 1.851-.199.52-.482.959-.847 1.316a3.58 3.58 0 0 1-1.28.796 4.942 4.942 0 0 1-1.629.26Zm.033-1.511c.632 0 1.114-.195 1.446-.584.344-.39.515-1.045.515-1.966v-.893c0-.553-.055-.997-.166-1.332-.1-.347-.244-.618-.432-.812a1.288 1.288 0 0 0-.632-.39 2.606 2.606 0 0 0-.781-.114c-.631 0-1.125.2-1.479.601-.355.401-.532 1.056-.532 1.965v.91c0 .542.05.986.149 1.332.111.336.261.601.449.796.189.184.405.314.649.39.254.065.526.097.814.097ZM171.111 104.393h-1.463v-1.543h1.463v-1.089c0-.953.266-1.651.798-2.095.543-.444 1.235-.666 2.077-.666.41 0 .759.032 1.047.097.3.055.527.125.682.212v1.364a3.477 3.477 0 0 0-.499-.081 4.522 4.522 0 0 0-.698-.049c-.465 0-.82.108-1.064.325-.232.217-.349.574-.349 1.072v.91h2.145v1.543h-2.145v7.245h-1.994v-7.245ZM183.96 111.751c-.377 0-.715-.038-1.014-.113a2.084 2.084 0 0 1-.781-.374 1.78 1.78 0 0 1-.499-.682c-.111-.293-.166-.65-.166-1.072v-5.117h-1.48v-1.543h1.48v-2.128h1.994v2.128h2.311v1.543h-2.311v4.808c0 .379.078.639.233.78.166.14.46.211.881.211.188 0 .416-.022.682-.065a2.87 2.87 0 0 0 .631-.163v1.332c-.188.12-.454.228-.798.325-.343.087-.731.13-1.163.13ZM187.327 99.146h1.995v4.597h.083a3.805 3.805 0 0 1 1.213-.747 3.934 3.934 0 0 1 1.546-.309c.831 0 1.452.19 1.862.569.421.379.632.996.632 1.852v6.53h-1.995v-6.043c0-.444-.094-.758-.283-.942-.188-.195-.57-.293-1.147-.293a3.8 3.8 0 0 0-1.013.147 4.3 4.3 0 0 0-.898.324v6.807h-1.995V99.146ZM200.565 111.8c-1.463 0-2.543-.352-3.242-1.056-.687-.704-1.03-1.732-1.03-3.086v-.796c0-.715.1-1.332.299-1.852.2-.53.477-.964.831-1.299.355-.347.77-.601 1.247-.764.476-.173.997-.26 1.562-.26 1.308 0 2.25.331 2.826.991.576.661.864 1.679.864 3.054v1.088h-5.568c.011.488.072.888.183 1.202.111.304.271.542.482.715.222.173.493.292.814.357.322.065.698.098 1.131.098.587 0 1.08-.054 1.479-.163a7.98 7.98 0 0 0 1.197-.454v1.413c-.299.184-.698.368-1.197.552-.488.173-1.114.26-1.878.26Zm-.349-7.651c-.233 0-.46.033-.682.098-.21.054-.404.168-.582.341-.177.162-.321.395-.432.698-.111.293-.172.677-.183 1.154h3.591c0-.878-.144-1.479-.432-1.803-.289-.325-.715-.488-1.28-.488ZM210.509 115c-.233 0-.482-.027-.748-.081-.255-.044-.449-.109-.582-.195v-1.381c.255.054.548.081.881.081.399 0 .726-.086.981-.26.266-.173.476-.465.631-.877l.316-.828-3.125-8.609h2.111l.981 2.859c.155.454.293.936.415 1.445.133.498.244.953.333 1.365.111.487.205.964.282 1.429h.05c.089-.465.189-.942.299-1.429.089-.412.194-.867.316-1.365.133-.509.277-.991.432-1.445l.931-2.859h1.978l-3.44 9.746c-.289.834-.665 1.44-1.131 1.819-.465.39-1.102.585-1.911.585ZM221.878 111.8c-1.463 0-2.543-.352-3.242-1.056-.687-.704-1.03-1.732-1.03-3.086v-.796c0-.715.1-1.332.299-1.852.199-.53.477-.964.831-1.299.355-.347.77-.601 1.247-.764.476-.173.997-.26 1.562-.26 1.308 0 2.25.331 2.826.991.576.661.864 1.679.864 3.054v1.088h-5.568c.011.488.072.888.183 1.202.111.304.271.542.482.715.221.173.493.292.814.357.322.065.698.098 1.131.098.587 0 1.08-.054 1.479-.163a7.98 7.98 0 0 0 1.197-.454v1.413c-.299.184-.698.368-1.197.552-.488.173-1.114.26-1.878.26Zm-.349-7.651c-.233 0-.46.033-.682.098-.21.054-.404.168-.582.341-.177.162-.321.395-.432.698-.111.293-.172.677-.183 1.154h3.591c0-.878-.144-1.479-.433-1.803-.288-.325-.714-.488-1.279-.488ZM228.997 111.8c-.798 0-1.441-.206-1.928-.617-.488-.412-.732-1.045-.732-1.901 0-.812.244-1.418.732-1.819.487-.412 1.169-.671 2.044-.78l1.995-.26v-.666c0-.281-.034-.514-.1-.698a.804.804 0 0 0-.332-.422c-.145-.109-.344-.185-.599-.228a5.388 5.388 0 0 0-.914-.065c-.421 0-.82.027-1.197.081a19.36 19.36 0 0 0-.947.163v-1.413c.809-.325 1.784-.488 2.925-.488 1.009 0 1.784.206 2.327.618.554.411.831 1.082.831 2.014v6.319h-1.645l-.166-.878h-.1a2.84 2.84 0 0 1-.831.731c-.344.206-.798.309-1.363.309Zm.615-1.413c.31 0 .593-.044.847-.13.266-.098.482-.222.649-.374v-2.225l-1.546.146c-.82.076-1.23.536-1.23 1.381 0 .422.116.731.349.926.233.184.543.276.931.276ZM235.113 102.85h1.912v1.202h.099c.111-.184.25-.358.416-.52a3.156 3.156 0 0 1 1.23-.698c.233-.076.465-.114.698-.114.277 0 .454.027.532.081v1.787a2.208 2.208 0 0 0-.349-.049 4.08 4.08 0 0 0-1.529.163 3.769 3.769 0 0 0-1.014.422v6.514h-1.995v-8.788Z">
+                </path>
+                <path fill="#fff"
+                  d="m68.131 51.554 5.152-2.675V8.502h-3.896L59.87 21.091h-1.075l.607-14.032h41.262l.596 14.032h-1.129L90.806 8.502h-3.992v40.292l5.184 2.728v1.369H68.131v-1.337Zm37.27-1.784V5.02l-4.003-1.592V2.59L115.866 0h1.522v21.175l.404-.34c3.205-2.79 7.804-4.585 12.402-4.585 6.335 0 9.134 3.567 9.134 10.211v23.31l3.386 1.835v1.36h-18.917v-1.349l3.395-1.847V26.376c0-3.65-1.596-5.116-4.598-5.116-2.002 0-3.726.627-5.004 1.646v26.917l3.332 1.837v1.295h-18.927V51.67l3.406-1.9Zm48.331-13.745c.393 7.398 3.715 13.12 11.592 13.12 3.811 0 6.515-1.763 9.06-3.1V47.5c-1.97 2.686-6.962 6.454-13.914 6.454-12.21 0-18.449-6.762-18.449-18.48 0-11.453 6.824-18.585 17.853-18.585 10.369 0 15.755 5.169 15.755 18.776v.35h-21.897v.01Zm-.203-1.698 10.742-.658c0-9.16-1.576-15.242-4.727-15.242-3.343 0-6.015 7.058-6.015 15.9ZM0 70.808C0 51.33 12.934 44.399 27.338 44.399c6.11 0 11.88.977 15.105 2.314l.277 13.597h-1.373l-8.453-13.15c-1.447-.616-2.82-.86-5.354-.86-7.654 0-11.572 8.82-11.455 23.287.15 17.301 3.162 25.156 10.188 25.156 1.831 0 3.236-.276 4.216-.7V75.498l-4.642-2.653v-1.55h22.42v1.656L43.7 75.499v18.288c-3.79 1.476-10.188 2.877-16.937 2.877C10.39 96.664 0 89.096 0 70.808Zm47.478-9.086v-1.125l15.075-2.653 1.65.138v29.614c0 3.566 1.724 4.67 4.609 4.67 1.863 0 3.545-.7 4.886-2.303V63.505l-4.13-1.784v-1.167L84.642 57.9l1.511.138v33.945l4.067 1.698v1.083L75.348 96.59l-1.511-.138v-4.458h-.416c-2.757 2.537-6.61 4.734-11.294 4.734-7.229 0-10.54-4.256-10.54-10.71V63.507l-4.109-1.785Zm95.289-3.842 1.235.138v10.964h.34c1.608-8.035 5.163-11.038 9.496-11.038.692 0 1.448.063 1.863.275v11.22c-.692-.202-1.927-.276-3.098-.276-3.438 0-5.972.615-8.197 1.634v21.675l3.428 1.9v1.4h-19.545v-1.39l3.524-1.9V62.9l-4.131-1.23v-1.01l15.085-2.78Z">
+                </path>
+                <path fill="#fff"
+                  d="M180.622 58.804v-11.57l-4.131-1.443v-.924l15.213-2.791 1.447.201v49.686l4.205 1.518v1.284l-15.01 2.016-1.171-.137v-4.108h-.34c-2.204 2.197-5.238 4.182-9.986 4.182-8.197 0-14.18-6.241-14.18-19.01 0-13.46 6.952-20.072 17.491-20.072 3.013 0 5.291.552 6.462 1.168Zm-.032 31.81V60.917c-.969-.616-1.661-1.38-4.163-1.295-4.066.138-6.578 6.273-6.578 17.184 0 9.819 1.809 15.306 7.228 15.126 1.522-.053 2.757-.595 3.513-1.316v-.002Zm33.48-32.766 1.309.138V92.46l3.439 1.9v1.4h-19.545v-1.39l3.513-1.9V63.43l-4.205-1.645v-1.147l15.489-2.79Zm1.384-9.31c0 3.642-3.098 6.38-6.675 6.38-3.715 0-6.611-2.749-6.611-6.38 0-3.64 2.896-6.453 6.611-6.453 3.577 0 6.675 2.813 6.675 6.454v-.001Zm45.999 43.934v-29.36l-4.131-1.443v-1.422l15.01-2.792 1.512.138v4.394h.415c3.236-2.887 8.059-4.734 12.807-4.734 6.536 0 9.432 3.09 9.432 9.957v25.198L300 94.36v1.4h-19.545v-1.39l3.513-1.9V67.9c0-3.778-1.65-5.285-4.748-5.285-2.001 0-3.641.51-5.163 1.634v28.213l3.438 1.9v1.4H257.94v-1.39l3.513-1.9Zm-21.685-18.448v-4.925c0-7.42-1.618-9.85-6.217-9.85-.543 0-1.011.063-1.554.137l-8.186 11.06h-1.15V60.269c3.513-1.083 7.91-2.357 13.733-2.357 10.006 0 15.829 2.77 15.829 11.124v24.01l3.588.944v.945c-1.416.88-4.258 1.687-7.377 1.687-4.94 0-7.303-1.613-8.389-4.32h-.341c-2.097 2.834-5.067 4.448-9.74 4.448-5.951 0-10.007-3.705-10.007-10.116 0-6.209 3.854-9.574 11.699-11.06l8.112-1.55Zm0 16.59v-14.84l-2.501.203c-3.929.34-5.344 2.834-5.344 8.364 0 5.997 1.958 7.557 4.737 7.557 1.554-.01 2.438-.478 3.108-1.284Zm-129.566-16.59v-4.925c0-7.42-1.618-9.85-6.227-9.85-.543 0-1.012.063-1.555.137l-8.186 11.06h-1.15V60.269c3.513-1.083 7.91-2.357 13.733-2.357 10.007 0 15.83 2.77 15.83 11.124v24.01l3.587.944v.945c-1.416.88-4.258 1.687-7.377 1.687-4.94 0-7.303-1.613-8.389-4.32h-.34c-2.097 2.834-5.078 4.448-9.741 4.448-5.95 0-10.007-3.705-10.007-10.116 0-6.209 3.854-9.574 11.7-11.06l8.122-1.55Zm0 16.59v-14.84l-2.501.203c-3.929.34-5.344 2.834-5.344 8.364 0 5.997 1.958 7.557 4.737 7.557 1.543-.01 2.427-.478 3.108-1.284Z">
+                </path>
+              </svg></a><gu-island name="SupportTheG" deferUntil="idle"
+              props="{&quot;urls&quot;:{&quot;contribute&quot;:&quot;https://support.theguardian.com/contribute?INTCMP=header_support_contribute&amp;acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22header_support_contribute%22%7D&quot;,&quot;subscribe&quot;:&quot;https://support.theguardian.com/subscribe?INTCMP=header_support_subscribe&amp;acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22header_support_subscribe%22%7D&quot;,&quot;support&quot;:&quot;https://support.theguardian.com?INTCMP=header_support&amp;acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22header_support%22%7D&quot;,&quot;supporter&quot;:&quot;https://support.theguardian.com/subscribe?INTCMP=header_supporter_cta&amp;acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22header_supporter_cta%22%7D&quot;},&quot;editionId&quot;:&quot;UK&quot;,&quot;dataLinkNamePrefix&quot;:&quot;nav3 : &quot;,&quot;inHeader&quot;:true,&quot;remoteHeader&quot;:true,&quot;contributionsServiceUrl&quot;:&quot;https://contributions.guardianapis.com&quot;}"
+              clientOnly></gu-island></div>
+        </div>
+      </div>
+    </header>
+    <nav class="dcr-1uyetce">
+      <div class="dcr-1z074wr">
+        <div class="dcr-x2bp9n">
+          <script>document.addEventListener('DOMContentLoaded', function () {
+              // Used to toggle data-link-name on label buttons
+              var navInputCheckbox = document.getElementById('top-nav-input-checkbox')
+              var showMoreButton = document.getElementById('show-more-button')
+              var veggieBurger = document.getElementById('veggie-burger')
+              var expandedMenuClickableTags = document.querySelectorAll('.selectableMenuItem')
+              var expandedMenu = document.getElementById('expanded-menu-root')
+
+              // We assume News is the 1st column
+              var firstColLabel = document.getElementById('News-button')
+              var firstColLink = document.querySelectorAll('#newsLinks > li:nth-of-type(2) > a')[0]
+
+              var focusOnFirstNavElement = function () {
+                // need to focus on first element in list, firstColLabel is not viewable on desktop
+                if (window.getComputedStyle(firstColLabel).display === 'none') {
+                  firstColLink.focus()
+                } else {
+                  firstColLabel.focus()
+                }
+              }
+
+              if (!navInputCheckbox) return; // Sticky nav replaces the nav so element no longer exists for users in test.
+
+              navInputCheckbox.addEventListener('click', function () {
+                document.body.classList.toggle('nav-is-open')
+
+                if (!navInputCheckbox.checked) {
+                  firstColLabel.setAttribute('aria-expanded', 'false')
+                  showMoreButton.setAttribute('data-link-name', 'nav2 : veggie-burger: show')
+                  veggieBurger.setAttribute('data-link-name', 'nav2 : veggie-burger: show')
+                  expandedMenuClickableTags.forEach(function ($selectableElement) {
+                    $selectableElement.setAttribute('tabindex', '-1')
+                  })
+                } else {
+                  firstColLabel.setAttribute('aria-expanded', 'true')
+                  showMoreButton.setAttribute('data-link-name', 'nav2 : veggie-burger: hide')
+                  veggieBurger.setAttribute('data-link-name', 'nav2 : veggie-burger: hide')
+                  expandedMenuClickableTags.forEach(function ($selectableElement) {
+                    $selectableElement.setAttribute('tabindex', '0')
+                  })
+                  focusOnFirstNavElement()
+                }
+              })
+              var toggleMainMenu = function (e) {
+                navInputCheckbox.click()
+              }
+              // Close hide menu on press enter
+              var keydownToggleMainMenu = function (e) {
+                // keyCode: 13 => Enter key | keyCode: 32 => Space key
+                if (e.keyCode === 13 || e.keyCode === 32) {
+                  e.preventDefault()
+                  toggleMainMenu()
+                }
+              }
+              showMoreButton.addEventListener('keydown', keydownToggleMainMenu)
+              veggieBurger.addEventListener('keydown', keydownToggleMainMenu)
+              // Accessibility to hide Nav when pressing escape key
+              document.addEventListener('keydown', function (e) {
+                // keyCode: 27 => esc
+                if (e.keyCode === 27) {
+                  if (navInputCheckbox.checked) {
+                    toggleMainMenu()
+                    if (window.getComputedStyle(veggieBurger).display === 'none') {
+                      showMoreButton.focus()
+                    } else {
+                      veggieBurger.focus()
+                    }
+                  }
+                }
+              })
+              // onBlur close dialog
+              document.addEventListener('mousedown', function (e) {
+                if (navInputCheckbox.checked && !expandedMenu.contains(e.target)) {
+                  toggleMainMenu()
+                }
+              });
+            })</script>
+          <div data-component="nav2" class="dcr-1yaxlqk"><input type="checkbox" id="top-nav-input-checkbox" name="more"
+              tabIndex="-1" aria-hidden="true" role="button" aria-expanded="false" aria-haspopup="true"
+              class="dcr-sy54ny" />
+            <ul data-testid="pillar-list" class="dcr-1ikbe4v">
+              <li class="dcr-1aeyz4o"><a id="navigation" href="/" data-link-name="nav2 : primary : News"
+                  class="dcr-h2gqsd">News</a></li>
+              <li class="dcr-1aeyz4o"><a href="/commentisfree" data-link-name="nav2 : primary : Opinion"
+                  class="dcr-c8vw16">Opinion</a></li>
+              <li class="dcr-1aeyz4o"><a href="/sport" data-link-name="nav2 : primary : Sport"
+                  class="dcr-a6bcsq">Sport</a></li>
+              <li class="dcr-1aeyz4o"><a href="/culture" data-link-name="nav2 : primary : Culture"
+                  class="dcr-1tabvac">Culture</a></li>
+              <li class="dcr-1aeyz4o"><a href="/lifeandstyle" data-link-name="nav2 : primary : Lifestyle"
+                  class="dcr-1t1n4fm">Lifestyle</a></li>
+            </ul>
+            <div id="expanded-menu-root"><label id="show-more-button" aria-label="Toggle main menu"
+                for="top-nav-input-checkbox" data-link-name="nav2 : veggie-burger: show" tabIndex="0" role="button"
+                data-cy="nav-show-more-button" class="dcr-1kuh7tf"><span class="dcr-1nvgr5i">Show</span><span
+                  class="dcr-a2u3ka">More<svg viewBox="-3 -3 30 30" xmlns="http://www.w3.org/2000/svg"
+                    aria-hidden="true">
+                    <path fill-rule="evenodd" clip-rule="evenodd"
+                      d="m1 7.224 10.498 10.498h1.004L23 7.224l-.98-.954L12 14.708 1.98 6.27 1 7.224Z"></path>
+                  </svg></span></label><label id="veggie-burger" aria-label="Toggle main menu"
+                for="top-nav-input-checkbox" data-link-name="nav2 : veggie-burger: show" tabIndex="0" role="button"
+                data-cy="veggie-burger" class="dcr-13vr4eh"><span class="dcr-1nvgr5i">Show More</span><span
+                  class="dcr-120u0k1"></span></label>
+              <div id="expanded-menu" class="dcr-mebke">
+                <div data-testid="expanded-menu" data-cy="expanded-menu" class="dcr-18m7gh9">
+                  <ul role="menubar" data-cy="nav-menu-columns" class="dcr-1kn7o79">
+                    <li role="none" class="dcr-1y4qg42">
+                      <script>document.addEventListener('DOMContentLoaded', function () {
+                          var columnInput = document.getElementById('News-button');
+
+                          if (!columnInput) return; // Sticky nav replaces the nav so element no longer exists for users in test.
+
+                          columnInput.addEventListener('keydown', function (e) {
+                            // keyCode: 13 => Enter key | keyCode: 32 => Space key
+                            if (e.keyCode === 13 || e.keyCode === 32) {
+                              e.preventDefault()
+                              document.getElementById('News-checkbox-input').click();
+                            }
+                          })
+                        })</script><input type="checkbox" id="News-checkbox-input" tabIndex="-1" aria-hidden="true"
+                        class="dcr-1acea34" /><label id="News-button" aria-label="Toggle News" for="News-checkbox-input"
+                        aria-haspopup="true" aria-controls="newsLinks" tabIndex="-1" role="menuitem"
+                        data-cy="column-collapse-News" data-link-name="nav2 : column-toggle-News: show"
+                        class="selectableMenuItem dcr-1fqnu7z">News</label>
+                      <ul role="menu" id="newsLinks" data-cy="newsLinks" class="dcr-nqw243">
+                        <li role="none" class="dcr-9ra8aa"><a href="/" role="menuitem"
+                            data-link-name="nav2 : secondary : View all News" data-cy="column-collapse-sublink-News"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">View all News</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/uk-news" role="menuitem"
+                            data-link-name="nav2 : secondary : UK news" data-cy="column-collapse-sublink-UK"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">UK news</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/world" role="menuitem"
+                            data-link-name="nav2 : secondary : World news" data-cy="column-collapse-sublink-World"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">World news</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/environment/climate-crisis" role="menuitem"
+                            data-link-name="nav2 : secondary : Climate crisis"
+                            data-cy="column-collapse-sublink-Climate crisis" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">Climate crisis</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/email-newsletters" role="menuitem"
+                            data-link-name="nav2 : secondary : Newsletters"
+                            data-cy="column-collapse-sublink-Newsletters" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">Newsletters</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/football" role="menuitem"
+                            data-link-name="nav2 : secondary : Football" data-cy="column-collapse-sublink-Football"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Football</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/world/coronavirus-outbreak" role="menuitem"
+                            data-link-name="nav2 : secondary : Coronavirus"
+                            data-cy="column-collapse-sublink-Coronavirus" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">Coronavirus</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/business" role="menuitem"
+                            data-link-name="nav2 : secondary : Business" data-cy="column-collapse-sublink-Business"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Business</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/environment" role="menuitem"
+                            data-link-name="nav2 : secondary : Environment"
+                            data-cy="column-collapse-sublink-Environment" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">Environment</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/politics" role="menuitem"
+                            data-link-name="nav2 : secondary : UK politics"
+                            data-cy="column-collapse-sublink-UK politics" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">UK politics</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/education" role="menuitem"
+                            data-link-name="nav2 : secondary : Education" data-cy="column-collapse-sublink-Education"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Education</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/society" role="menuitem"
+                            data-link-name="nav2 : secondary : Society" data-cy="column-collapse-sublink-Society"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Society</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/science" role="menuitem"
+                            data-link-name="nav2 : secondary : Science" data-cy="column-collapse-sublink-Science"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Science</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/technology" role="menuitem"
+                            data-link-name="nav2 : secondary : Tech" data-cy="column-collapse-sublink-Tech"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Tech</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/global-development" role="menuitem"
+                            data-link-name="nav2 : secondary : Global development"
+                            data-cy="column-collapse-sublink-Global development" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">Global development</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/obituaries" role="menuitem"
+                            data-link-name="nav2 : secondary : Obituaries" data-cy="column-collapse-sublink-Obituaries"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Obituaries</a></li>
+                      </ul>
+                      <div class="dcr-16d24hr"></div>
+                    </li>
+                    <li role="none" class="dcr-1y4qg42">
+                      <script>document.addEventListener('DOMContentLoaded', function () {
+                          var columnInput = document.getElementById('Opinion-button');
+
+                          if (!columnInput) return; // Sticky nav replaces the nav so element no longer exists for users in test.
+
+                          columnInput.addEventListener('keydown', function (e) {
+                            // keyCode: 13 => Enter key | keyCode: 32 => Space key
+                            if (e.keyCode === 13 || e.keyCode === 32) {
+                              e.preventDefault()
+                              document.getElementById('Opinion-checkbox-input').click();
+                            }
+                          })
+                        })</script><input type="checkbox" id="Opinion-checkbox-input" tabIndex="-1" aria-hidden="true"
+                        class="dcr-1acea34" /><label id="Opinion-button" aria-label="Toggle Opinion"
+                        for="Opinion-checkbox-input" aria-haspopup="true" aria-controls="opinionLinks" tabIndex="-1"
+                        role="menuitem" data-cy="column-collapse-Opinion"
+                        data-link-name="nav2 : column-toggle-Opinion: show"
+                        class="selectableMenuItem dcr-15vcq54">Opinion</label>
+                      <ul role="menu" id="opinionLinks" data-cy="opinionLinks" class="dcr-bu7bnv">
+                        <li role="none" class="dcr-9ra8aa"><a href="/commentisfree" role="menuitem"
+                            data-link-name="nav2 : secondary : View all Opinion"
+                            data-cy="column-collapse-sublink-Opinion" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">View all Opinion</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/profile/editorial" role="menuitem"
+                            data-link-name="nav2 : secondary : The Guardian view"
+                            data-cy="column-collapse-sublink-The Guardian view" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">The Guardian view</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/index/contributors" role="menuitem"
+                            data-link-name="nav2 : secondary : Columnists" data-cy="column-collapse-sublink-Columnists"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Columnists</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/cartoons/archive" role="menuitem"
+                            data-link-name="nav2 : secondary : Cartoons" data-cy="column-collapse-sublink-Cartoons"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Cartoons</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/type/video+tone/comment" role="menuitem"
+                            data-link-name="nav2 : secondary : Opinion videos"
+                            data-cy="column-collapse-sublink-Opinion videos" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">Opinion videos</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/tone/letters" role="menuitem"
+                            data-link-name="nav2 : secondary : Letters" data-cy="column-collapse-sublink-Letters"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Letters</a></li>
+                      </ul>
+                      <div class="dcr-1xxnrhn"></div>
+                    </li>
+                    <li role="none" class="dcr-1y4qg42">
+                      <script>document.addEventListener('DOMContentLoaded', function () {
+                          var columnInput = document.getElementById('Sport-button');
+
+                          if (!columnInput) return; // Sticky nav replaces the nav so element no longer exists for users in test.
+
+                          columnInput.addEventListener('keydown', function (e) {
+                            // keyCode: 13 => Enter key | keyCode: 32 => Space key
+                            if (e.keyCode === 13 || e.keyCode === 32) {
+                              e.preventDefault()
+                              document.getElementById('Sport-checkbox-input').click();
+                            }
+                          })
+                        })</script><input type="checkbox" id="Sport-checkbox-input" tabIndex="-1" aria-hidden="true"
+                        class="dcr-1acea34" /><label id="Sport-button" aria-label="Toggle Sport"
+                        for="Sport-checkbox-input" aria-haspopup="true" aria-controls="sportLinks" tabIndex="-1"
+                        role="menuitem" data-cy="column-collapse-Sport"
+                        data-link-name="nav2 : column-toggle-Sport: show"
+                        class="selectableMenuItem dcr-11zodys">Sport</label>
+                      <ul role="menu" id="sportLinks" data-cy="sportLinks" class="dcr-1efvfp0">
+                        <li role="none" class="dcr-9ra8aa"><a href="/sport" role="menuitem"
+                            data-link-name="nav2 : secondary : View all Sport" data-cy="column-collapse-sublink-Sport"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">View all Sport</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/football" role="menuitem"
+                            data-link-name="nav2 : secondary : Football" data-cy="column-collapse-sublink-Football"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Football</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/sport/cricket" role="menuitem"
+                            data-link-name="nav2 : secondary : Cricket" data-cy="column-collapse-sublink-Cricket"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Cricket</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/sport/rugby-union" role="menuitem"
+                            data-link-name="nav2 : secondary : Rugby union"
+                            data-cy="column-collapse-sublink-Rugby union" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">Rugby union</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/sport/tennis" role="menuitem"
+                            data-link-name="nav2 : secondary : Tennis" data-cy="column-collapse-sublink-Tennis"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Tennis</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/sport/cycling" role="menuitem"
+                            data-link-name="nav2 : secondary : Cycling" data-cy="column-collapse-sublink-Cycling"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Cycling</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/sport/formulaone" role="menuitem"
+                            data-link-name="nav2 : secondary : F1" data-cy="column-collapse-sublink-F1" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">F1</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/sport/golf" role="menuitem"
+                            data-link-name="nav2 : secondary : Golf" data-cy="column-collapse-sublink-Golf"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Golf</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/sport/boxing" role="menuitem"
+                            data-link-name="nav2 : secondary : Boxing" data-cy="column-collapse-sublink-Boxing"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Boxing</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/sport/rugbyleague" role="menuitem"
+                            data-link-name="nav2 : secondary : Rugby league"
+                            data-cy="column-collapse-sublink-Rugby league" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">Rugby league</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/sport/horse-racing" role="menuitem"
+                            data-link-name="nav2 : secondary : Racing" data-cy="column-collapse-sublink-Racing"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Racing</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/sport/us-sport" role="menuitem"
+                            data-link-name="nav2 : secondary : US sports" data-cy="column-collapse-sublink-US sports"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">US sports</a></li>
+                      </ul>
+                      <div class="dcr-xlajkp"></div>
+                    </li>
+                    <li role="none" class="dcr-1y4qg42">
+                      <script>document.addEventListener('DOMContentLoaded', function () {
+                          var columnInput = document.getElementById('Culture-button');
+
+                          if (!columnInput) return; // Sticky nav replaces the nav so element no longer exists for users in test.
+
+                          columnInput.addEventListener('keydown', function (e) {
+                            // keyCode: 13 => Enter key | keyCode: 32 => Space key
+                            if (e.keyCode === 13 || e.keyCode === 32) {
+                              e.preventDefault()
+                              document.getElementById('Culture-checkbox-input').click();
+                            }
+                          })
+                        })</script><input type="checkbox" id="Culture-checkbox-input" tabIndex="-1" aria-hidden="true"
+                        class="dcr-1acea34" /><label id="Culture-button" aria-label="Toggle Culture"
+                        for="Culture-checkbox-input" aria-haspopup="true" aria-controls="cultureLinks" tabIndex="-1"
+                        role="menuitem" data-cy="column-collapse-Culture"
+                        data-link-name="nav2 : column-toggle-Culture: show"
+                        class="selectableMenuItem dcr-hmp1vw">Culture</label>
+                      <ul role="menu" id="cultureLinks" data-cy="cultureLinks" class="dcr-1kltmkq">
+                        <li role="none" class="dcr-9ra8aa"><a href="/culture" role="menuitem"
+                            data-link-name="nav2 : secondary : View all Culture"
+                            data-cy="column-collapse-sublink-Culture" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">View all Culture</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/film" role="menuitem"
+                            data-link-name="nav2 : secondary : Film" data-cy="column-collapse-sublink-Film"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Film</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/music" role="menuitem"
+                            data-link-name="nav2 : secondary : Music" data-cy="column-collapse-sublink-Music"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Music</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/tv-and-radio" role="menuitem"
+                            data-link-name="nav2 : secondary : TV &amp; radio"
+                            data-cy="column-collapse-sublink-TV &amp; radio" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">TV &amp; radio</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/books" role="menuitem"
+                            data-link-name="nav2 : secondary : Books" data-cy="column-collapse-sublink-Books"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Books</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/artanddesign" role="menuitem"
+                            data-link-name="nav2 : secondary : Art &amp; design"
+                            data-cy="column-collapse-sublink-Art &amp; design" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">Art &amp; design</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/stage" role="menuitem"
+                            data-link-name="nav2 : secondary : Stage" data-cy="column-collapse-sublink-Stage"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Stage</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/games" role="menuitem"
+                            data-link-name="nav2 : secondary : Games" data-cy="column-collapse-sublink-Games"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Games</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/music/classicalmusicandopera" role="menuitem"
+                            data-link-name="nav2 : secondary : Classical" data-cy="column-collapse-sublink-Classical"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Classical</a></li>
+                      </ul>
+                      <div class="dcr-8lx8k9"></div>
+                    </li>
+                    <li role="none" class="dcr-1y4qg42">
+                      <script>document.addEventListener('DOMContentLoaded', function () {
+                          var columnInput = document.getElementById('Lifestyle-button');
+
+                          if (!columnInput) return; // Sticky nav replaces the nav so element no longer exists for users in test.
+
+                          columnInput.addEventListener('keydown', function (e) {
+                            // keyCode: 13 => Enter key | keyCode: 32 => Space key
+                            if (e.keyCode === 13 || e.keyCode === 32) {
+                              e.preventDefault()
+                              document.getElementById('Lifestyle-checkbox-input').click();
+                            }
+                          })
+                        })</script><input type="checkbox" id="Lifestyle-checkbox-input" tabIndex="-1" aria-hidden="true"
+                        class="dcr-1acea34" /><label id="Lifestyle-button" aria-label="Toggle Lifestyle"
+                        for="Lifestyle-checkbox-input" aria-haspopup="true" aria-controls="lifestyleLinks" tabIndex="-1"
+                        role="menuitem" data-cy="column-collapse-Lifestyle"
+                        data-link-name="nav2 : column-toggle-Lifestyle: show"
+                        class="selectableMenuItem dcr-19s2ze7">Lifestyle</label>
+                      <ul role="menu" id="lifestyleLinks" data-cy="lifestyleLinks" class="dcr-1ay3cld">
+                        <li role="none" class="dcr-9ra8aa"><a href="/lifeandstyle" role="menuitem"
+                            data-link-name="nav2 : secondary : View all Lifestyle"
+                            data-cy="column-collapse-sublink-Lifestyle" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">View all Lifestyle</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/fashion" role="menuitem"
+                            data-link-name="nav2 : secondary : Fashion" data-cy="column-collapse-sublink-Fashion"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Fashion</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/food" role="menuitem"
+                            data-link-name="nav2 : secondary : Food" data-cy="column-collapse-sublink-Food"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Food</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/tone/recipes" role="menuitem"
+                            data-link-name="nav2 : secondary : Recipes" data-cy="column-collapse-sublink-Recipes"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Recipes</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/travel" role="menuitem"
+                            data-link-name="nav2 : secondary : Travel" data-cy="column-collapse-sublink-Travel"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Travel</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/lifeandstyle/health-and-wellbeing" role="menuitem"
+                            data-link-name="nav2 : secondary : Health &amp; fitness"
+                            data-cy="column-collapse-sublink-Health &amp; fitness" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">Health &amp; fitness</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/lifeandstyle/women" role="menuitem"
+                            data-link-name="nav2 : secondary : Women" data-cy="column-collapse-sublink-Women"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Women</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/lifeandstyle/men" role="menuitem"
+                            data-link-name="nav2 : secondary : Men" data-cy="column-collapse-sublink-Men" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">Men</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/lifeandstyle/love-and-sex" role="menuitem"
+                            data-link-name="nav2 : secondary : Love &amp; sex"
+                            data-cy="column-collapse-sublink-Love &amp; sex" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">Love &amp; sex</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/fashion/beauty" role="menuitem"
+                            data-link-name="nav2 : secondary : Beauty" data-cy="column-collapse-sublink-Beauty"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Beauty</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/lifeandstyle/home-and-garden" role="menuitem"
+                            data-link-name="nav2 : secondary : Home &amp; garden"
+                            data-cy="column-collapse-sublink-Home &amp; garden" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">Home &amp; garden</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/money" role="menuitem"
+                            data-link-name="nav2 : secondary : Money" data-cy="column-collapse-sublink-Money"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Money</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/technology/motoring" role="menuitem"
+                            data-link-name="nav2 : secondary : Cars" data-cy="column-collapse-sublink-Cars"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Cars</a></li>
+                      </ul>
+                    </li>
+                    <li role="none">
+                      <form action="https://www.google.co.uk/search" class="dcr-g8v7m4"><label for="src-component-14035"
+                          class="dcr-0">
+                          <div class="dcr-19ilr9m">Search input </div>
+                        </label><input type="text" id="src-component-14035" aria-required="true" aria-invalid="false"
+                          aria-describedby required name="q" placeholder="Search" data-link-name="nav2 : search"
+                          tabIndex="-1" class="selectableMenuItem dcr-1xcf7cw" /><label class="dcr-0">
+                          <div class="dcr-19ilr9m">google-search </div>
+                          <div class="dcr-190ztmi"><svg width="30" viewBox="-3 -3 30 30"
+                              xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                              <path fill-rule="evenodd" clip-rule="evenodd"
+                                d="M9.273 2c4.023 0 7.25 3.295 7.25 7.273a7.226 7.226 0 0 1-7.25 7.25C5.25 16.523 2 13.296 2 9.273 2 5.295 5.25 2 9.273 2Zm0 1.84A5.403 5.403 0 0 0 3.84 9.274c0 3 2.409 5.454 5.432 5.454 3 0 5.454-2.454 5.454-5.454 0-3.023-2.454-5.432-5.454-5.432Zm7.295 10.887L22 20.16 20.16 22l-5.433-5.432v-.932l.91-.909h.931Z">
+                              </path>
+                            </svg><span class="dcr-1p0hins">Search</span></div>
+                        </label><button type="submit" aria-live="polite" aria-label="Search with Google"
+                          data-link-name="nav2 : search : submit" tabIndex="-1" class="dcr-a7qyd9">
+                          <div class="src-button-space"></div><svg width="30" viewBox="-3 -3 30 30"
+                            xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                            <path fill-rule="evenodd" clip-rule="evenodd"
+                              d="M1 12.956h18.274l-7.167 8.575.932.932L23 12.478v-.956l-9.96-9.985-.932.932 7.166 8.575H1v1.912Z">
+                            </path>
+                          </svg>
+                        </button><input type="hidden" name="as_sitesearch" value="www.theguardian.com" /></form>
+                      <div class="dcr-12vycz3"></div>
+                    </li>
+                    <ul role="menu" class="dcr-e1bf28">
+                      <li role="none" class="dcr-9ra8aa"><a
+                          href="https://support.theguardian.com?INTCMP=side_menu_support&amp;acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22side_menu_support%22%7D"
+                          role="menuitem" data-link-name="nav2 : secondary : Support us"
+                          data-cy="column-collapse-sublink-Support us" tabIndex="-1"
+                          class="selectableMenuItem dcr-r07hem">Support us</a></li>
+                      <li role="none" class="dcr-9ra8aa"><a
+                          href="https://support.theguardian.com/subscribe?REFPVID=&amp;INTCMP=undefined&amp;acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentId%22%3A%22PrintSubscriptionsHeaderLink%22%2C%22componentType%22%3A%22ACQUISITIONS_HEADER%22%2C%22referrerPageviewId%22%3A%22%22%2C%22referrerUrl%22%3A%22%22%7D"
+                          role="menuitem" data-link-name="nav2 : secondary : Print subscriptions"
+                          data-cy="column-collapse-sublink-Print subscriptions" tabIndex="-1"
+                          class="selectableMenuItem dcr-r07hem">Print subscriptions</a></li>
+                    </ul>
+                    <section class="dcr-e1bf28">
+                      <li role="none" class="dcr-1y4qg42">
+                        <script>document.addEventListener('DOMContentLoaded', function () {
+                            var columnInput = document.getElementById('UK-edition-button');
+
+                            if (!columnInput) return; // Sticky nav replaces the nav so element no longer exists for users in test.
+
+                            columnInput.addEventListener('keydown', function (e) {
+                              // keyCode: 13 => Enter key | keyCode: 32 => Space key
+                              if (e.keyCode === 13 || e.keyCode === 32) {
+                                e.preventDefault()
+                                document.getElementById('UK-edition-checkbox-input').click();
+                              }
+                            })
+                          })</script><input type="checkbox" id="UK-edition-checkbox-input" tabIndex="-1" aria-hidden="true"
+                          class="dcr-1acea34" /><label id="UK-edition-button" aria-label="Toggle UK edition"
+                          for="UK-edition-checkbox-input" aria-haspopup="true" aria-controls="uk-editionLinks"
+                          tabIndex="-1" role="menuitem" data-cy="column-collapse-UK edition"
+                          data-link-name="nav2 : column-toggle-UK edition: show"
+                          class="selectableMenuItem dcr-1sks1z0">UK edition</label>
+                        <ul role="menu" id="uk-editionLinks" data-cy="uk-editionLinks" class="dcr-b3zdlu">
+                          <li role="none" class="dcr-4hq641"><a href="/preference/edition/us" role="menuitem"
+                              data-link-name="nav2 : secondary : US edition"
+                              data-cy="column-collapse-sublink-US edition" tabIndex="-1"
+                              class="selectableMenuItem dcr-13wwvzl">US edition</a></li>
+                          <li role="none" class="dcr-4hq641"><a href="/preference/edition/au" role="menuitem"
+                              data-link-name="nav2 : secondary : Australia edition"
+                              data-cy="column-collapse-sublink-AU edition" tabIndex="-1"
+                              class="selectableMenuItem dcr-13wwvzl">Australia edition</a></li>
+                          <li role="none" class="dcr-4hq641"><a href="/preference/edition/int" role="menuitem"
+                              data-link-name="nav2 : secondary : International edition"
+                              data-cy="column-collapse-sublink-International edition" tabIndex="-1"
+                              class="selectableMenuItem dcr-13wwvzl">International edition</a></li>
+                        </ul>
+                      </li>
+                      <div class="dcr-12vycz3"></div>
+                    </section>
+                    <li role="none" class="dcr-jv36lp">
+                      <ul role="menu" id="moreLinks" class="dcr-17sb2rc">
+                        <li role="none" class="dcr-9ra8aa"><a href="https://jobs.theguardian.com" role="menuitem"
+                            data-link-name="nav2 : secondary : Search jobs"
+                            data-cy="column-collapse-sublink-Search jobs" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">Search jobs</a></li>
+                        <li role="none" class="dcr-9ra8aa"><a
+                            href="https://recruiters.theguardian.com/?utm_source=gdnwb&amp;utm_medium=navbar&amp;utm_campaign=Guardian_Navbar_Recruiters&amp;CMP_TU=trdmkt&amp;CMP_BUNIT=jobs"
+                            role="menuitem" data-link-name="nav2 : secondary : Hire with Guardian Jobs"
+                            data-cy="column-collapse-sublink-Hire with Guardian Jobs" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">Hire with Guardian Jobs</a></li>
+                        <li role="none" class="dcr-9ra8aa"><a
+                            href="https://holidays.theguardian.com?INTCMP=holidays_uk_web_newheader" role="menuitem"
+                            data-link-name="nav2 : secondary : Holidays" data-cy="column-collapse-sublink-Holidays"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Holidays</a></li>
+                        <li role="none" class="dcr-9ra8aa"><a
+                            href="https://membership.theguardian.com/events?INTCMP=live_uk_header_dropdown"
+                            role="menuitem" data-link-name="nav2 : secondary : Live events"
+                            data-cy="column-collapse-sublink-Live events" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">Live events</a></li>
+                        <li role="none" class="dcr-9ra8aa"><a href="/guardian-masterclasses" role="menuitem"
+                            data-link-name="nav2 : secondary : Masterclasses"
+                            data-cy="column-collapse-sublink-Masterclasses" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">Masterclasses</a></li>
+                        <li role="none" class="dcr-9ra8aa"><a href="https://theguardian.newspapers.com" role="menuitem"
+                            data-link-name="nav2 : secondary : Digital Archive"
+                            data-cy="column-collapse-sublink-Digital Archive" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">Digital Archive</a></li>
+                        <li role="none" class="dcr-9ra8aa"><a href="/artanddesign/series/gnm-print-sales"
+                            role="menuitem" data-link-name="nav2 : secondary : Guardian Print Shop"
+                            data-cy="column-collapse-sublink-Guardian Print Shop" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">Guardian Print Shop</a></li>
+                        <li role="none" class="dcr-9ra8aa"><a
+                            href="https://patrons.theguardian.com/?INTCMP=header_patrons" role="menuitem"
+                            data-link-name="nav2 : secondary : Patrons" data-cy="column-collapse-sublink-Patrons"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Patrons</a></li>
+                        <li role="none" class="dcr-9ra8aa"><a href="https://puzzles.theguardian.com/download"
+                            role="menuitem" data-link-name="nav2 : secondary : Guardian Puzzles app"
+                            data-cy="column-collapse-sublink-Guardian Puzzles app" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">Guardian Puzzles app</a></li>
+                        <li role="none" class="dcr-9ra8aa"><a href="https://licensing.theguardian.com/" role="menuitem"
+                            data-link-name="nav2 : secondary : Guardian Licensing"
+                            data-cy="column-collapse-sublink-Guardian Licensing" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">Guardian Licensing</a></li>
+                        <li role="none" class="dcr-4hq641"><a
+                            href="https://www.theguardian.com/mobile/2014/may/29/the-guardian-for-mobile-and-tablet"
+                            role="menuitem" data-link-name="nav2 : secondary : The Guardian app"
+                            data-cy="column-collapse-sublink-The Guardian app" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">The Guardian app</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/video" role="menuitem"
+                            data-link-name="nav2 : secondary : Video" data-cy="column-collapse-sublink-Video"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Video</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/podcasts" role="menuitem"
+                            data-link-name="nav2 : secondary : Podcasts" data-cy="column-collapse-sublink-Podcasts"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Podcasts</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/inpictures" role="menuitem"
+                            data-link-name="nav2 : secondary : Pictures" data-cy="column-collapse-sublink-Pictures"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Pictures</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/email-newsletters" role="menuitem"
+                            data-link-name="nav2 : secondary : Newsletters"
+                            data-cy="column-collapse-sublink-Newsletters" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">Newsletters</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/theguardian" role="menuitem"
+                            data-link-name="nav2 : secondary : Today's paper"
+                            data-cy="column-collapse-sublink-Today's paper" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">Today's paper</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="https://www.theguardian.com/membership"
+                            role="menuitem" data-link-name="nav2 : secondary : Inside the Guardian"
+                            data-cy="column-collapse-sublink-Inside the Guardian" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">Inside the Guardian</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/observer" role="menuitem"
+                            data-link-name="nav2 : secondary : The Observer"
+                            data-cy="column-collapse-sublink-The Observer" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">The Observer</a></li>
+                        <li role="none" class="dcr-4hq641"><a
+                            href="https://www.theguardian.com/weekly?INTCMP=gdnwb_mawns_editorial_gweekly_GW_TopNav_UK"
+                            role="menuitem" data-link-name="nav2 : secondary : Guardian Weekly"
+                            data-cy="column-collapse-sublink-Guardian Weekly" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">Guardian Weekly</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/crosswords" role="menuitem"
+                            data-link-name="nav2 : secondary : Crosswords" data-cy="column-collapse-sublink-Crosswords"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Crosswords</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="https://www.wordiply.com" role="menuitem"
+                            data-link-name="nav2 : secondary : Wordiply" data-cy="column-collapse-sublink-Wordiply"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Wordiply</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/theguardian/series/corrections-and-clarifications"
+                            role="menuitem" data-link-name="nav2 : secondary : Corrections"
+                            data-cy="column-collapse-sublink-Corrections" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">Corrections</a></li>
+                      </ul>
+                    </li>
+                    <li role="none" class="dcr-vwltw3">
+                      <ul role="menu" class="dcr-17sb2rc">
+                        <li role="none" class="dcr-9ra8aa"><a data-link-name="nav2 : secondary : facebook"
+                            href="https://www.facebook.com/theguardian" role="menuitem" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl"><svg width="32" height="32" viewBox="-2 -2 32 32"
+                              class="dcr-6sdrzu">
+                              <path
+                                d="M17.9 14h-3v8H12v-8h-2v-2.9h2V8.7C12 6.8 13.1 5 16 5c1.2 0 2 .1 2 .1v3h-1.8c-1 0-1.2.5-1.2 1.3v1.8h3l-.1 2.8z">
+                              </path>
+                            </svg>Facebook</a></li>
+                        <li role="none" class="dcr-9ra8aa"><a data-link-name="nav2 : secondary : twitter"
+                            href="https://twitter.com/guardian" role="menuitem" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl"><svg width="32" height="32" viewBox="-2 -2 32 32"
+                              class="dcr-6sdrzu">
+                              <path
+                                d="M21.3 10.5v.5c0 4.7-3.5 10.1-9.9 10.1-2 0-3.8-.6-5.3-1.6.3 0 .6.1.8.1 1.6 0 3.1-.6 4.3-1.5-1.5 0-2.8-1-3.3-2.4.2 0 .4.1.7.1l.9-.1c-1.6-.3-2.8-1.8-2.8-3.5.5.3 1 .4 1.6.4-.9-.6-1.6-1.7-1.6-2.9 0-.6.2-1.3.5-1.8 1.7 2.1 4.3 3.6 7.2 3.7-.1-.3-.1-.5-.1-.8 0-2 1.6-3.5 3.5-3.5 1 0 1.9.4 2.5 1.1.8-.1 1.5-.4 2.2-.8-.3.8-.8 1.5-1.5 1.9.7-.1 1.4-.3 2-.5-.4.4-1 1-1.7 1.5z">
+                              </path>
+                            </svg>Twitter</a></li>
+                      </ul>
+                    </li>
+                    <li role="none" class="dcr-pt8pb9">
+                      <ul role="menu" class="dcr-4phbzi">
+                        <li class="dcr-nnfu1a"><a href="https://jobs.theguardian.com" role="menuitem"
+                            data-link-name="nav2 : brand extension : Search jobs" tabIndex="-1"
+                            class="selectableMenuItem dcr-wzkd0n">Search jobs</a></li>
+                        <li class="dcr-nnfu1a"><a
+                            href="https://recruiters.theguardian.com/?utm_source=gdnwb&amp;utm_medium=navbar&amp;utm_campaign=Guardian_Navbar_Recruiters&amp;CMP_TU=trdmkt&amp;CMP_BUNIT=jobs"
+                            role="menuitem" data-link-name="nav2 : brand extension : Hire with Guardian Jobs"
+                            tabIndex="-1" class="selectableMenuItem dcr-wzkd0n">Hire with Guardian Jobs</a></li>
+                        <li class="dcr-nnfu1a"><a
+                            href="https://holidays.theguardian.com?INTCMP=holidays_uk_web_newheader" role="menuitem"
+                            data-link-name="nav2 : brand extension : Holidays" tabIndex="-1"
+                            class="selectableMenuItem dcr-wzkd0n">Holidays</a></li>
+                        <li class="dcr-nnfu1a"><a
+                            href="https://membership.theguardian.com/events?INTCMP=live_uk_header_dropdown"
+                            role="menuitem" data-link-name="nav2 : brand extension : Live events" tabIndex="-1"
+                            class="selectableMenuItem dcr-wzkd0n">Live events</a></li>
+                        <li class="dcr-nnfu1a"><a href="/guardian-masterclasses" role="menuitem"
+                            data-link-name="nav2 : brand extension : Masterclasses" tabIndex="-1"
+                            class="selectableMenuItem dcr-wzkd0n">Masterclasses</a></li>
+                        <li class="dcr-nnfu1a"><a href="https://theguardian.newspapers.com" role="menuitem"
+                            data-link-name="nav2 : brand extension : Digital Archive" tabIndex="-1"
+                            class="selectableMenuItem dcr-wzkd0n">Digital Archive</a></li>
+                        <li class="dcr-nnfu1a"><a href="/artanddesign/series/gnm-print-sales" role="menuitem"
+                            data-link-name="nav2 : brand extension : Guardian Print Shop" tabIndex="-1"
+                            class="selectableMenuItem dcr-wzkd0n">Guardian Print Shop</a></li>
+                        <li class="dcr-nnfu1a"><a href="https://patrons.theguardian.com/?INTCMP=header_patrons"
+                            role="menuitem" data-link-name="nav2 : brand extension : Patrons" tabIndex="-1"
+                            class="selectableMenuItem dcr-wzkd0n">Patrons</a></li>
+                        <li class="dcr-nnfu1a"><a href="https://puzzles.theguardian.com/download" role="menuitem"
+                            data-link-name="nav2 : brand extension : Guardian Puzzles app" tabIndex="-1"
+                            class="selectableMenuItem dcr-wzkd0n">Guardian Puzzles app</a></li>
+                        <li class="dcr-nnfu1a"><a href="https://licensing.theguardian.com/" role="menuitem"
+                            data-link-name="nav2 : brand extension : Guardian Licensing" tabIndex="-1"
+                            class="selectableMenuItem dcr-wzkd0n">Guardian Licensing</a></li>
+                      </ul>
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </nav>
+    <aside class="dcr-1h92x0c">
+      <div class="dcr-188zz3t"><gu-island name="SubNav" deferUntil="idle"
+          props="{&quot;subNavSections&quot;:{&quot;parent&quot;:{&quot;title&quot;:&quot;Football&quot;,&quot;longTitle&quot;:&quot;Football&quot;,&quot;url&quot;:&quot;/football&quot;,&quot;children&quot;:[{&quot;title&quot;:&quot;Live scores&quot;,&quot;longTitle&quot;:&quot;football/live&quot;,&quot;url&quot;:&quot;/football/live&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Tables&quot;,&quot;longTitle&quot;:&quot;football/tables&quot;,&quot;url&quot;:&quot;/football/tables&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Fixtures&quot;,&quot;longTitle&quot;:&quot;football/fixtures&quot;,&quot;url&quot;:&quot;/football/fixtures&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Results&quot;,&quot;longTitle&quot;:&quot;football/results&quot;,&quot;url&quot;:&quot;/football/results&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Competitions&quot;,&quot;longTitle&quot;:&quot;football/competitions&quot;,&quot;url&quot;:&quot;/football/competitions&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Clubs&quot;,&quot;longTitle&quot;:&quot;football/teams&quot;,&quot;url&quot;:&quot;/football/teams&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false}],&quot;mobileOnly&quot;:false},&quot;links&quot;:[{&quot;title&quot;:&quot;Live scores&quot;,&quot;longTitle&quot;:&quot;football/live&quot;,&quot;url&quot;:&quot;/football/live&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Tables&quot;,&quot;longTitle&quot;:&quot;football/tables&quot;,&quot;url&quot;:&quot;/football/tables&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Fixtures&quot;,&quot;longTitle&quot;:&quot;football/fixtures&quot;,&quot;url&quot;:&quot;/football/fixtures&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Results&quot;,&quot;longTitle&quot;:&quot;football/results&quot;,&quot;url&quot;:&quot;/football/results&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Competitions&quot;,&quot;longTitle&quot;:&quot;football/competitions&quot;,&quot;url&quot;:&quot;/football/competitions&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Clubs&quot;,&quot;longTitle&quot;:&quot;football/teams&quot;,&quot;url&quot;:&quot;/football/teams&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false}]},&quot;currentNavLink&quot;:&quot;Football&quot;,&quot;format&quot;:{&quot;display&quot;:0,&quot;design&quot;:0,&quot;theme&quot;:0}}">
+          <div data-print-layout="hide" data-cy="sub-nav" data-component="sub-nav" class="dcr-v6jxf0">
+            <ul role="list" class="dcr-1gt8egs">
+              <li class="dcr-izfjfz"><a data-src-focus-disabled="true" href="/football" class="dcr-qo5392">Football</a>
+              </li>
+              <li><a data-src-focus-disabled="true" href="/football/live" data-link-name="nav2 : subnav : football/live"
+                  class="dcr-qo5392">Live scores</a></li>
+              <li><a data-src-focus-disabled="true" href="/football/tables"
+                  data-link-name="nav2 : subnav : football/tables" class="dcr-qo5392">Tables</a></li>
+              <li><a data-src-focus-disabled="true" href="/football/fixtures"
+                  data-link-name="nav2 : subnav : football/fixtures" class="dcr-qo5392">Fixtures</a></li>
+              <li><a data-src-focus-disabled="true" href="/football/results"
+                  data-link-name="nav2 : subnav : football/results" class="dcr-qo5392">Results</a></li>
+              <li><a data-src-focus-disabled="true" href="/football/competitions"
+                  data-link-name="nav2 : subnav : football/competitions" class="dcr-qo5392">Competitions</a></li>
+              <li><a data-src-focus-disabled="true" href="/football/teams"
+                  data-link-name="nav2 : subnav : football/teams" class="dcr-qo5392">Clubs</a></li>
+            </ul>
+          </div>
+        </gu-island></div>
+    </aside>
+    <section class="dcr-1h92x0c">
+      <div class="dcr-188zz3t"><svg xmlns="http://www.w3.org/2000/svg" width="100%" height="13" viewBox="0 0 1300 13"
+          preserveAspectRatio="none" stroke="#DCDCDC" stroke-width="1" aria-hidden="true" focusable="false"
+          class="dcr-65xb9q">
+          <line x1="0" x2="1300" y1="0.5" y2="0.5"></line>
+          <line x1="0" x2="1300" y1="4.5" y2="4.5"></line>
+          <line x1="0" x2="1300" y1="8.5" y2="8.5"></line>
+          <line x1="0" x2="1300" y1="12.5" y2="12.5"></line>
+        </svg></div>
+    </section>
+  </div>
+  <main data-layout="FrontLayout" id="maincontent">
+    <div class="dcr-vkkuzs">
+      <section id="palette-styles-do-not-delete" data-link-name="container-0 | palette-styles-do-not-delete"
+        data-component="palette-styles-do-not-delete" data-container-name="fixed/thrasher" class="dcr-v339xn">
+        <div class="dcr-1ykr3rf">
+          <div class="dcr-1a2uz3">
+            <div class="interactive-wrapper"></div>
+          </div>
+          <div>
+            <script>!function (e) { var t = {}; function n(r) { if (t[r]) return t[r].exports; var o = t[r] = { i: r, l: !1, exports: {} }; return e[r].call(o.exports, o, o.exports, n), o.l = !0, o.exports } n.m = e, n.c = t, n.d = function (e, t, r) { n.o(e, t) || Object.defineProperty(e, t, { enumerable: !0, get: r }) }, n.r = function (e) { "undefined" != typeof Symbol && Symbol.toStringTag && Object.defineProperty(e, Symbol.toStringTag, { value: "Module" }), Object.defineProperty(e, "__esModule", { value: !0 }) }, n.t = function (e, t) { if (1 & t && (e = n(e)), 8 & t) return e; if (4 & t && "object" == typeof e && e && e.__esModule) return e; var r = Object.create(null); if (n.r(r), Object.defineProperty(r, "default", { enumerable: !0, value: e }), 2 & t && "string" != typeof e) for (var o in e) n.d(r, o, function (t) { return e[t] }.bind(null, o)); return r }, n.n = function (e) { var t = e && e.__esModule ? function () { return e.default } : function () { return e }; return n.d(t, "a", t), t }, n.o = function (e, t) { return Object.prototype.hasOwnProperty.call(e, t) }, n.p = "", n(n.s = 2) }([, , function (e, t, n) { e.exports = n(3) }, function (e, t) { var n = document.createElement("script"); n.src = "https://interactive.guim.co.uk/atoms/2022/03/29/fronts-container-colours/default/v/1680097930144/app.js", document.body.appendChild(n), setTimeout((function () { if (window.resize) { var e = document.querySelector("html"), t = document.querySelector("body"); e.style.overflow = "hidden", e.style.margin = "0px", e.style.padding = "0px", t.style.overflow = "hidden", t.style.margin = "0px", t.style.padding = "0px", window.resize() } }), 100) }]);
+//# sourceMappingURL=main.js.map</script>
+          </div>
+        </div>
+      </section>
+    </div>
+    <section id="football" data-link-name="container-1 | football" data-component="football"
+      data-container-name="dynamic/fast" class="dcr-r91ehr">
+      <div class="dcr-b25wgn"></div>
+      <div class="dcr-1kx60rc"><span class="dcr-1n8hb96"></span>
+        <div class="dcr-15t9kli"><span class="dcr-1iz7gbk"></span>
+          <div class="dcr-1atljbz">
+            <h2 class="dcr-eubdc">Football</h2>
+          </div>
+        </div>
+      </div>
+      <div class="dcr-owfrse"><button data-link-name="Hide" data-show-hide-button="football" aria-controls="football"
+          aria-expanded="true" class="dcr-kfs8io">Hide</button></div>
+      <div id="container-football" class="dcr-1lex7d6">
+        <ul class="dcr-1mi5u71">
+          <li class="dcr-w3rkaf">
+            <div class="dcr-6vr3s5"><a
+                href="/football/2023/jun/12/pep-guardiola-plans-leave-manchester-city-two-years-end-of-contract"
+                data-link-name="news | group-2+ | card-@1"
+                aria-label="Guardiola plans to leave in two years when deal expires" class="dcr-pkharf"></a>
+              <div class="dcr-1eb5jgw">
+                <div class="dcr-1pe3pea">
+                  <picture data-size="large" class="dcr-yosj9c">
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/e9f2a7d796cf47c57c52cefee3a67a82d55ce9cd/0_40_4587_2753/master/4587.jpg?width=700&amp;quality=45&amp;dpr=2&amp;s=none"
+                      media="(min-width: 980px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 980px) and (min-resolution: 120dpi)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/e9f2a7d796cf47c57c52cefee3a67a82d55ce9cd/0_40_4587_2753/master/4587.jpg?width=700&amp;quality=85&amp;dpr=1&amp;s=none"
+                      media="(min-width: 980px)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/e9f2a7d796cf47c57c52cefee3a67a82d55ce9cd/0_40_4587_2753/master/4587.jpg?width=500&amp;quality=45&amp;dpr=2&amp;s=none"
+                      media="(min-width: 740px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 740px) and (min-resolution: 120dpi)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/e9f2a7d796cf47c57c52cefee3a67a82d55ce9cd/0_40_4587_2753/master/4587.jpg?width=500&amp;quality=85&amp;dpr=1&amp;s=none"
+                      media="(min-width: 740px)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/e9f2a7d796cf47c57c52cefee3a67a82d55ce9cd/0_40_4587_2753/master/4587.jpg?width=480&amp;quality=45&amp;dpr=2&amp;s=none"
+                      media="(min-width: 480px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 480px) and (min-resolution: 120dpi)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/e9f2a7d796cf47c57c52cefee3a67a82d55ce9cd/0_40_4587_2753/master/4587.jpg?width=480&amp;quality=85&amp;dpr=1&amp;s=none"
+                      media="(min-width: 480px)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/e9f2a7d796cf47c57c52cefee3a67a82d55ce9cd/0_40_4587_2753/master/4587.jpg?width=360&amp;quality=45&amp;dpr=2&amp;s=none"
+                      media="(min-width: 320px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 320px) and (min-resolution: 120dpi)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/e9f2a7d796cf47c57c52cefee3a67a82d55ce9cd/0_40_4587_2753/master/4587.jpg?width=360&amp;quality=85&amp;dpr=1&amp;s=none"
+                      media="(min-width: 320px)" /><img alt
+                      src="https://i.guim.co.uk/img/media/e9f2a7d796cf47c57c52cefee3a67a82d55ce9cd/0_40_4587_2753/master/4587.jpg?width=360&amp;quality=85&amp;dpr=1&amp;s=none"
+                      class="dcr-evn1e9" />
+                  </picture>
+                  <div class="image-overlay"></div>
+                </div>
+                <div class="dcr-rrcudz">
+                  <div class="dcr-dbozpd">
+                    <h3 class="dcr-14gfmlq">
+                      <div class="dcr-zdnpsd">Manchester City</div><span class="show-underline dcr-adlhb4">Guardiola
+                        plans to leave in two years when deal expires</span>
+                    </h3>
+                  </div>
+                  <div>
+                    <div class="dcr-hcib8t">
+                      <div>Pep Guardiola, fresh from leading Manchester City to the treble, has all but decided that he
+                        will depart in summer 2025</div>
+                    </div>
+                    <footer class="dcr-4xb9x1">
+                      <div class="dcr-j8q3ty"></div>
+                    </footer>
+                  </div>
+                </div>
+              </div>
+              <ul class="dcr-gf0nnr">
+                <li class="dcr-z7lzm0">
+                  <h3 class="dcr-wi48h0"><a href="/football/2023/jun/12/pep-guardiola-manchester-city-future"
+                      class="dcr-os58m2">
+                      <div class="dcr-15f6w0y">Jamie Jackson</div><span class="show-underline dcr-adlhb4">What next for
+                        Guardiola after Istanbul glory?</span>
+                    </a></h3>
+                </li>
+                <li class="dcr-ibz96v">
+                  <h3 class="dcr-wi48h0"><a href="/football/2023/jun/11/manchester-city-pep-guardiola-champions-league"
+                      class="dcr-os58m2">
+                      <div class="dcr-15f6w0y">Jonathan Wilson</div><span class="show-underline dcr-adlhb4">Guardiola
+                        enters his third age as legend</span>
+                    </a></h3>
+                </li>
+                <li class="dcr-1ttos39">
+                  <h3 class="dcr-8cyqm2"><a
+                      href="/football/blog/2023/jun/11/manchester-city-champions-league-ascent-is-a-total-victory-for-politics-in-football"
+                      class="dcr-os58m2">
+                      <div class="dcr-15f6w0y">Barney Ronay</div><span class="show-underline dcr-adlhb4">City claim
+                        total victory for football politics</span>
+                    </a></h3>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li class="dcr-1cgn3lv">
+            <div class="dcr-6vr3s5"><a href="/football/2023/jun/12/silvio-berlusconi-good-for-football-milan"
+                data-link-name="feature | group-2 | card-@2"
+                aria-label="Berlusconi was good for football but the game served him well too" class="dcr-pkharf"></a>
+              <div class="dcr-17h8ziz">
+                <div class="dcr-1pb5o7w">
+                  <picture data-size="small" class="dcr-yosj9c">
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/4649df312089320aa88248b065ce7f6379e9c757/0_193_3000_1801/master/3000.jpg?width=220&amp;quality=45&amp;dpr=2&amp;s=none"
+                      media="(min-width: 980px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 980px) and (min-resolution: 120dpi)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/4649df312089320aa88248b065ce7f6379e9c757/0_193_3000_1801/master/3000.jpg?width=220&amp;quality=85&amp;dpr=1&amp;s=none"
+                      media="(min-width: 980px)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/4649df312089320aa88248b065ce7f6379e9c757/0_193_3000_1801/master/3000.jpg?width=160&amp;quality=45&amp;dpr=2&amp;s=none"
+                      media="(min-width: 740px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 740px) and (min-resolution: 120dpi)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/4649df312089320aa88248b065ce7f6379e9c757/0_193_3000_1801/master/3000.jpg?width=160&amp;quality=85&amp;dpr=1&amp;s=none"
+                      media="(min-width: 740px)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/4649df312089320aa88248b065ce7f6379e9c757/0_193_3000_1801/master/3000.jpg?width=120&amp;quality=45&amp;dpr=2&amp;s=none"
+                      media="(min-width: 320px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 320px) and (min-resolution: 120dpi)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/4649df312089320aa88248b065ce7f6379e9c757/0_193_3000_1801/master/3000.jpg?width=120&amp;quality=85&amp;dpr=1&amp;s=none"
+                      media="(min-width: 320px)" /><img alt
+                      src="https://i.guim.co.uk/img/media/4649df312089320aa88248b065ce7f6379e9c757/0_193_3000_1801/master/3000.jpg?width=120&amp;quality=85&amp;dpr=1&amp;s=none"
+                      class="dcr-evn1e9" />
+                  </picture>
+                  <div class="image-overlay"></div>
+                </div>
+                <div class="dcr-1y2cu33">
+                  <div class="dcr-dbozpd">
+                    <h3 class="dcr-p1dvl6"><svg viewBox="4 4 24 16" class="dcr-14ukgk6">
+                        <path
+                          d="M9.2776 8H14.0473C13.4732 12.5489 12.9653 17.0095 12.7445 22H4C4.79495 17.142 6.4511 12.5489 9.2776 8ZM20.3852 8H25.0887C24.5808 12.5489 24.0067 17.0095 23.7859 22H15.0635C15.9688 17.142 17.5587 12.5489 20.3852 8Z">
+                        </path>
+                      </svg><span class="show-underline dcr-adlhb4">Berlusconi was good for football but the game served
+                        him well too</span></h3><span class="dcr-wwzlz2">John Brewin</span>
+                  </div>
+                  <div>
+                    <footer class="dcr-4xb9x1">
+                      <div class="dcr-j8q3ty"></div>
+                    </footer>
+                  </div>
+                </div>
+              </div>
+              <ul class="dcr-kz9nqe">
+                <li class="dcr-1hipxkh">
+                  <h3 class="dcr-wi48h0"><a
+                      href="/world/2023/jun/12/silvio-berlusconi-former-italian-prime-minister-dies" class="dcr-os58m2">
+                      <div class="dcr-ect2dm">Silvio Berlusconi</div><span class="show-underline dcr-adlhb4">Former
+                        Milan owner and Monza chief dies</span>
+                    </a></h3>
+                </li>
+              </ul>
+            </div>
+          </li>
+        </ul>
+        <ul class="dcr-y4cf8a">
+          <li class="dcr-elbm7f">
+            <div class="dcr-6vr3s5"><a
+                href="/football/2023/jun/12/carlo-ancelotti-suing-everton-in-high-court-manager-real-madrid"
+                data-link-name="news | group-1 | card-@1"
+                aria-label="Everton sued in high court two years after leaving as manager" class="dcr-pkharf"></a>
+              <div class="dcr-17h8ziz">
+                <div class="dcr-1pb5o7w">
+                  <picture data-size="small" class="dcr-yosj9c">
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/941f41b017d1e6782c3034b74ae4e8c7e1f1ee26/930_345_3424_2055/master/3424.jpg?width=220&amp;quality=45&amp;dpr=2&amp;s=none"
+                      media="(min-width: 980px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 980px) and (min-resolution: 120dpi)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/941f41b017d1e6782c3034b74ae4e8c7e1f1ee26/930_345_3424_2055/master/3424.jpg?width=220&amp;quality=85&amp;dpr=1&amp;s=none"
+                      media="(min-width: 980px)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/941f41b017d1e6782c3034b74ae4e8c7e1f1ee26/930_345_3424_2055/master/3424.jpg?width=160&amp;quality=45&amp;dpr=2&amp;s=none"
+                      media="(min-width: 740px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 740px) and (min-resolution: 120dpi)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/941f41b017d1e6782c3034b74ae4e8c7e1f1ee26/930_345_3424_2055/master/3424.jpg?width=160&amp;quality=85&amp;dpr=1&amp;s=none"
+                      media="(min-width: 740px)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/941f41b017d1e6782c3034b74ae4e8c7e1f1ee26/930_345_3424_2055/master/3424.jpg?width=120&amp;quality=45&amp;dpr=2&amp;s=none"
+                      media="(min-width: 320px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 320px) and (min-resolution: 120dpi)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/941f41b017d1e6782c3034b74ae4e8c7e1f1ee26/930_345_3424_2055/master/3424.jpg?width=120&amp;quality=85&amp;dpr=1&amp;s=none"
+                      media="(min-width: 320px)" /><img alt
+                      src="https://i.guim.co.uk/img/media/941f41b017d1e6782c3034b74ae4e8c7e1f1ee26/930_345_3424_2055/master/3424.jpg?width=120&amp;quality=85&amp;dpr=1&amp;s=none"
+                      class="dcr-evn1e9" />
+                  </picture>
+                  <div class="image-overlay"></div>
+                </div>
+                <div class="dcr-1y2cu33">
+                  <div class="dcr-dbozpd">
+                    <h3 class="dcr-p1dvl6">
+                      <div class="dcr-zdnpsd">Carlo Ancelotti</div><span class="show-underline dcr-adlhb4">Everton sued
+                        in high court two years after leaving as manager</span>
+                    </h3>
+                  </div>
+                  <div>
+                    <footer class="dcr-4xb9x1">
+                      <div class="dcr-j8q3ty"></div>
+                    </footer>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </li>
+          <li class="dcr-1cgn3lv">
+            <div class="dcr-1e9i83y"><a href="/football/blog/2023/jun/12/germany-ukraine-friendly-uefa-europe"
+                data-link-name="comment | group-1 | card-@2"
+                aria-label="Germany’s match against Ukraine sends message of peace" class="dcr-pkharf"></a>
+              <div class="dcr-17h8ziz">
+                <div class="dcr-1pb5o7w">
+                  <picture data-size="small" class="dcr-yosj9c">
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/0be2f063eca5d742a23bc6d5f803d08f6443ab28/126_308_3374_2025/master/3374.jpg?width=220&amp;quality=45&amp;dpr=2&amp;s=none"
+                      media="(min-width: 980px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 980px) and (min-resolution: 120dpi)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/0be2f063eca5d742a23bc6d5f803d08f6443ab28/126_308_3374_2025/master/3374.jpg?width=220&amp;quality=85&amp;dpr=1&amp;s=none"
+                      media="(min-width: 980px)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/0be2f063eca5d742a23bc6d5f803d08f6443ab28/126_308_3374_2025/master/3374.jpg?width=160&amp;quality=45&amp;dpr=2&amp;s=none"
+                      media="(min-width: 740px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 740px) and (min-resolution: 120dpi)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/0be2f063eca5d742a23bc6d5f803d08f6443ab28/126_308_3374_2025/master/3374.jpg?width=160&amp;quality=85&amp;dpr=1&amp;s=none"
+                      media="(min-width: 740px)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/0be2f063eca5d742a23bc6d5f803d08f6443ab28/126_308_3374_2025/master/3374.jpg?width=120&amp;quality=45&amp;dpr=2&amp;s=none"
+                      media="(min-width: 320px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 320px) and (min-resolution: 120dpi)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/0be2f063eca5d742a23bc6d5f803d08f6443ab28/126_308_3374_2025/master/3374.jpg?width=120&amp;quality=85&amp;dpr=1&amp;s=none"
+                      media="(min-width: 320px)" /><img alt
+                      src="https://i.guim.co.uk/img/media/0be2f063eca5d742a23bc6d5f803d08f6443ab28/126_308_3374_2025/master/3374.jpg?width=120&amp;quality=85&amp;dpr=1&amp;s=none"
+                      class="dcr-evn1e9" />
+                  </picture>
+                  <div class="image-overlay"></div>
+                </div>
+                <div class="dcr-1y2cu33">
+                  <div class="dcr-dbozpd">
+                    <h3 class="dcr-p1dvl6"><svg viewBox="4 4 24 16" class="dcr-14ukgk6">
+                        <path
+                          d="M9.2776 8H14.0473C13.4732 12.5489 12.9653 17.0095 12.7445 22H4C4.79495 17.142 6.4511 12.5489 9.2776 8ZM20.3852 8H25.0887C24.5808 12.5489 24.0067 17.0095 23.7859 22H15.0635C15.9688 17.142 17.5587 12.5489 20.3852 8Z">
+                        </path>
+                      </svg><span class="show-underline dcr-adlhb4">Germany’s match against Ukraine sends message of
+                        peace</span></h3><span class="dcr-wwzlz2">Philipp Lahm</span>
+                  </div>
+                  <div></div>
+                </div>
+              </div>
+              <footer class="dcr-4xb9x1">
+                <div class="dcr-17yg843"><svg xmlns="http://www.w3.org/2000/svg" width="100%" height="13"
+                    viewBox="0 0 1300 13" preserveAspectRatio="none" stroke="#DCDCDC" stroke-width="1"
+                    aria-hidden="true" focusable="false" class="dcr-tttgpl">
+                    <line x1="0" x2="1300" y1="0.5" y2="0.5"></line>
+                    <line x1="0" x2="1300" y1="4.5" y2="4.5"></line>
+                    <line x1="0" x2="1300" y1="8.5" y2="8.5"></line>
+                    <line x1="0" x2="1300" y1="12.5" y2="12.5"></line>
+                  </svg></div>
+              </footer>
+            </div>
+          </li>
+          <li class="dcr-16fqzm2">
+            <ul class="dcr-1lcaowc">
+              <li class="dcr-avaain">
+                <div class="dcr-6vr3s5"><a
+                    href="/football/2023/jun/12/aston-villa-target-monchi-sporting-director-christian-purslow-leaves"
+                    data-link-name="news | group-0 | card-@1"
+                    aria-label="Club target Monchi as sporting director after Purslow leaves" class="dcr-pkharf"></a>
+                  <div class="dcr-17h8ziz">
+                    <div class="dcr-1y2cu33">
+                      <div class="dcr-dbozpd">
+                        <h3 class="dcr-12hccii">
+                          <div class="dcr-zdnpsd">Aston Villa</div><span class="show-underline dcr-adlhb4">Club target
+                            Monchi as sporting director after Purslow leaves</span>
+                        </h3>
+                      </div>
+                      <div>
+                        <footer class="dcr-4xb9x1">
+                          <div class="dcr-j8q3ty"></div>
+                        </footer>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </li>
+              <li class="dcr-y8nd8l">
+                <div class="dcr-6vr3s5"><a href="/football/2023/jun/12/ivan-toney-criticises-fa-charges-brentford"
+                    data-link-name="news | group-0 | card-@2" aria-label="Toney criticises FA for timing of his charges"
+                    class="dcr-pkharf"></a>
+                  <div class="dcr-17h8ziz">
+                    <div class="dcr-1y2cu33">
+                      <div class="dcr-dbozpd">
+                        <h3 class="dcr-12hccii">
+                          <div class="dcr-zdnpsd">‘A bit spiteful’</div><span class="show-underline dcr-adlhb4">Toney
+                            criticises FA for timing of his charges</span>
+                        </h3>
+                      </div>
+                      <div>
+                        <footer class="dcr-4xb9x1">
+                          <div class="dcr-j8q3ty"></div>
+                        </footer>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </li>
+              <li class="dcr-avaain">
+                <div class="dcr-6vr3s5"><a
+                    href="/football/2023/jun/12/claudio-ranieri-leads-cagliari-promoted-playoff-winner-bari"
+                    data-link-name="news | group-0 | card-@3"
+                    aria-label="Ranieri leads club back to Serie A in dramatic playoff triumph" class="dcr-pkharf"></a>
+                  <div class="dcr-17h8ziz">
+                    <div class="dcr-1y2cu33">
+                      <div class="dcr-dbozpd">
+                        <h3 class="dcr-12hccii">
+                          <div class="dcr-zdnpsd">Cagliari</div><span class="show-underline dcr-adlhb4">Ranieri leads
+                            club back to Serie A in dramatic playoff triumph</span>
+                        </h3>
+                      </div>
+                      <div>
+                        <footer class="dcr-4xb9x1">
+                          <div class="dcr-j8q3ty"></div>
+                        </footer>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </li>
+              <li class="dcr-y8nd8l">
+                <div class="dcr-6vr3s5"><a
+                    href="/football/2023/jun/12/wilfried-zaha-reject-saudi-arabia-offer-luka-modric"
+                    data-link-name="news | group-0 | card-@4"
+                    aria-label="Zaha poised to reject £30m-a-year Saudi offer but Modric may move"
+                    class="dcr-pkharf"></a>
+                  <div class="dcr-17h8ziz">
+                    <div class="dcr-1y2cu33">
+                      <div class="dcr-dbozpd">
+                        <h3 class="dcr-12hccii">
+                          <div class="dcr-zdnpsd">Transfer news</div><span class="show-underline dcr-adlhb4">Zaha poised
+                            to reject £30m-a-year Saudi offer but Modric may move</span>
+                        </h3>
+                      </div>
+                      <div>
+                        <footer class="dcr-4xb9x1">
+                          <div class="dcr-j8q3ty"></div>
+                        </footer>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </li>
+              <li class="dcr-avaain">
+                <div class="dcr-6vr3s5"><a
+                    href="/football/2023/jun/12/transfer-news-rumour-mill-tottenham-liverpool-arsenal-manchester-united"
+                    data-link-name="feature | group-0 | card-@5" aria-label="Sancho to Spurs? Ward-Prowse to Liverpool?"
+                    class="dcr-pkharf"></a>
+                  <div class="dcr-17h8ziz">
+                    <div class="dcr-1y2cu33">
+                      <div class="dcr-dbozpd">
+                        <h3 class="dcr-12hccii">
+                          <div class="dcr-zdnpsd">The Rumour Mill</div><span class="show-underline dcr-adlhb4">Sancho to
+                            Spurs? Ward-Prowse to Liverpool?</span>
+                        </h3>
+                      </div>
+                      <div>
+                        <footer class="dcr-4xb9x1">
+                          <div class="dcr-j8q3ty"></div>
+                        </footer>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </li>
+              <li class="dcr-9e78hl">
+                <div class="dcr-6vr3s5"><a
+                    href="/football/2023/jun/12/wsl-breaks-revenue-record-with-60-increase-in-2021-22-season"
+                    data-link-name="news | group-0 | card-@6"
+                    aria-label="Revenue record broken with 60% rise in 2021-22" class="dcr-pkharf"></a>
+                  <div class="dcr-17h8ziz">
+                    <div class="dcr-1y2cu33">
+                      <div class="dcr-dbozpd">
+                        <h3 class="dcr-12hccii">
+                          <div class="dcr-zdnpsd">Women's Super League</div><span
+                            class="show-underline dcr-adlhb4">Revenue record broken with 60% rise in 2021-22</span>
+                        </h3>
+                      </div>
+                      <div>
+                        <footer class="dcr-4xb9x1">
+                          <div class="dcr-j8q3ty"></div>
+                        </footer>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </li>
+            </ul>
+          </li>
+        </ul>
+      </div>
+      <div class="dcr-glvxc9"></div>
+      <div class="dcr-rdw702">
+        <ul class="dcr-1mbvac">
+          <li class="dcr-109rq7o"><a subdued href="/football/all" class="dcr-3tlap1">All stories</a></li>
+          <li class="dcr-109rq7o"><a subdued href="https://twitter.com/guardian_sport" class="dcr-3tlap1">Twitter</a>
+          </li>
+          <li class="dcr-109rq7o"><a subdued href="https://www.instagram.com/guardian_sport/"
+              class="dcr-3tlap1">Instagram</a></li>
+          <li class="dcr-109rq7o"><a subdued href="https://www.facebook.com/guardianfootball"
+              class="dcr-3tlap1">Facebook</a></li>
+          <li class="dcr-109rq7o"><a subdued href="/football/series/footballweekly" class="dcr-3tlap1">Football Weekly
+              podcast</a></li>
+          <li class="dcr-109rq7o"><a subdued
+              href="/football/2022/mar/22/sign-up-for-our-new-womens-football-newsletter-moving-the-goalposts"
+              class="dcr-3tlap1">Get our new women’s football newsletter</a></li>
+          <li class="dcr-109rq7o"><a subdued
+              href="/football/2016/jan/05/sign-up-for-the-fiver-newsletter-our-free-football-email"
+              class="dcr-3tlap1">Sign up for the Football Daily newsletter</a></li>
+        </ul>
+      </div>
+    </section><span class="dcr-12r3co1">
+      <div class="ad-slot-container dcr-1uz1ca8">
+        <div id="dfp-ad--inline1--mobile" data-link-name="ad slot inline1" data-name="inline1" aria-hidden="true"
+          class="js-ad-slot ad-slot ad-slot--inline1 ad-slot--container-inline ad-slot--mobile mobile-only ad-slot--rendered dcr-1r4i92e">
+        </div>
+      </div>
+    </span>
+    <div class="dcr-4mjixn">
+      <section data-link-name="container-2 | thrasher-preview" data-component="thrasher-preview" data-container-name="fixed/thrasher"
+        id="thrasher-preview" class="dcr-v339xn">
+        <div class="dcr-1ykr3rf">
+          <div class="dcr-tyd89o">
+            <!-- thrasher content sits in this div -->
+            <link rel="stylesheet" type="text/css" href="main.css" />
+            <div
+              id="thrasher__atom"
+              class="thrasher-inner thrasher-atom"
+              data-branch="thrashers/thrasher-atom"
+            >
+            <%= html %>
+            </div>
+          </div>
+          <div>
+            <script>
+              <%= js %>
+            </script>
+          </div>
+        </div>
+      </section>
+    </div>
+    <section id="news-and-features" data-link-name="container-3 | news-and-features" data-component="news-and-features"
+      data-container-name="fixed/medium/slow-XII-mpu" class="dcr-r91ehr">
+      <div class="dcr-b25wgn"></div>
+      <div class="dcr-1kx60rc"><span class="dcr-1n8hb96"></span>
+        <div class="dcr-15t9kli"><span class="dcr-1iz7gbk"></span>
+          <div class="dcr-1atljbz">
+            <h2 class="dcr-eubdc">News and features</h2>
+          </div>
+        </div>
+      </div>
+      <div class="dcr-owfrse"><button data-link-name="Hide" data-show-hide-button="news-and-features"
+          aria-controls="news-and-features" aria-expanded="true" class="dcr-kfs8io">Hide</button></div>
+      <div id="container-news-and-features" class="dcr-1lex7d6">
+        <ul class="dcr-1mi5u71">
+          <li class="dcr-klul57">
+            <div class="dcr-1e9i83y"><a
+                href="/football/blog/2023/jun/12/celtic-have-problems-of-their-own-making-as-they-seek-postecoglous-successor"
+                data-link-name="comment | group-2 | card-@1"
+                aria-label="Celtic have issues of their own making as they seek successor" class="dcr-pkharf"></a>
+              <div class="dcr-1a53cuj">
+                <div class="dcr-1shzr3u">
+                  <picture data-size="medium" class="dcr-yosj9c">
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/cd2ce6f2da235df765f74ade014f6aacdd13408d/0_110_3500_2101/master/3500.jpg?width=460&amp;quality=45&amp;dpr=2&amp;s=none"
+                      media="(min-width: 980px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 980px) and (min-resolution: 120dpi)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/cd2ce6f2da235df765f74ade014f6aacdd13408d/0_110_3500_2101/master/3500.jpg?width=460&amp;quality=85&amp;dpr=1&amp;s=none"
+                      media="(min-width: 980px)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/cd2ce6f2da235df765f74ade014f6aacdd13408d/0_110_3500_2101/master/3500.jpg?width=330&amp;quality=45&amp;dpr=2&amp;s=none"
+                      media="(min-width: 740px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 740px) and (min-resolution: 120dpi)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/cd2ce6f2da235df765f74ade014f6aacdd13408d/0_110_3500_2101/master/3500.jpg?width=330&amp;quality=85&amp;dpr=1&amp;s=none"
+                      media="(min-width: 740px)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/cd2ce6f2da235df765f74ade014f6aacdd13408d/0_110_3500_2101/master/3500.jpg?width=240&amp;quality=45&amp;dpr=2&amp;s=none"
+                      media="(min-width: 320px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 320px) and (min-resolution: 120dpi)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/cd2ce6f2da235df765f74ade014f6aacdd13408d/0_110_3500_2101/master/3500.jpg?width=240&amp;quality=85&amp;dpr=1&amp;s=none"
+                      media="(min-width: 320px)" /><img alt
+                      src="https://i.guim.co.uk/img/media/cd2ce6f2da235df765f74ade014f6aacdd13408d/0_110_3500_2101/master/3500.jpg?width=240&amp;quality=85&amp;dpr=1&amp;s=none"
+                      class="dcr-evn1e9" />
+                  </picture>
+                  <div class="image-overlay"></div>
+                </div>
+                <div class="dcr-1y2cu33">
+                  <div class="dcr-dbozpd">
+                    <h3 class="dcr-tosbt8"><svg viewBox="4 4 24 16" class="dcr-14ukgk6">
+                        <path
+                          d="M9.2776 8H14.0473C13.4732 12.5489 12.9653 17.0095 12.7445 22H4C4.79495 17.142 6.4511 12.5489 9.2776 8ZM20.3852 8H25.0887C24.5808 12.5489 24.0067 17.0095 23.7859 22H15.0635C15.9688 17.142 17.5587 12.5489 20.3852 8Z">
+                        </path>
+                      </svg><span class="show-underline dcr-adlhb4">Celtic have issues of their own making as they seek
+                        successor</span></h3><span class="dcr-wwzlz2">Ewan Murray</span>
+                  </div>
+                  <div>
+                    <div class="dcr-isu8nh">
+                      <div>Lower-profile manager may make more sense than bringing Rodgers back</div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <footer class="dcr-4xb9x1">
+                <div class="dcr-17yg843"><svg xmlns="http://www.w3.org/2000/svg" width="100%" height="13"
+                    viewBox="0 0 1300 13" preserveAspectRatio="none" stroke="#DCDCDC" stroke-width="1"
+                    aria-hidden="true" focusable="false" class="dcr-tttgpl">
+                    <line x1="0" x2="1300" y1="0.5" y2="0.5"></line>
+                    <line x1="0" x2="1300" y1="4.5" y2="4.5"></line>
+                    <line x1="0" x2="1300" y1="8.5" y2="8.5"></line>
+                    <line x1="0" x2="1300" y1="12.5" y2="12.5"></line>
+                  </svg><a data-discussion-id="/p/z7ee3"
+                    data-format="{&quot;display&quot;:0,&quot;theme&quot;:2,&quot;design&quot;:7}"
+                    data-ignore="global-link-styling" data-link-name="Comment count"
+                    href="/football/blog/2023/jun/12/celtic-have-problems-of-their-own-making-as-they-seek-postecoglous-successor#comments"
+                    class="dcr-1xir693"></a></div>
+              </footer>
+            </div>
+          </li>
+          <li class="dcr-vkpbou">
+            <div class="dcr-6vr3s5"><a
+                href="/football/ng-interactive/2023/jun/01/mens-transfer-window-summer-2023-premier-league-italy-spain-germany-france"
+                data-link-name="news | group-2 | card-@2" aria-label="Track all the latest moves around Europe"
+                class="dcr-pkharf"></a>
+              <div class="dcr-17h8ziz">
+                <div class="dcr-1pb5o7w">
+                  <picture data-size="medium" class="dcr-yosj9c">
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/733271505cc9352b6e1d88c797969671335b50da/190_353_2739_1644/master/2739.jpg?width=460&amp;quality=45&amp;dpr=2&amp;s=none"
+                      media="(min-width: 980px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 980px) and (min-resolution: 120dpi)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/733271505cc9352b6e1d88c797969671335b50da/190_353_2739_1644/master/2739.jpg?width=460&amp;quality=85&amp;dpr=1&amp;s=none"
+                      media="(min-width: 980px)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/733271505cc9352b6e1d88c797969671335b50da/190_353_2739_1644/master/2739.jpg?width=330&amp;quality=45&amp;dpr=2&amp;s=none"
+                      media="(min-width: 740px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 740px) and (min-resolution: 120dpi)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/733271505cc9352b6e1d88c797969671335b50da/190_353_2739_1644/master/2739.jpg?width=330&amp;quality=85&amp;dpr=1&amp;s=none"
+                      media="(min-width: 740px)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/733271505cc9352b6e1d88c797969671335b50da/190_353_2739_1644/master/2739.jpg?width=240&amp;quality=45&amp;dpr=2&amp;s=none"
+                      media="(min-width: 320px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 320px) and (min-resolution: 120dpi)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/733271505cc9352b6e1d88c797969671335b50da/190_353_2739_1644/master/2739.jpg?width=240&amp;quality=85&amp;dpr=1&amp;s=none"
+                      media="(min-width: 320px)" /><img alt
+                      src="https://i.guim.co.uk/img/media/733271505cc9352b6e1d88c797969671335b50da/190_353_2739_1644/master/2739.jpg?width=240&amp;quality=85&amp;dpr=1&amp;s=none"
+                      class="dcr-evn1e9" />
+                  </picture>
+                  <div class="image-overlay"></div>
+                </div>
+                <div class="dcr-1y2cu33">
+                  <div class="dcr-dbozpd">
+                    <h3 class="dcr-p1dvl6">
+                      <div class="dcr-zdnpsd">Men's transfer interactive</div><span
+                        class="show-underline dcr-adlhb4">Track all the latest moves around Europe</span>
+                    </h3>
+                  </div>
+                  <div>
+                    <footer class="dcr-4xb9x1">
+                      <div class="dcr-j8q3ty"></div>
+                    </footer>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </li>
+          <li class="dcr-vkpbou">
+            <div class="dcr-6vr3s5"><a
+                href="/football/ng-interactive/2023/jun/01/womens-transfer-window-summer-2023-all-deals-wsl-europe-top-five-leagues"
+                data-link-name="news | group-2 | card-@3" aria-label="Follow the summer moves from WSL and beyond"
+                class="dcr-pkharf"></a>
+              <div class="dcr-17h8ziz">
+                <div class="dcr-1pb5o7w">
+                  <picture data-size="medium" class="dcr-yosj9c">
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/21c2f96134de763d338d01e32dfb746eb8e25e42/0_972_2948_1769/master/2948.jpg?width=460&amp;quality=45&amp;dpr=2&amp;s=none"
+                      media="(min-width: 980px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 980px) and (min-resolution: 120dpi)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/21c2f96134de763d338d01e32dfb746eb8e25e42/0_972_2948_1769/master/2948.jpg?width=460&amp;quality=85&amp;dpr=1&amp;s=none"
+                      media="(min-width: 980px)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/21c2f96134de763d338d01e32dfb746eb8e25e42/0_972_2948_1769/master/2948.jpg?width=330&amp;quality=45&amp;dpr=2&amp;s=none"
+                      media="(min-width: 740px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 740px) and (min-resolution: 120dpi)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/21c2f96134de763d338d01e32dfb746eb8e25e42/0_972_2948_1769/master/2948.jpg?width=330&amp;quality=85&amp;dpr=1&amp;s=none"
+                      media="(min-width: 740px)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/21c2f96134de763d338d01e32dfb746eb8e25e42/0_972_2948_1769/master/2948.jpg?width=240&amp;quality=45&amp;dpr=2&amp;s=none"
+                      media="(min-width: 320px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 320px) and (min-resolution: 120dpi)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/21c2f96134de763d338d01e32dfb746eb8e25e42/0_972_2948_1769/master/2948.jpg?width=240&amp;quality=85&amp;dpr=1&amp;s=none"
+                      media="(min-width: 320px)" /><img alt
+                      src="https://i.guim.co.uk/img/media/21c2f96134de763d338d01e32dfb746eb8e25e42/0_972_2948_1769/master/2948.jpg?width=240&amp;quality=85&amp;dpr=1&amp;s=none"
+                      class="dcr-evn1e9" />
+                  </picture>
+                  <div class="image-overlay"></div>
+                </div>
+                <div class="dcr-1y2cu33">
+                  <div class="dcr-dbozpd">
+                    <h3 class="dcr-p1dvl6">
+                      <div class="dcr-zdnpsd">Women's transfer interactive</div><span
+                        class="show-underline dcr-adlhb4">Follow the summer moves from WSL and beyond</span>
+                    </h3>
+                  </div>
+                  <div>
+                    <footer class="dcr-4xb9x1">
+                      <div class="dcr-j8q3ty"></div>
+                    </footer>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </li>
+        </ul>
+        <ul class="dcr-1wwe1mi">
+          <li class="dcr-11xe9bu">
+            <ul class="dcr-y4cf8a">
+              <li class="dcr-avaain">
+                <div class="dcr-6vr3s5"><a
+                    href="/football/2023/jun/11/jude-bellingham-and-lewis-dunk-ruled-out-of-england-euro-2024-qualifiers"
+                    data-link-name="news | group-2 | card-@4" aria-label="Bellingham and Dunk ruled out of qualifiers"
+                    class="dcr-pkharf"></a>
+                  <div class="dcr-17h8ziz">
+                    <div class="dcr-1y2cu33">
+                      <div class="dcr-dbozpd">
+                        <h3 class="dcr-12hccii">
+                          <div class="dcr-zdnpsd">England</div><span class="show-underline dcr-adlhb4">Bellingham and
+                            Dunk ruled out of qualifiers</span>
+                        </h3>
+                      </div>
+                      <div>
+                        <footer class="dcr-4xb9x1">
+                          <div class="dcr-j8q3ty"></div>
+                        </footer>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </li>
+              <li class="dcr-y8nd8l">
+                <div class="dcr-1p6anfw"><a
+                    href="/society/2023/jun/12/wembley-dementia-friendly-measures-stadium-scheme"
+                    data-link-name="news | group-2 | card-@5" aria-label="Dementia-friendly measures introduced"
+                    class="dcr-pkharf"></a>
+                  <div class="dcr-17h8ziz">
+                    <div class="dcr-1y2cu33">
+                      <div class="dcr-dbozpd">
+                        <h3 class="dcr-12hccii">
+                          <div class="dcr-1o7trcs">Wembley</div><span
+                            class="show-underline dcr-adlhb4">Dementia-friendly measures introduced</span>
+                        </h3>
+                      </div>
+                      <div>
+                        <footer class="dcr-4xb9x1">
+                          <div class="dcr-j8q3ty"></div>
+                        </footer>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </li>
+              <li class="dcr-avaain">
+                <div class="dcr-6vr3s5"><a
+                    href="/football/2023/jun/11/uefa-treated-fans-at-istanbul-champions-league-final-like-cattle-say-supporters"
+                    data-link-name="news | group-2 | card-@6"
+                    aria-label="Uefa treated fans like ‘cattle’ at final, say supporters" class="dcr-pkharf"></a>
+                  <div class="dcr-17h8ziz">
+                    <div class="dcr-1y2cu33">
+                      <div class="dcr-dbozpd">
+                        <h3 class="dcr-12hccii">
+                          <div class="dcr-zdnpsd">Champions League</div><span class="show-underline dcr-adlhb4">Uefa
+                            treated fans like ‘cattle’ at final, say supporters</span>
+                        </h3>
+                      </div>
+                      <div>
+                        <footer class="dcr-4xb9x1">
+                          <div class="dcr-j8q3ty"></div>
+                        </footer>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </li>
+              <li class="dcr-y8nd8l">
+                <div class="dcr-6vr3s5"><a
+                    href="/football/2023/jun/10/aston-villa-sign-youri-tielemans-leicester-free-transfer"
+                    data-link-name="news | group-2 | card-@7"
+                    aria-label="Tielemans to join on free after leaving Leicester" class="dcr-pkharf"></a>
+                  <div class="dcr-17h8ziz">
+                    <div class="dcr-1y2cu33">
+                      <div class="dcr-dbozpd">
+                        <h3 class="dcr-12hccii">
+                          <div class="dcr-zdnpsd">Aston Villa</div><span class="show-underline dcr-adlhb4">Tielemans to
+                            join on free after leaving Leicester</span>
+                        </h3>
+                      </div>
+                      <div>
+                        <footer class="dcr-4xb9x1">
+                          <div class="dcr-j8q3ty"></div>
+                        </footer>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </li>
+              <li class="dcr-avaain">
+                <div class="dcr-6vr3s5"><a
+                    href="/football/2023/jun/10/manchester-city-owner-sheikh-mansour-champions-league-final"
+                    data-link-name="news | group-2 | card-@8"
+                    aria-label="City owner attends only second game in 15 years" class="dcr-pkharf"></a>
+                  <div class="dcr-17h8ziz">
+                    <div class="dcr-1y2cu33">
+                      <div class="dcr-dbozpd">
+                        <h3 class="dcr-12hccii">
+                          <div class="dcr-zdnpsd">Sheikh Mansour</div><span class="show-underline dcr-adlhb4">City owner
+                            attends only second game in 15 years</span>
+                        </h3>
+                      </div>
+                      <div>
+                        <footer class="dcr-4xb9x1">
+                          <div class="dcr-j8q3ty"></div>
+                        </footer>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </li>
+              <li class="dcr-9e78hl">
+                <div class="dcr-6vr3s5"><a
+                    href="/football/2023/jun/11/manchester-city-scrap-their-way-to-a-first-champions-league-win"
+                    data-link-name="news | group-2 | card-@9"
+                    aria-label="City scrap their way to fulfilling 'obsession'" class="dcr-pkharf"></a>
+                  <div class="dcr-17h8ziz">
+                    <div class="dcr-1y2cu33">
+                      <div class="dcr-dbozpd">
+                        <h3 class="dcr-12hccii">
+                          <div class="dcr-zdnpsd">Champions League</div><span class="show-underline dcr-adlhb4">City
+                            scrap their way to fulfilling 'obsession'</span>
+                        </h3>
+                      </div>
+                      <div>
+                        <footer class="dcr-4xb9x1">
+                          <div class="dcr-j8q3ty"></div>
+                        </footer>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </li>
+            </ul>
+          </li>
+          <li class="dcr-vkpbou"><span class="dcr-1bn3p0w">
+              <div class="ad-slot-container dcr-1uz1ca8">
+                <div id="dfp-ad--inline2" data-link-name="ad slot inline2" data-name="inline2" aria-hidden="true"
+                  class="js-ad-slot ad-slot ad-slot--inline2 ad-slot--container-inline ad-slot--rendered dcr-er9oa0">
+                </div>
+              </div>
+            </span></li>
+        </ul>
+      </div>
+      <div class="dcr-glvxc9"><gu-island name="ShowMore" deferUntil="interaction"
+          props="{&quot;title&quot;:&quot;News and features&quot;,&quot;sectionId&quot;:&quot;news-and-features&quot;,&quot;collectionId&quot;:&quot;7be00148-a3ca-44f7-bb7d-10650eaa7ad6&quot;,&quot;pageId&quot;:&quot;football&quot;,&quot;ajaxUrl&quot;:&quot;https://api.nextgen.guardianapps.co.uk&quot;,&quot;editionId&quot;:&quot;UK&quot;,&quot;showAge&quot;:false}">
+          <div id="show-more-7be00148-a3ca-44f7-bb7d-10650eaa7ad6" aria-live="polite"></div>
+          <div class="dcr-11vxpqc"><button type="button" aria-live="polite"
+              aria-controls="show-more-7be00148-a3ca-44f7-bb7d-10650eaa7ad6" aria-expanded="false"
+              aria-describedby="show-more-button-7be00148-a3ca-44f7-bb7d-10650eaa7ad6-description"
+              class="dcr-w6hc5l">More News and features<div class="src-button-space"></div><svg viewBox="-3 -3 30 30"
+                xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                <path fill-rule="evenodd" clip-rule="evenodd"
+                  d="m10.8 13.2.425 9.8h1.525l.45-9.8 9.8-.45v-1.525l-9.8-.425-.45-9.8h-1.525l-.425 9.8-9.8.425v1.525l9.8.45Z">
+                </path>
+              </svg></button><span id="show-more-button-7be00148-a3ca-44f7-bb7d-10650eaa7ad6-description"
+              class="dcr-194i6pr">Loads more stories and moves focus to first new story.</span></div>
+        </gu-island></div>
+      <div class="dcr-rdw702">
+        <ul class="dcr-1mbvac">
+          <li class="dcr-109rq7o"><a subdued href="/football/all" class="dcr-3tlap1">All stories</a></li>
+        </ul>
+      </div>
+    </section>
+  </main>
+  <section class="dcr-v339xn">
+    <div class="dcr-1v397f0">
+      <div data-link-name="keywords" class="dcr-1hy529c"><svg xmlns="http://www.w3.org/2000/svg" width="100%"
+          height="13" viewBox="0 0 1300 13" preserveAspectRatio="none" stroke="#DCDCDC" stroke-width="1"
+          aria-hidden="true" focusable="false" class="dcr-kammsl">
+          <line x1="0" x2="1300" y1="0.5" y2="0.5"></line>
+          <line x1="0" x2="1300" y1="4.5" y2="4.5"></line>
+          <line x1="0" x2="1300" y1="8.5" y2="8.5"></line>
+          <line x1="0" x2="1300" y1="12.5" y2="12.5"></line>
+        </svg>
+        <div class="dcr-c4kygy">Topics</div><a href="https://www.theguardian.com/football/manchestercity"
+          data-link-name="keyword: /football/manchestercity" class="dcr-91lgpk">Manchester City</a><a
+          href="https://www.theguardian.com/football/europeanfootball"
+          data-link-name="keyword: /football/europeanfootball" class="dcr-91lgpk">European club football</a><a
+          href="https://www.theguardian.com/football/transfer-window"
+          data-link-name="keyword: /football/transfer-window" class="dcr-91lgpk">Transfer window</a><a
+          href="https://www.theguardian.com/football/premierleague" data-link-name="keyword: /football/premierleague"
+          class="dcr-91lgpk">Premier League</a><a href="https://www.theguardian.com/football/championsleague"
+          data-link-name="keyword: /football/championsleague" class="dcr-91lgpk">Champions League</a>
+      </div>
+    </div>
+  </section>
+  <aside class="dcr-nosp2s">
+    <div class="dcr-1ykr3rf">
+      <div class="ad-slot-container dcr-10hq5cq">
+        <div id="dfp-ad--merchandising" data-link-name="ad slot merchandising" data-name="merchandising"
+          aria-hidden="true" class="js-ad-slot ad-slot ad-slot--merchandising dcr-5zzwsk"></div>
+      </div>
+    </div>
+  </aside>
+  <aside class="dcr-v339xn">
+    <div class="dcr-188zz3t"><gu-island name="SubNav" deferUntil="visible"
+        props="{&quot;subNavSections&quot;:{&quot;parent&quot;:{&quot;title&quot;:&quot;Football&quot;,&quot;longTitle&quot;:&quot;Football&quot;,&quot;url&quot;:&quot;/football&quot;,&quot;children&quot;:[{&quot;title&quot;:&quot;Live scores&quot;,&quot;longTitle&quot;:&quot;football/live&quot;,&quot;url&quot;:&quot;/football/live&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Tables&quot;,&quot;longTitle&quot;:&quot;football/tables&quot;,&quot;url&quot;:&quot;/football/tables&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Fixtures&quot;,&quot;longTitle&quot;:&quot;football/fixtures&quot;,&quot;url&quot;:&quot;/football/fixtures&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Results&quot;,&quot;longTitle&quot;:&quot;football/results&quot;,&quot;url&quot;:&quot;/football/results&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Competitions&quot;,&quot;longTitle&quot;:&quot;football/competitions&quot;,&quot;url&quot;:&quot;/football/competitions&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Clubs&quot;,&quot;longTitle&quot;:&quot;football/teams&quot;,&quot;url&quot;:&quot;/football/teams&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false}],&quot;mobileOnly&quot;:false},&quot;links&quot;:[{&quot;title&quot;:&quot;Live scores&quot;,&quot;longTitle&quot;:&quot;football/live&quot;,&quot;url&quot;:&quot;/football/live&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Tables&quot;,&quot;longTitle&quot;:&quot;football/tables&quot;,&quot;url&quot;:&quot;/football/tables&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Fixtures&quot;,&quot;longTitle&quot;:&quot;football/fixtures&quot;,&quot;url&quot;:&quot;/football/fixtures&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Results&quot;,&quot;longTitle&quot;:&quot;football/results&quot;,&quot;url&quot;:&quot;/football/results&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Competitions&quot;,&quot;longTitle&quot;:&quot;football/competitions&quot;,&quot;url&quot;:&quot;/football/competitions&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Clubs&quot;,&quot;longTitle&quot;:&quot;football/teams&quot;,&quot;url&quot;:&quot;/football/teams&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false}]},&quot;currentNavLink&quot;:&quot;Football&quot;,&quot;format&quot;:{&quot;display&quot;:0,&quot;design&quot;:0,&quot;theme&quot;:0}}">
+        <div data-print-layout="hide" data-cy="sub-nav" data-component="sub-nav" class="dcr-v6jxf0">
+          <ul role="list" class="dcr-1gt8egs">
+            <li class="dcr-izfjfz"><a data-src-focus-disabled="true" href="/football" class="dcr-qo5392">Football</a>
+            </li>
+            <li><a data-src-focus-disabled="true" href="/football/live" data-link-name="nav2 : subnav : football/live"
+                class="dcr-qo5392">Live scores</a></li>
+            <li><a data-src-focus-disabled="true" href="/football/tables"
+                data-link-name="nav2 : subnav : football/tables" class="dcr-qo5392">Tables</a></li>
+            <li><a data-src-focus-disabled="true" href="/football/fixtures"
+                data-link-name="nav2 : subnav : football/fixtures" class="dcr-qo5392">Fixtures</a></li>
+            <li><a data-src-focus-disabled="true" href="/football/results"
+                data-link-name="nav2 : subnav : football/results" class="dcr-qo5392">Results</a></li>
+            <li><a data-src-focus-disabled="true" href="/football/competitions"
+                data-link-name="nav2 : subnav : football/competitions" class="dcr-qo5392">Competitions</a></li>
+            <li><a data-src-focus-disabled="true" href="/football/teams" data-link-name="nav2 : subnav : football/teams"
+                class="dcr-qo5392">Clubs</a></li>
+          </ul>
+        </div>
+      </gu-island></div>
+  </aside>
+  <footer class="dcr-1uyetce">
+    <div class="dcr-1ykr3rf">
+      <div data-print-layout="hide" data-link-name="footer" data-component="footer" class="dcr-10rqwzg">
+        <div class="dcr-1w2x6ij">
+          <ul data-testid="pillar-list" class="dcr-1ikbe4v">
+            <li class="dcr-1aeyz4o"><a href="/" data-link-name="footer : primary : News" class="dcr-11rhxc6">News</a>
+            </li>
+            <li class="dcr-1aeyz4o"><a href="/commentisfree" data-link-name="footer : primary : Opinion"
+                class="dcr-yqz51q">Opinion</a></li>
+            <li class="dcr-1aeyz4o"><a href="/sport" data-link-name="footer : primary : Sport"
+                class="dcr-1dijbt5">Sport</a></li>
+            <li class="dcr-1aeyz4o"><a href="/culture" data-link-name="footer : primary : Culture"
+                class="dcr-qjynpy">Culture</a></li>
+            <li class="dcr-1aeyz4o"><a href="/lifeandstyle" data-link-name="footer : primary : Lifestyle"
+                class="dcr-1vrrbyb">Lifestyle</a></li>
+          </ul>
+        </div>
+        <div class="dcr-1xyi04h">
+          <div class="dcr-1wf840d">
+            <div>Original reporting and incisive analysis, direct from the Guardian every morning</div><a
+              href="https://www.theguardian.com/global/2022/sep/20/sign-up-for-the-first-edition-newsletter-our-free-news-email"
+              data-link-name="footer : morning-briefing" class="dcr-1creg26">Sign up for our email<div
+                class="src-button-space"></div><svg viewBox="-3 -3 30 30" xmlns="http://www.w3.org/2000/svg"
+                aria-hidden="true">
+                <path fill-rule="evenodd" clip-rule="evenodd"
+                  d="M1 12.956h18.274l-7.167 8.575.932.932L23 12.478v-.956l-9.96-9.985-.932.932 7.166 8.575H1v1.912Z">
+                </path>
+              </svg></a>
+          </div>
+          <div class="dcr-ygowzy">
+            <ul>
+              <li><a href="/about" data-link-name="uk : footer : about us" class="dcr-5hi9qv">About us</a></li>
+              <li><a href="/help" data-link-name="uk : footer : tech feedback" class="dcr-sts64">Help</a></li>
+              <li><a href="/info/complaints-and-corrections" data-link-name="complaints" class="dcr-5hi9qv">Complaints
+                  &amp; corrections</a></li>
+              <li><a href="https://www.theguardian.com/securedrop" data-link-name="securedrop"
+                  class="dcr-5hi9qv">SecureDrop</a></li>
+              <li><a href="https://workforus.theguardian.com" data-link-name="uk : footer : work for us"
+                  class="dcr-5hi9qv">Work for us</a></li>
+              <li><a href="/info/privacy" data-link-name="privacy" class="dcr-5hi9qv">Privacy policy</a></li>
+              <li><a href="/info/cookies" data-link-name="cookie" class="dcr-5hi9qv">Cookie policy</a></li>
+              <li><a href="/help/terms-of-service" data-link-name="terms" class="dcr-5hi9qv">Terms &amp; conditions</a>
+              </li>
+              <li><a href="/help/contact-us" data-link-name="uk : footer : contact us" class="dcr-5hi9qv">Contact us</a>
+              </li>
+            </ul>
+            <ul>
+              <li><a href="/index/subjects/a" data-link-name="uk : footer : all topics" class="dcr-5hi9qv">All
+                  topics</a></li>
+              <li><a href="/index/contributors" data-link-name="uk : footer : all contributors" class="dcr-5hi9qv">All
+                  writers</a></li>
+              <li><a href="https://uploads.guim.co.uk/2022/07/20/STL_Modern_Slavery_Statement_2022.pdf"
+                  data-link-name="uk : footer : modern slavery act statement" class="dcr-5hi9qv">Modern Slavery Act</a>
+              </li>
+              <li><a href="https://theguardian.newspapers.com" data-link-name="digital newspaper archive"
+                  class="dcr-5hi9qv">Digital newspaper archive</a></li>
+              <li><a href="https://www.facebook.com/theguardian" data-link-name="uk : footer : facebook"
+                  class="dcr-5hi9qv">Facebook</a></li>
+              <li><a href="https://www.youtube.com/user/TheGuardian" data-link-name="uk : footer : youtube"
+                  class="dcr-5hi9qv">YouTube</a></li>
+              <li><a href="https://www.instagram.com/guardian" data-link-name="uk : footer : instagram"
+                  class="dcr-5hi9qv">Instagram</a></li>
+              <li><a href="https://www.linkedin.com/company/theguardian" data-link-name="uk : footer : linkedin"
+                  class="dcr-5hi9qv">LinkedIn</a></li>
+              <li><a href="https://twitter.com/guardian" data-link-name="uk: footer : twitter"
+                  class="dcr-5hi9qv">Twitter</a></li>
+              <li><a href="/email-newsletters?INTCMP=DOTCOM_FOOTER_NEWSLETTER_UK"
+                  data-link-name="uk : footer : newsletters" class="dcr-5hi9qv">Newsletters</a></li>
+            </ul>
+            <ul>
+              <li><a href="https://advertising.theguardian.com" data-link-name="uk : footer : advertise with us"
+                  class="dcr-5hi9qv">Advertise with us</a></li>
+              <li><a href="/guardian-labs" data-link-name="uk : footer : guardian labs" class="dcr-5hi9qv">Guardian
+                  Labs</a></li>
+              <li><a href="https://jobs.theguardian.com" data-link-name="uk : footer : jobs" class="dcr-5hi9qv">Search
+                  jobs</a></li>
+              <li><a href="https://patrons.theguardian.com?INTCMP=footer_patrons" data-link-name="uk : footer : patrons"
+                  class="dcr-5hi9qv">Patrons</a></li>
+            </ul>
+            <div class="dcr-1g9k069"><gu-island name="ReaderRevenueLinks" deferUntil="visible"
+                props="{&quot;urls&quot;:{&quot;contribute&quot;:&quot;https://support.theguardian.com/contribute?INTCMP=header_support_contribute&amp;acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22header_support_contribute%22%7D&quot;,&quot;subscribe&quot;:&quot;https://support.theguardian.com/subscribe?INTCMP=header_support_subscribe&amp;acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22header_support_subscribe%22%7D&quot;,&quot;support&quot;:&quot;https://support.theguardian.com?INTCMP=header_support&amp;acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22header_support%22%7D&quot;,&quot;supporter&quot;:&quot;https://support.theguardian.com/subscribe?INTCMP=header_supporter_cta&amp;acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22header_supporter_cta%22%7D&quot;},&quot;editionId&quot;:&quot;UK&quot;,&quot;dataLinkNamePrefix&quot;:&quot;footer : &quot;,&quot;inHeader&quot;:false,&quot;remoteHeader&quot;:false,&quot;contributionsServiceUrl&quot;:&quot;https://contributions.guardianapis.com&quot;}"
+                clientOnly></gu-island></div>
+          </div>
+          <div class="dcr-1xnlu54"><a href="#top" class="dcr-1bljy3y"><span class="dcr-4rr662">Back to top</span><span
+                class="icon-container dcr-18yycfp"><i class="dcr-13lm9u3"></i></span></a></div>
+        </div>
+        <div class="dcr-1qbs42f">© 2023 Guardian News &amp; Media Limited or its affiliated companies. All rights
+          reserved. (modern)</div>
+      </div>
+    </div>
+  </footer>
+  <!-- no recipe markup -->
+</body>
+
+</html>

--- a/harness/dcr-front-uk.html
+++ b/harness/dcr-front-uk.html
@@ -43,488 +43,2831 @@ https://workforus.theguardian.com/careers/product-engineering/
         GGGGGGG   GGG     GGG        G    GGGGGG  G    G  G    G   GGGG
 
 --->
-    <title>Pandora papers | The Guardian</title>
-    <meta
-      name="description"
-      content="Latest Pandora papers news, comment and analysis from the Guardian, the world&#x27;s leading liberal voice"
-    />
-    <!-- no canonical URL -->
-    <meta charset="utf-8" />
-    <meta
-      name="viewport"
-      content="width=device-width,minimum-scale=1,initial-scale=1"
-    />
-    <meta name="theme-color" content="#052962" />
-    <link
-      rel="icon"
-      href="https://static.guim.co.uk/images/favicon-32x32.ico"
-    />
-    <link rel="preconnect" href="https://assets.guim.co.uk/" />
-    <link rel="preconnect" href="https://i.guim.co.uk" />
-    <link rel="preconnect" href="https://j.ophan.co.uk" />
-    <link rel="preconnect" href="https://ophan.theguardian.com" />
-    <link rel="preconnect" href="https://sourcepoint.theguardian.com" />
-    <link rel="dns-prefetch" href="https://assets.guim.co.uk/" />
-    <link rel="dns-prefetch" href="https://i.guim.co.uk" />
-    <link rel="dns-prefetch" href="https://j.ophan.co.uk" />
-    <link rel="dns-prefetch" href="https://ophan.theguardian.com" />
-    <link rel="dns-prefetch" href="https://api.nextgen.guardianapps.co.uk" />
-    <link rel="dns-prefetch" href="https://hits-secure.theguardian.com" />
-    <link rel="dns-prefetch" href="https://interactive.guim.co.uk" />
-    <link rel="dns-prefetch" href="https://static.theguardian.com" />
-    <link rel="dns-prefetch" href="https://support.theguardian.com" />
-    <!-- no linked data -->
-    <!-- TODO make this conditional when we support more content types -->
-    <!-- no Amp link -->
-    <link
-      rel="preload"
-      href="https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Bold.woff2?http3=true"
-      as="font"
-      crossorigin
-    />
-    <link
-      rel="preload"
-      href="https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Regular.woff2?http3=true"
-      as="font"
-      crossorigin
-    />
-    <!-- no Open Graph meta tags -->
-    <meta name="twitter:dnt" content="on" />
-    <!-- no Twitter meta tags -->
-    <!--  This tag enables pages to be featured in Google Discover as large previews
+  <title>News, sport and opinion from the Guardian's UK edition | The Guardian</title>
+  <meta name="description"
+    content="Latest news, sport, business, comment, analysis and reviews from the Guardian, the world&#x27;s leading liberal voice" />
+  <!-- no canonical URL -->
+  <meta charset="utf-8">
+
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <meta name="theme-color" content="#052962" />
+  <link rel="icon" href="https://static.guim.co.uk/images/favicon-32x32.ico">
+
+  <link rel="preconnect" href="https://assets.guim.co.uk/">
+  <link rel="preconnect" href="https://i.guim.co.uk">
+  <link rel="preconnect" href="https://j.ophan.co.uk">
+  <link rel="preconnect" href="https://ophan.theguardian.com">
+  <link rel="preconnect" href="https://sourcepoint.theguardian.com">
+  <link rel="dns-prefetch" href="https://assets.guim.co.uk/">
+  <link rel="dns-prefetch" href="https://i.guim.co.uk">
+  <link rel="dns-prefetch" href="https://j.ophan.co.uk">
+  <link rel="dns-prefetch" href="https://ophan.theguardian.com">
+  <link rel="dns-prefetch" href="https://api.nextgen.guardianapps.co.uk">
+  <link rel="dns-prefetch" href="https://hits-secure.theguardian.com">
+  <link rel="dns-prefetch" href="https://interactive.guim.co.uk">
+  <link rel="dns-prefetch" href="https://static.theguardian.com">
+  <link rel="dns-prefetch" href="https://support.theguardian.com">
+
+  <!-- no linked data -->
+
+  <!-- TODO make this conditional when we support more content types -->
+  <!-- no Amp link -->
+
+  <link rel="preload"
+    href="https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Bold.woff2?http3=true"
+    as="font" crossorigin>
+  <link rel="preload"
+    href="https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Regular.woff2?http3=true"
+    as="font" crossorigin>
+
+  <!-- no Open Graph meta tags -->
+
+  <meta name="twitter:dnt" content="on">
+
+  <!-- no Twitter meta tags -->
+
+  <!--  This tag enables pages to be featured in Google Discover as large previews
                     See: https://developers.google.com/search/docs/advanced/mobile/google-discover?hl=en&visit_id=637424198370039526-3805703503&rd=1 -->
-    <meta name="robots" content="max-image-preview:large" />
-    <script>
-      window.guardian = {
-        config: {
-          isDotcomRendering: true,
-          isDev: false,
-          stage: 'PROD',
-          frontendAssetsFullURL: 'https://assets.guim.co.uk/',
-          page: {
-            avatarApiUrl: 'https://avatar.theguardian.com',
-            externalEmbedHost: 'https://embed.theguardian.com',
-            ajaxUrl: 'https://api.nextgen.guardianapps.co.uk',
-            keywords: 'Pandora papers',
-            revisionNumber: '2eae12f734780efb2eb68700401a4aa3238103a4',
-            isProd: true,
-            switches: {
-              prebidAppnexusUkRow: true,
-              mobileStickyPrebid: true,
-              newsletterOnwards: false,
-              abSignInGateMainVariant: true,
-              commercialMetrics: true,
-              prebidTrustx: true,
-              scAdFreeBanner: false,
-              abSignInGateCopyTestJan2023: false,
-              frontsBannerAds: false,
-              prebidPermutiveAudience: true,
-              compareVariantDecision: false,
-              adFreeStrictExpiryEnforcement: false,
-              enableSentryReporting: true,
-              lazyLoadContainers: true,
-              ampArticleSwitch: true,
-              remarketing: true,
-              keyEventsCarousel: true,
-              fetchNonRefreshableLineItems: true,
-              actionCardRedesign: true,
-              registerWithPhone: false,
-              targeting: true,
-              remoteHeader: true,
-              slotBodyEnd: true,
-              prebidImproveDigitalSkins: true,
-              ampPrebidOzone: true,
-              extendedMostPopularFronts: true,
-              emailInlineInFooter: true,
-              showNewPrivacyWordingOnEmailSignupEmbeds: true,
-              iasAdTargeting: true,
-              prebidAnalytics: true,
-              extendedMostPopular: true,
-              ampContentAbTesting: false,
-              okta: true,
-              abDeeplyReadArticleFooter: false,
-              puzzlesBanner: false,
-              prebidCriteo: true,
-              dcrFronts: true,
-              imrWorldwide: true,
-              acast: true,
-              automaticFilters: true,
-              twitterUwt: true,
-              prebidAppnexusInvcode: true,
-              ampPrebidPubmatic: true,
-              a9HeaderBidding: true,
-              prebidAppnexus: true,
-              enableDiscussionSwitch: true,
-              prebidXaxis: true,
-              stickyVideos: true,
-              abRemoveBusinessLiveblogEpics: false,
-              interactiveFullHeaderSwitch: true,
-              discussionAllPageSize: true,
-              prebidUserSync: true,
-              audioOnwardJourneySwitch: true,
-              dcrJavascriptBundle: true,
-              brazeTaylorReport: false,
-              abConsentlessAds: true,
-              externalVideoEmbeds: true,
-              simpleReach: true,
-              abIntegrateIma: true,
-              callouts: true,
-              carrotTrafficDriver: true,
-              sentinelLogger: true,
-              geoMostPopular: true,
-              weAreHiring: true,
-              relatedContent: true,
-              thirdPartyEmbedTracking: true,
-              prebidOzone: true,
-              ampLiveblogSwitch: true,
-              ampAmazon: true,
-              borkFid: false,
-              prebidAdYouLike: true,
-              mostViewedFronts: true,
-              optOutAdvertising: true,
-              abSignInGateMainControl: true,
-              headerTopNav: true,
-              googleSearch: true,
-              brazeSwitch: true,
-              consentManagement: true,
-              borkFcp: false,
-              commercial: true,
-              personaliseSignInGateAfterCheckout: true,
-              redplanetForAus: true,
-              prebidSonobi: true,
-              idProfileNavigation: true,
-              confiantAdVerification: true,
-              discussionAllowAnonymousRecommendsSwitch: false,
-              permutive: true,
-              comscore: true,
-              headerTopBarSearchCapi: false,
-              ampPrebidCriteo: true,
-              webFonts: true,
-              europeNetworkFront: true,
-              abBillboardsInMerch: false,
-              prebidImproveDigital: true,
-              offerHttp3: true,
-              ophan: true,
-              crosswordSvgThumbnails: true,
-              prebidTriplelift: true,
-              weather: true,
-              commercialOutbrainNewids: true,
-              disableAmpTest: true,
-              abLimitInlineMerch: true,
-              serverShareCounts: false,
-              abAdblockAsk: true,
-              prebidPubmatic: true,
-              autoRefresh: true,
-              enhanceTweets: true,
-              prebidIndexExchange: true,
-              prebidOpenx: true,
-              abElementsManager: true,
-              prebidHeaderBidding: true,
-              idCookieRefresh: true,
-              serverSideLiveblogInlineAds: true,
-              discussionPageSize: true,
-              smartAppBanner: false,
-              boostGaUserTimingFidelity: false,
-              historyTags: true,
-              mobileStickyLeaderboard: true,
-              brazeContentCards: true,
-              surveys: true,
-              remoteBanner: true,
-              emailSignupRecaptcha: true,
-              prebidSmart: true,
-              inizio: true,
-            },
-            section: 'news',
-            keywordIds:
-              'news/series/pandora-papers,news-series-pandora-papers/news-series-pandora-papers',
-            locationapiurl: '/weatherapi/locations?query=',
-            sharedAdTargeting: {
-              se: ['pandora-papers'],
-              ct: 'tag',
-              url: '/news/series/pandora-papers',
-              edition: 'uk',
-              p: 'ng',
-            },
-            buildNumber: '47250',
-            ampIframeUrl:
-              'https://assets.guim.co.uk/data/vendor/2533d5cb94302889e6a8f1b24b5329e7/amp-iframe.html',
-            beaconUrl: '//phar.gu-web.net',
-            userAttributesApiUrl:
-              'https://members-data-api.theguardian.com/user-attributes',
-            brazeApiKey: '7f28c639-8bda-48ff-a3f6-24345abfc07c',
-            host: 'https://www.theguardian.com',
-            calloutsUrl:
-              'https://callouts.code.dev-guardianapis.com/formstack-campaign/submit',
-            requiresMembershipAccess: false,
-            onwardWebSocket:
-              'ws://api.nextgen.guardianapps.co.uk/recently-published',
-            contentType: '',
-            pbIndexSites: [
-              {
-                bp: 'D',
-                id: 208234,
-              },
-              {
-                bp: 'M',
-                id: 213507,
-              },
-              {
-                bp: 'T',
-                id: 215442,
-              },
-            ],
-            a9PublisherId: '3722',
-            facebookIaAdUnitRoot: 'facebook-instant-articles',
-            ophanEmbedJsUrl: '//j.ophan.co.uk/ophan.embed',
-            idUrl: 'https://profile.theguardian.com',
-            dcrSentryDsn:
-              'https://1937ab71c8804b2b8438178dfdd6468f@sentry.io/1377847',
-            isFront: true,
-            idWebAppUrl: 'https://oauth.theguardian.com',
-            discussionApiUrl:
-              'https://discussion.theguardian.com/discussion-api',
-            sentryPublicApiKey: '344003a8d11c41d8800fbad8383fdc50',
-            omnitureAccount: 'guardiangu-network',
-            dfpAccountId: '59666047',
-            pageId: 'news/series/pandora-papers',
-            isAdFree: true,
-            forecastsapiurl: '/weatherapi/forecast',
-            assetsPath: 'https://assets.guim.co.uk/',
-            pillar: '',
-            commercialBundleUrl:
-              'https://assets.guim.co.uk/javascripts/commercial/e92f4210a1a3b17a6277/graun.standalone.commercial.js',
-            discussionApiClientHeader: 'nextgen',
-            membershipUrl: 'https://membership.theguardian.com',
-            dfpHost: 'pubads.g.doubleclick.net',
-            cardStyle: '',
-            googletagUrl: '//securepubads.g.doubleclick.net/tag/js/gpt.js',
-            sentryHost: 'app.getsentry.com/35463',
-            shouldHideAdverts: false,
-            mmaUrl: 'https://manage.theguardian.com',
-            isPreview: false,
-            membershipAccess: '',
-            abTests: {
-              dcrFrontsControl: 'control',
-            },
-            googletagJsUrl: '//securepubads.g.doubleclick.net/tag/js/gpt.js',
-            supportUrl: 'https://support.theguardian.com',
-            edition: 'UK',
-            discussionFrontendUrl: '',
-            ipsosTag: 'guardian',
-            ophanJsUrl: '//j.ophan.co.uk/ophan.ng',
-            isPaidContent: false,
-            mobileAppsAdUnitRoot: 'beta-guardian-app',
-            plistaPublicApiKey: '462925f4f131001fd974bebe',
-            frontendAssetsFullURL: 'https://assets.guim.co.uk/',
-            googleSearchId: '007466294097402385199:m2ealvuxh1i',
-            allowUserGeneratedContent: false,
-            dfpAdUnitRoot: 'theguardian.com',
-            idApiUrl: 'https://idapi.theguardian.com',
-            omnitureAmpAccount: 'guardiangu-thirdpartyapps',
-            adUnit: '/59666047/theguardian.com/news/subsection/ng',
-            hasPageSkin: false,
-            webTitle: 'Pandora papers',
-            stripePublicToken: 'pk_live_2O6zPMHXNs2AGea4bAmq5R7Z',
-            googleRecaptchaSiteKey: '6LdzlmsdAAAAALFH63cBVagSFPuuHXQ9OfpIDdMc',
-            discussionD2Uid: 'zHoBy6HNKsk',
-            weatherapiurl: '/weatherapi/city',
-            googleSearchUrl: '//www.google.co.uk/cse/cse.js',
-            optimizeEpicUrl:
-              'https://support.theguardian.com/epic/control/index.html',
-            stage: 'PROD',
-            idOAuthUrl: 'https://oauth.theguardian.com',
-            isSensitive: false,
-            isDev: false,
-            thirdPartyAppsAccount: 'guardiangu-thirdpartyapps',
-            avatarImagesUrl: 'https://avatar.guim.co.uk',
-            fbAppId: '180444840287',
-            dcrCouldRender: true,
-            showRelatedContent: true,
-            shouldHideReaderRevenue: false,
-          },
-          libs: {
-            googletag: '//securepubads.g.doubleclick.net/tag/js/gpt.js',
-          },
-          switches: {
-            prebidAppnexusUkRow: true,
-            mobileStickyPrebid: true,
-            newsletterOnwards: false,
-            abSignInGateMainVariant: true,
-            commercialMetrics: true,
-            prebidTrustx: true,
-            scAdFreeBanner: false,
-            abSignInGateCopyTestJan2023: false,
-            frontsBannerAds: false,
-            prebidPermutiveAudience: true,
-            compareVariantDecision: false,
-            adFreeStrictExpiryEnforcement: false,
-            enableSentryReporting: true,
-            lazyLoadContainers: true,
-            ampArticleSwitch: true,
-            remarketing: true,
-            keyEventsCarousel: true,
-            fetchNonRefreshableLineItems: true,
-            actionCardRedesign: true,
-            registerWithPhone: false,
-            targeting: true,
-            remoteHeader: true,
-            slotBodyEnd: true,
-            prebidImproveDigitalSkins: true,
-            ampPrebidOzone: true,
-            extendedMostPopularFronts: true,
-            emailInlineInFooter: true,
-            showNewPrivacyWordingOnEmailSignupEmbeds: true,
-            iasAdTargeting: true,
-            prebidAnalytics: true,
-            extendedMostPopular: true,
-            ampContentAbTesting: false,
-            okta: true,
-            abDeeplyReadArticleFooter: false,
-            puzzlesBanner: false,
-            prebidCriteo: true,
-            dcrFronts: true,
-            imrWorldwide: true,
-            acast: true,
-            automaticFilters: true,
-            twitterUwt: true,
-            prebidAppnexusInvcode: true,
-            ampPrebidPubmatic: true,
-            a9HeaderBidding: true,
-            prebidAppnexus: true,
-            enableDiscussionSwitch: true,
-            prebidXaxis: true,
-            stickyVideos: true,
-            abRemoveBusinessLiveblogEpics: false,
-            interactiveFullHeaderSwitch: true,
-            discussionAllPageSize: true,
-            prebidUserSync: true,
-            audioOnwardJourneySwitch: true,
-            dcrJavascriptBundle: true,
-            brazeTaylorReport: false,
-            abConsentlessAds: true,
-            externalVideoEmbeds: true,
-            simpleReach: true,
-            abIntegrateIma: true,
-            callouts: true,
-            carrotTrafficDriver: true,
-            sentinelLogger: true,
-            geoMostPopular: true,
-            weAreHiring: true,
-            relatedContent: true,
-            thirdPartyEmbedTracking: true,
-            prebidOzone: true,
-            ampLiveblogSwitch: true,
-            ampAmazon: true,
-            borkFid: false,
-            prebidAdYouLike: true,
-            mostViewedFronts: true,
-            optOutAdvertising: true,
-            abSignInGateMainControl: true,
-            headerTopNav: true,
-            googleSearch: true,
-            brazeSwitch: true,
-            consentManagement: true,
-            borkFcp: false,
-            commercial: true,
-            personaliseSignInGateAfterCheckout: true,
-            redplanetForAus: true,
-            prebidSonobi: true,
-            idProfileNavigation: true,
-            confiantAdVerification: true,
-            discussionAllowAnonymousRecommendsSwitch: false,
-            permutive: true,
-            comscore: true,
-            headerTopBarSearchCapi: false,
-            ampPrebidCriteo: true,
-            webFonts: true,
-            europeNetworkFront: true,
-            abBillboardsInMerch: false,
-            prebidImproveDigital: true,
-            offerHttp3: true,
-            ophan: true,
-            crosswordSvgThumbnails: true,
-            prebidTriplelift: true,
-            weather: true,
-            commercialOutbrainNewids: true,
-            disableAmpTest: true,
-            abLimitInlineMerch: true,
-            serverShareCounts: false,
-            abAdblockAsk: true,
-            prebidPubmatic: true,
-            autoRefresh: true,
-            enhanceTweets: true,
-            prebidIndexExchange: true,
-            prebidOpenx: true,
-            abElementsManager: true,
-            prebidHeaderBidding: true,
-            idCookieRefresh: true,
-            serverSideLiveblogInlineAds: true,
-            discussionPageSize: true,
-            smartAppBanner: false,
-            boostGaUserTimingFidelity: false,
-            historyTags: true,
-            mobileStickyLeaderboard: true,
-            brazeContentCards: true,
-            surveys: true,
-            remoteBanner: true,
-            emailSignupRecaptcha: true,
-            prebidSmart: true,
-            inizio: true,
-          },
-          tests: {
-            dcrFrontsControl: 'control',
-          },
-          ophan: {
-            pageViewId: '',
-            browserId: '',
-          },
-        },
-        polyfilled: false,
-        adBlockers: {
-          onDetect: [],
-        },
-        modules: {
-          sentry: {},
-        },
-        borkWebVitals: {},
-      };
-      window.guardian.queue = [];
-      // Queue for functions to be fired by polyfill.io callback
-    </script>
-    <script type="module">
-      window.guardian.mustardCut = true;
-    </script>
-    <script nomodule>
-      // Browser fails mustard check
-      window.guardian.mustardCut = false;
-    </script>
-    <script>
-      // Noop monkey patch perf.mark and perf.measure if not supported
-      if (
-        window.performance !== undefined &&
-        window.performance.mark === undefined
-      ) {
-        window.performance.mark = function () {};
-        window.performance.measure = function () {};
+  <meta name="robots" content="max-image-preview:large">
+
+  <script>
+    window.guardian = { "config": { "isDotcomRendering": true, "isDev": false, "stage": "PROD", "frontendAssetsFullURL": "https://assets.guim.co.uk/", "page": { "avatarApiUrl": "https://avatar.theguardian.com", "externalEmbedHost": "https://embed.theguardian.com", "ajaxUrl": "https://api.nextgen.guardianapps.co.uk", "keywords": "Network Front", "revisionNumber": "66c651cdb7e55c14411e158c57a757f0c5cac04e", "isProd": true, "switches": { "prebidAppnexusUkRow": true, "mobileStickyPrebid": true, "newsletterOnwards": false, "abSignInGateMainVariant": true, "commercialMetrics": true, "prebidTrustx": true, "scAdFreeBanner": false, "abSignInGateCopyTestJan2023": false, "frontsBannerAds": true, "prebidPermutiveAudience": true, "compareVariantDecision": false, "adFreeStrictExpiryEnforcement": false, "enableSentryReporting": true, "lazyLoadContainers": true, "ampArticleSwitch": true, "remarketing": true, "keyEventsCarousel": true, "fetchNonRefreshableLineItems": true, "actionCardRedesign": true, "registerWithPhone": false, "targeting": true, "remoteHeader": true, "deeplyReadSwitch": false, "slotBodyEnd": true, "prebidImproveDigitalSkins": true, "ampPrebidOzone": true, "extendedMostPopularFronts": true, "emailInlineInFooter": true, "showNewPrivacyWordingOnEmailSignupEmbeds": true, "iasAdTargeting": true, "prebidAnalytics": true, "extendedMostPopular": true, "ampContentAbTesting": false, "prebidCriteo": true, "okta": true, "abDeeplyReadArticleFooter": false, "puzzlesBanner": false, "imrWorldwide": true, "acast": true, "automaticFilters": true, "twitterUwt": true, "prebidAppnexusInvcode": true, "ampPrebidPubmatic": true, "a9HeaderBidding": true, "prebidAppnexus": true, "enableDiscussionSwitch": true, "prebidXaxis": true, "stickyVideos": true, "abRemoveBusinessLiveblogEpics": true, "interactiveFullHeaderSwitch": true, "discussionAllPageSize": true, "prebidUserSync": true, "audioOnwardJourneySwitch": true, "dcrJavascriptBundle": true, "brazeTaylorReport": false, "abConsentlessAds": true, "externalVideoEmbeds": true, "simpleReach": true, "abIntegrateIma": true, "callouts": true, "carrotTrafficDriver": true, "sentinelLogger": true, "geoMostPopular": true, "weAreHiring": true, "relatedContent": true, "thirdPartyEmbedTracking": true, "prebidOzone": true, "ampLiveblogSwitch": true, "ampAmazon": true, "borkFid": false, "prebidAdYouLike": true, "mostViewedFronts": true, "optOutAdvertising": true, "abSignInGateMainControl": true, "headerTopNav": true, "googleSearch": true, "brazeSwitch": true, "consentManagement": true, "borkFcp": false, "commercial": true, "personaliseSignInGateAfterCheckout": true, "redplanetForAus": true, "prebidSonobi": true, "idProfileNavigation": true, "confiantAdVerification": true, "discussionAllowAnonymousRecommendsSwitch": false, "permutive": true, "comscore": true, "headerTopBarSearchCapi": false, "ampPrebidCriteo": true, "webFonts": true, "europeNetworkFront": true, "abBillboardsInMerch": false, "prebidImproveDigital": true, "offerHttp3": true, "ophan": true, "crosswordSvgThumbnails": true, "prebidTriplelift": true, "weather": true, "commercialOutbrainNewids": true, "disableAmpTest": true, "abLimitInlineMerch": true, "serverShareCounts": false, "abAdblockAsk": true, "prebidPubmatic": true, "autoRefresh": true, "enhanceTweets": true, "prebidIndexExchange": true, "prebidOpenx": true, "abElementsManager": true, "prebidHeaderBidding": true, "idCookieRefresh": true, "serverSideLiveblogInlineAds": true, "discussionPageSize": true, "smartAppBanner": false, "boostGaUserTimingFidelity": false, "historyTags": true, "mobileStickyLeaderboard": true, "brazeContentCards": true, "surveys": true, "remoteBanner": true, "emailSignupRecaptcha": true, "prebidSmart": true, "inizio": true }, "keywordIds": "", "locationapiurl": "/weatherapi/locations?query=", "sharedAdTargeting": { "ct": "network-front", "url": "/uk", "edition": "uk", "p": "ng", "k": ["uk"] }, "buildNumber": "47359", "ampIframeUrl": "https://assets.guim.co.uk/data/vendor/2533d5cb94302889e6a8f1b24b5329e7/amp-iframe.html", "beaconUrl": "//phar.gu-web.net", "userAttributesApiUrl": "https://members-data-api.theguardian.com/user-attributes", "brazeApiKey": "7f28c639-8bda-48ff-a3f6-24345abfc07c", "host": "https://www.theguardian.com", "calloutsUrl": "https://callouts.code.dev-guardianapis.com/formstack-campaign/submit", "requiresMembershipAccess": false, "onwardWebSocket": "ws://api.nextgen.guardianapps.co.uk/recently-published", "contentType": "", "pbIndexSites": [{ "bp": "D", "id": 208209 }, { "bp": "M", "id": 213483 }, { "bp": "T", "id": 215418 }], "a9PublisherId": "3722", "facebookIaAdUnitRoot": "facebook-instant-articles", "ophanEmbedJsUrl": "//j.ophan.co.uk/ophan.embed", "idUrl": "https://profile.theguardian.com", "dcrSentryDsn": "https://1937ab71c8804b2b8438178dfdd6468f@sentry.io/1377847", "isFront": true, "idWebAppUrl": "https://oauth.theguardian.com", "discussionApiUrl": "https://discussion.theguardian.com/discussion-api", "sentryPublicApiKey": "344003a8d11c41d8800fbad8383fdc50", "omnitureAccount": "guardiangu-network", "dfpAccountId": "59666047", "pageId": "uk", "isAdFree": false, "forecastsapiurl": "/weatherapi/forecast", "assetsPath": "https://assets.guim.co.uk/", "pillar": "", "commercialBundleUrl": "https://assets.guim.co.uk/javascripts/commercial/83846fe715c5230f732d/graun.standalone.commercial.js", "discussionApiClientHeader": "nextgen", "membershipUrl": "https://membership.theguardian.com", "dfpHost": "pubads.g.doubleclick.net", "cardStyle": "", "googletagUrl": "//securepubads.g.doubleclick.net/tag/js/gpt.js", "sentryHost": "app.getsentry.com/35463", "shouldHideAdverts": false, "mmaUrl": "https://manage.theguardian.com", "isPreview": false, "membershipAccess": "", "abTests": { "actionCardRedesignControl": "control" }, "googletagJsUrl": "//securepubads.g.doubleclick.net/tag/js/gpt.js", "supportUrl": "https://support.theguardian.com", "edition": "UK", "discussionFrontendUrl": "", "ipsosTag": "uk", "ophanJsUrl": "//j.ophan.co.uk/ophan.ng", "isPaidContent": false, "mobileAppsAdUnitRoot": "beta-guardian-app", "plistaPublicApiKey": "462925f4f131001fd974bebe", "frontendAssetsFullURL": "https://assets.guim.co.uk/", "googleSearchId": "007466294097402385199:m2ealvuxh1i", "allowUserGeneratedContent": false, "dfpAdUnitRoot": "theguardian.com", "idApiUrl": "https://idapi.theguardian.com", "omnitureAmpAccount": "guardiangu-thirdpartyapps", "adUnit": "/59666047/theguardian.com/uk/front/ng", "hasPageSkin": false, "webTitle": "Network Front", "stripePublicToken": "pk_live_2O6zPMHXNs2AGea4bAmq5R7Z", "googleRecaptchaSiteKey": "6LdzlmsdAAAAALFH63cBVagSFPuuHXQ9OfpIDdMc", "discussionD2Uid": "zHoBy6HNKsk", "weatherapiurl": "/weatherapi/city", "googleSearchUrl": "//www.google.co.uk/cse/cse.js", "optimizeEpicUrl": "https://support.theguardian.com/epic/control/index.html", "stage": "PROD", "idOAuthUrl": "https://oauth.theguardian.com", "isSensitive": false, "isDev": false, "thirdPartyAppsAccount": "guardiangu-thirdpartyapps", "avatarImagesUrl": "https://avatar.guim.co.uk", "fbAppId": "180444840287", "dcrCouldRender": true, "showRelatedContent": true, "shouldHideReaderRevenue": false }, "libs": { "googletag": "//securepubads.g.doubleclick.net/tag/js/gpt.js" }, "switches": { "prebidAppnexusUkRow": true, "mobileStickyPrebid": true, "newsletterOnwards": false, "abSignInGateMainVariant": true, "commercialMetrics": true, "prebidTrustx": true, "scAdFreeBanner": false, "abSignInGateCopyTestJan2023": false, "frontsBannerAds": true, "prebidPermutiveAudience": true, "compareVariantDecision": false, "adFreeStrictExpiryEnforcement": false, "enableSentryReporting": true, "lazyLoadContainers": true, "ampArticleSwitch": true, "remarketing": true, "keyEventsCarousel": true, "fetchNonRefreshableLineItems": true, "actionCardRedesign": true, "registerWithPhone": false, "targeting": true, "remoteHeader": true, "deeplyReadSwitch": false, "slotBodyEnd": true, "prebidImproveDigitalSkins": true, "ampPrebidOzone": true, "extendedMostPopularFronts": true, "emailInlineInFooter": true, "showNewPrivacyWordingOnEmailSignupEmbeds": true, "iasAdTargeting": true, "prebidAnalytics": true, "extendedMostPopular": true, "ampContentAbTesting": false, "prebidCriteo": true, "okta": true, "abDeeplyReadArticleFooter": false, "puzzlesBanner": false, "imrWorldwide": true, "acast": true, "automaticFilters": true, "twitterUwt": true, "prebidAppnexusInvcode": true, "ampPrebidPubmatic": true, "a9HeaderBidding": true, "prebidAppnexus": true, "enableDiscussionSwitch": true, "prebidXaxis": true, "stickyVideos": true, "abRemoveBusinessLiveblogEpics": true, "interactiveFullHeaderSwitch": true, "discussionAllPageSize": true, "prebidUserSync": true, "audioOnwardJourneySwitch": true, "dcrJavascriptBundle": true, "brazeTaylorReport": false, "abConsentlessAds": true, "externalVideoEmbeds": true, "simpleReach": true, "abIntegrateIma": true, "callouts": true, "carrotTrafficDriver": true, "sentinelLogger": true, "geoMostPopular": true, "weAreHiring": true, "relatedContent": true, "thirdPartyEmbedTracking": true, "prebidOzone": true, "ampLiveblogSwitch": true, "ampAmazon": true, "borkFid": false, "prebidAdYouLike": true, "mostViewedFronts": true, "optOutAdvertising": true, "abSignInGateMainControl": true, "headerTopNav": true, "googleSearch": true, "brazeSwitch": true, "consentManagement": true, "borkFcp": false, "commercial": true, "personaliseSignInGateAfterCheckout": true, "redplanetForAus": true, "prebidSonobi": true, "idProfileNavigation": true, "confiantAdVerification": true, "discussionAllowAnonymousRecommendsSwitch": false, "permutive": true, "comscore": true, "headerTopBarSearchCapi": false, "ampPrebidCriteo": true, "webFonts": true, "europeNetworkFront": true, "abBillboardsInMerch": false, "prebidImproveDigital": true, "offerHttp3": true, "ophan": true, "crosswordSvgThumbnails": true, "prebidTriplelift": true, "weather": true, "commercialOutbrainNewids": true, "disableAmpTest": true, "abLimitInlineMerch": true, "serverShareCounts": false, "abAdblockAsk": true, "prebidPubmatic": true, "autoRefresh": true, "enhanceTweets": true, "prebidIndexExchange": true, "prebidOpenx": true, "abElementsManager": true, "prebidHeaderBidding": true, "idCookieRefresh": true, "serverSideLiveblogInlineAds": true, "discussionPageSize": true, "smartAppBanner": false, "boostGaUserTimingFidelity": false, "historyTags": true, "mobileStickyLeaderboard": true, "brazeContentCards": true, "surveys": true, "remoteBanner": true, "emailSignupRecaptcha": true, "prebidSmart": true, "inizio": true }, "tests": { "actionCardRedesignControl": "control" }, "ophan": { "pageViewId": "", "browserId": "" } }, "polyfilled": false, "adBlockers": { "onDetect": [] }, "modules": { "sentry": {} }, "borkWebVitals": {} };
+    window.guardian.queue = []; // Queue for functions to be fired by polyfill.io callback
+  </script>
+
+  <script type="module">
+    window.guardian.mustardCut = true;
+  </script>
+
+  <script nomodule>
+    // Browser fails mustard check
+    window.guardian.mustardCut = false;
+  </script>
+
+  <script>
+    // Noop monkey patch perf.mark and perf.measure if not supported
+    if (window.performance !== undefined && window.performance.mark === undefined) {
+      window.performance.mark = function () { };
+      window.performance.measure = function () { };
+    }
+  </script>
+
+  <script>
+    // record the number of times the browser goes offline during a pageview
+    window.guardian.offlineCount = 0;
+    window.addEventListener('offline', function incrementOfflineCount() { window.guardian.offlineCount++ });
+  </script>
+
+  <script>
+    // this is a global that's called at the bottom of the pf.io response,
+    // once the polyfills have run. This may be useful for debugging.
+    // mainly to support browsers that don't support async=false or defer
+    function guardianPolyfilled() {
+      window.guardian.polyfilled = true;
+      if (window.guardian.mustardCut === false) {
+        window.guardian.queue.forEach(function (startup) { startup() })
       }
-    </script>
-    <script>
-      // record the number of times the browser goes offline during a pageview
-      window.guardian.offlineCount = 0;
-      window.addEventListener('offline', function incrementOfflineCount() {
-        window.guardian.offlineCount++;
-      });
-    </script>
-    <script>
-      // this is a global that's called at the bottom of the pf.io response,
-      // once the polyfills have run. This may be useful for debugging.
-      // mainly to support browsers that don't support async=false or defer
-      function guardianPolyfilled() {
-        window.guardian.polyfilled = true;
-        if (window.guardian.mustardCut === false) {
-          window.guardian.queue.forEach(function (startup) {
-            startup();
-          });
+    }
+
+    // We've got contracts to abide by with the Ophan tracker
+    // Setting pageViewId here ensures we're not getting race-conditions at all
+    window.guardian.config.ophan = {
+      // This is duplicated from
+      // https://github.com/guardian/ophan/blob/master/tracker-js/assets/coffee/ophan/transmit.coffee
+      // Please do not change this without talking to the Ophan project first.
+      pageViewId:
+        new Date().getTime().toString(36) +
+        'xxxxxxxxxxxx'.replace(/x/g, function () {
+          return Math.floor(Math.random() * 36).toString(36);
+        }),
+    };
+  </script>
+
+  <script>
+    // Set the browserId from the bwid cookie on the ophan object created above
+    // This will need to be replaced later with an async request to an endpoint
+    (function (window, document) {
+
+      function getCookieValue(name) {
+        var nameEq = name + "=",
+          cookies = document.cookie.split(';'),
+          value = null;
+        cookies.forEach(function (cookie) {
+          while (cookie.charAt(0) === ' ') {
+            cookie = cookie.substring(1, cookie.length);
+          }
+          if (cookie.indexOf(nameEq) === 0) {
+            value = cookie.substring(nameEq.length, cookie.length);
+          }
+        });
+        return value;
+      }
+
+      window.guardian.config.ophan.browserId = getCookieValue("bwid");
+
+    })(window, document);
+  </script>
+
+  <script>
+    window.curlConfig = {
+      baseUrl: 'https://assets.guim.co.uk/assets',
+      apiName: 'require'
+    };
+    window.curl = window.curlConfig;
+  </script>
+
+  <!-- no borking -->
+
+
+
+
+
+  <noscript>
+    <img src="https://sb.scorecardresearch.com/p?c1=2&c2=6035250&cv=2.0&cj=1&cs_ucfr=0&comscorekw=Network+Front" />
+
+
+    <style>
+      gu-island[clientOnly=true] {
+        display: none;
+      }
+    </style>
+
+  </noscript>
+
+  <!-- The following script does not vary between modern & legacy browsers -->
+  <script defer
+    src="https://assets.guim.co.uk/polyfill.io/v3/polyfill.min.js?rum=0&features=es6%2Ces7%2Ces2017%2Ces2018%2Ces2019%2Cdefault-3.6%2CHTMLPictureElement%2CIntersectionObserver%2CIntersectionObserverEntry%2CURLSearchParams%2Cfetch%2CNodeList.prototype.forEach%2Cnavigator.sendBeacon%2Cperformance.now%2CPromise.allSettled&flags=gated&callback=guardianPolyfilled&unknown=polyfill&cacheClear=1&http3=true"></script>
+  <script type="module"
+    src="https://assets.guim.co.uk/assets/frameworks.modern.e855de231d40f9b5e577.js?http3=true"></script>
+  <script defer nomodule
+    src="https://assets.guim.co.uk/assets/frameworks.legacy.e855de231d40f9b5e577.js?http3=true"></script>
+  <script type="module" src="https://assets.guim.co.uk/assets/index.modern.12586c7791cb9d968f6c.js?http3=true"></script>
+  <script defer nomodule
+    src="https://assets.guim.co.uk/assets/index.legacy.d9211ede1e73b29f13d0.js?http3=true"></script>
+  <!-- The following script does not vary between modern & legacy browsers -->
+  <script defer
+    src="https://assets.guim.co.uk/javascripts/commercial/83846fe715c5230f732d/graun.standalone.commercial.js?http3=true"></script>
+  <style class="webfont">
+    @font-face {
+      font-family: "GH Guardian Headline";
+      src: url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Light.woff2?http3=true) format("woff2"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-Light.woff?http3=true) format("woff"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-Light.ttf?http3=true) format("truetype");
+      font-weight: 300;
+      font-style: normal;
+      font-display: swap;
+    }
+
+    @font-face {
+      font-family: "Guardian Egyptian Web";
+      src: url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Light.woff2?http3=true) format("woff2"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-Light.woff?http3=true) format("woff"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-Light.ttf?http3=true) format("truetype");
+      font-weight: 300;
+      font-style: normal;
+      font-display: swap;
+    }
+
+    @font-face {
+      font-family: "GH Guardian Headline";
+      src: url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-LightItalic.woff2?http3=true) format("woff2"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-LightItalic.woff?http3=true) format("woff"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-LightItalic.ttf?http3=true) format("truetype");
+      font-weight: 300;
+      font-style: italic;
+      font-display: swap;
+    }
+
+    @font-face {
+      font-family: "Guardian Egyptian Web";
+      src: url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-LightItalic.woff2?http3=true) format("woff2"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-LightItalic.woff?http3=true) format("woff"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-LightItalic.ttf?http3=true) format("truetype");
+      font-weight: 300;
+      font-style: italic;
+      font-display: swap;
+    }
+
+    @font-face {
+      font-family: "GH Guardian Headline";
+      src: url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Medium.woff2?http3=true) format("woff2"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Medium.woff?http3=true) format("woff"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-Medium.ttf?http3=true) format("truetype");
+      font-weight: 500;
+      font-style: normal;
+      font-display: swap;
+    }
+
+    @font-face {
+      font-family: "Guardian Egyptian Web";
+      src: url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Medium.woff2?http3=true) format("woff2"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Medium.woff?http3=true) format("woff"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-Medium.ttf?http3=true) format("truetype");
+      font-weight: 500;
+      font-style: normal;
+      font-display: swap;
+    }
+
+    @font-face {
+      font-family: "GH Guardian Headline";
+      src: url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-MediumItalic.woff2?http3=true) format("woff2"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-MediumItalic.woff?http3=true) format("woff"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-MediumItalic.ttf?http3=true) format("truetype");
+      font-weight: 500;
+      font-style: italic;
+      font-display: swap;
+    }
+
+    @font-face {
+      font-family: "Guardian Egyptian Web";
+      src: url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-MediumItalic.woff2?http3=true) format("woff2"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-MediumItalic.woff?http3=true) format("woff"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-MediumItalic.ttf?http3=true) format("truetype");
+      font-weight: 500;
+      font-style: italic;
+      font-display: swap;
+    }
+
+    @font-face {
+      font-family: "GH Guardian Headline";
+      src: url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Bold.woff2?http3=true) format("woff2"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-Bold.woff?http3=true) format("woff"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-Bold.ttf?http3=true) format("truetype");
+      font-weight: 700;
+      font-style: normal;
+      font-display: swap;
+    }
+
+    @font-face {
+      font-family: "Guardian Egyptian Web";
+      src: url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Bold.woff2?http3=true) format("woff2"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-Bold.woff?http3=true) format("woff"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-Bold.ttf?http3=true) format("truetype");
+      font-weight: 700;
+      font-style: normal;
+      font-display: swap;
+    }
+
+    @font-face {
+      font-family: "GH Guardian Headline";
+      src: url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-BoldItalic.woff2?http3=true) format("woff2"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-BoldItalic.woff?http3=true) format("woff"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-BoldItalic.ttf?http3=true) format("truetype");
+      font-weight: 700;
+      font-style: italic;
+      font-display: swap;
+    }
+
+    @font-face {
+      font-family: "Guardian Egyptian Web";
+      src: url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-BoldItalic.woff2?http3=true) format("woff2"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-BoldItalic.woff?http3=true) format("woff"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-BoldItalic.ttf?http3=true) format("truetype");
+      font-weight: 700;
+      font-style: italic;
+      font-display: swap;
+    }
+
+    @font-face {
+      font-family: "GuardianTextEgyptian";
+      src: url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Regular.woff2?http3=true) format("woff2"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Regular.woff?http3=true) format("woff"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/latin1-not-hinted/GuardianTextEgyptian-Regular.ttf?http3=true) format("truetype");
+      font-weight: 400;
+      font-style: normal;
+      font-display: swap;
+    }
+
+    @font-face {
+      font-family: "Guardian Text Egyptian Web";
+      src: url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Regular.woff2?http3=true) format("woff2"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Regular.woff?http3=true) format("woff"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/latin1-not-hinted/GuardianTextEgyptian-Regular.ttf?http3=true) format("truetype");
+      font-weight: 400;
+      font-style: normal;
+      font-display: swap;
+    }
+
+    @font-face {
+      font-family: "GuardianTextEgyptian";
+      src: url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-RegularItalic.woff2?http3=true) format("woff2"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/latin1-not-hinted/GuardianTextEgyptian-RegularItalic.woff?http3=true) format("woff"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/latin1-not-hinted/GuardianTextEgyptian-RegularItalic.ttf?http3=true) format("truetype");
+      font-weight: 400;
+      font-style: italic;
+      font-display: swap;
+    }
+
+    @font-face {
+      font-family: "Guardian Text Egyptian Web";
+      src: url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-RegularItalic.woff2?http3=true) format("woff2"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/latin1-not-hinted/GuardianTextEgyptian-RegularItalic.woff?http3=true) format("woff"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/latin1-not-hinted/GuardianTextEgyptian-RegularItalic.ttf?http3=true) format("truetype");
+      font-weight: 400;
+      font-style: italic;
+      font-display: swap;
+    }
+
+    @font-face {
+      font-family: "GuardianTextEgyptian";
+      src: url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Bold.woff2?http3=true) format("woff2"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/latin1-not-hinted/GuardianTextEgyptian-Bold.woff?http3=true) format("woff"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/latin1-not-hinted/GuardianTextEgyptian-Bold.ttf?http3=true) format("truetype");
+      font-weight: 700;
+      font-style: normal;
+      font-display: swap;
+    }
+
+    @font-face {
+      font-family: "Guardian Text Egyptian Web";
+      src: url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Bold.woff2?http3=true) format("woff2"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/latin1-not-hinted/GuardianTextEgyptian-Bold.woff?http3=true) format("woff"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/latin1-not-hinted/GuardianTextEgyptian-Bold.ttf?http3=true) format("truetype");
+      font-weight: 700;
+      font-style: normal;
+      font-display: swap;
+    }
+
+    @font-face {
+      font-family: "GuardianTextEgyptian";
+      src: url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-BoldItalic.woff2?http3=true) format("woff2"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/latin1-not-hinted/GuardianTextEgyptian-BoldItalic.woff?http3=true) format("woff"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/latin1-not-hinted/GuardianTextEgyptian-BoldItalic.ttf?http3=true) format("truetype");
+      font-weight: 700;
+      font-style: italic;
+      font-display: swap;
+    }
+
+    @font-face {
+      font-family: "Guardian Text Egyptian Web";
+      src: url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-BoldItalic.woff2?http3=true) format("woff2"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/latin1-not-hinted/GuardianTextEgyptian-BoldItalic.woff?http3=true) format("woff"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/latin1-not-hinted/GuardianTextEgyptian-BoldItalic.ttf?http3=true) format("truetype");
+      font-weight: 700;
+      font-style: italic;
+      font-display: swap;
+    }
+
+    @font-face {
+      font-family: "GuardianTextSans";
+      src: url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Regular.woff2?http3=true) format("woff2"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Regular.woff?http3=true) format("woff"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/latin1-not-hinted/GuardianTextSans-Regular.ttf?http3=true) format("truetype");
+      font-weight: 400;
+      font-style: normal;
+      font-display: swap;
+    }
+
+    @font-face {
+      font-family: "Guardian Text Sans Web";
+      src: url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Regular.woff2?http3=true) format("woff2"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Regular.woff?http3=true) format("woff"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/latin1-not-hinted/GuardianTextSans-Regular.ttf?http3=true) format("truetype");
+      font-weight: 400;
+      font-style: normal;
+      font-display: swap;
+    }
+
+    @font-face {
+      font-family: "GuardianTextSans";
+      src: url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-RegularItalic.woff2?http3=true) format("woff2"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/latin1-not-hinted/GuardianTextSans-RegularItalic.woff?http3=true) format("woff"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/latin1-not-hinted/GuardianTextSans-RegularItalic.ttf?http3=true) format("truetype");
+      font-weight: 400;
+      font-style: italic;
+      font-display: swap;
+    }
+
+    @font-face {
+      font-family: "Guardian Text Sans Web";
+      src: url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-RegularItalic.woff2?http3=true) format("woff2"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/latin1-not-hinted/GuardianTextSans-RegularItalic.woff?http3=true) format("woff"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/latin1-not-hinted/GuardianTextSans-RegularItalic.ttf?http3=true) format("truetype");
+      font-weight: 400;
+      font-style: italic;
+      font-display: swap;
+    }
+
+    @font-face {
+      font-family: "GuardianTextSans";
+      src: url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Bold.woff2?http3=true) format("woff2"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/latin1-not-hinted/GuardianTextSans-Bold.woff?http3=true) format("woff"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/latin1-not-hinted/GuardianTextSans-Bold.ttf?http3=true) format("truetype");
+      font-weight: 700;
+      font-style: normal;
+      font-display: swap;
+    }
+
+    @font-face {
+      font-family: "Guardian Text Sans Web";
+      src: url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Bold.woff2?http3=true) format("woff2"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/latin1-not-hinted/GuardianTextSans-Bold.woff?http3=true) format("woff"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/latin1-not-hinted/GuardianTextSans-Bold.ttf?http3=true) format("truetype");
+      font-weight: 700;
+      font-style: normal;
+      font-display: swap;
+    }
+
+    @font-face {
+      font-family: "GuardianTextSans";
+      src: url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-BoldItalic.woff2?http3=true) format("woff2"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/latin1-not-hinted/GuardianTextSans-BoldItalic.woff?http3=true) format("woff"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/latin1-not-hinted/GuardianTextSans-BoldItalic.ttf?http3=true) format("truetype");
+      font-weight: 700;
+      font-style: italic;
+      font-display: swap;
+    }
+
+    @font-face {
+      font-family: "Guardian Text Sans Web";
+      src: url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-BoldItalic.woff2?http3=true) format("woff2"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/latin1-not-hinted/GuardianTextSans-BoldItalic.woff?http3=true) format("woff"), url(https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/latin1-not-hinted/GuardianTextSans-BoldItalic.ttf?http3=true) format("truetype");
+      font-weight: 700;
+      font-style: italic;
+      font-display: swap;
+    }
+  </style>
+  <style>
+    html,
+    body,
+    div,
+    span,
+    applet,
+    object,
+    iframe,
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6,
+    p,
+    blockquote,
+    pre,
+    a,
+    abbr,
+    acronym,
+    address,
+    big,
+    cite,
+    code,
+    del,
+    dfn,
+    em,
+    img,
+    ins,
+    kbd,
+    q,
+    s,
+    samp,
+    small,
+    strike,
+    strong,
+    sub,
+    sup,
+    tt,
+    var,
+    b,
+    u,
+    i,
+    center,
+    dl,
+    dt,
+    dd,
+    menu,
+    ol,
+    ul,
+    li,
+    fieldset,
+    form,
+    label,
+    legend,
+    table,
+    caption,
+    tbody,
+    tfoot,
+    thead,
+    tr,
+    th,
+    td,
+    article,
+    aside,
+    canvas,
+    details,
+    embed,
+    figure,
+    figcaption,
+    footer,
+    header,
+    hgroup,
+    main,
+    menu,
+    nav,
+    output,
+    ruby,
+    section,
+    summary,
+    time,
+    mark,
+    audio,
+    video {
+      margin: 0;
+      padding: 0;
+      border: 0;
+      font-size: 100%;
+      font: inherit;
+      vertical-align: baseline;
+    }
+
+    /* HTML5 display-role reset for older browsers */
+    article,
+    aside,
+    details,
+    figcaption,
+    figure,
+    footer,
+    header,
+    hgroup,
+    main,
+    menu,
+    nav,
+    section {
+      display: block;
+    }
+
+    /* HTML5 hidden-attribute fix for newer browsers */
+    *[hidden] {
+      display: none;
+    }
+
+    body {
+      line-height: 1;
+    }
+
+    menu,
+    ol,
+    ul {
+      list-style: none;
+    }
+
+    blockquote,
+    q {
+      quotes: none;
+    }
+
+    blockquote:before,
+    blockquote:after,
+    q:before,
+    q:after {
+      content: '';
+      content: none;
+    }
+
+    table {
+      border-collapse: collapse;
+      border-spacing: 0;
+    }
+
+
+    *,
+    *:before,
+    *:after {
+      box-sizing: border-box;
+    }
+
+    html {
+      -moz-osx-font-smoothing: grayscale;
+      -webkit-font-smoothing: antialiased;
+      /* always show the vertical scroll bar to stop the page
+         * jumping about when navigating between pages where
+         * one has content shorter than the viewport */
+      overflow-y: scroll;
+    }
+
+    html,
+    body {
+      text-rendering: optimizeLegibility;
+      font-feature-settings: 'kern';
+      font-kerning: normal;
+      /* Safari 7+, Firefox 24+, Chrome 33(?)+, Opera 21 */
+      font-variant-ligatures: common-ligatures;
+    }
+
+    body {
+      background-color: #FFFFFF;
+      color: #121212;
+    }
+
+    em {
+      font-style: italic;
+    }
+  </style>
+  <style data-emotion="dcr-global 0"></style>
+  <style data-emotion="dcr-global 1l07i1x">
+    *:focus {
+      outline: 0;
+    }
+
+    html:not(.src-focus-disabled) *:focus {
+      box-shadow: 0 0 0 5px #0077B6;
+    }
+
+    ::selection {
+      background: #FFE500;
+      color: #121212;
+    }
+  </style>
+  <style data-emotion="dcr-global 1uvnolp">
+    .bz-custom-container~#bannerandheader .top-banner-ad-container {
+      display: none;
+    }
+  </style>
+  <style data-emotion="dcr-global o115em">
+    @media (max-width: 979px) {
+      .nav-is-open {
+        overflow: hidden;
+      }
+    }
+  </style>
+  <style data-emotion="dcr-global animation-111ynch">
+    @-webkit-keyframes animation-111ynch {
+      0% {
+        opacity: 1;
+      }
+
+      10% {
+        opacity: .25;
+      }
+
+      40% {
+        opacity: 1;
+      }
+
+      100% {
+        opacity: 1;
+      }
+    }
+
+    @keyframes animation-111ynch {
+      0% {
+        opacity: 1;
+      }
+
+      10% {
+        opacity: .25;
+      }
+
+      40% {
+        opacity: 1;
+      }
+
+      100% {
+        opacity: 1;
+      }
+    }
+  </style>
+  <style
+    data-emotion="dcr vg6br7 8h2mpe v339xn 1s8spa1 1u9kji9 1bn3p0w zzftu fks95w 12433rp 1uyetce henwc 1kfeu4u 1kvcc9o 1492oy5 1086n7e bi2aot xg94hc 1gd007l 1yaip4y j7jlyl 14f8c26 h39xrs g8r8o3 pzbwhq 1w7ojan 1irynrj 16rjsjj 127sebo 12xduix 1ppwqv1 1z074wr x2bp9n 1yaxlqk sy54ny 1ikbe4v 1aeyz4o h2gqsd c8vw16 a6bcsq 1tabvac 1t1n4fm 1kuh7tf 1nvgr5i a2u3ka 13vr4eh 120u0k1 mebke 18m7gh9 1kn7o79 1y4qg42 1acea34 1fqnu7z nqw243 9ra8aa 13wwvzl 4hq641 16d24hr 15vcq54 bu7bnv 1xxnrhn 11zodys 1efvfp0 xlajkp hmp1vw 1kltmkq 8lx8k9 19s2ze7 1ay3cld g8v7m4 19ilr9m 1xcf7cw 190ztmi 1p0hins a7qyd9 12vycz3 e1bf28 r07hem 1sks1z0 b3zdlu jv36lp 17sb2rc vwltw3 6sdrzu pt8pb9 4phbzi nnfu1a wzkd0n 1h92x0c 188zz3t v6jxf0 1gt8egs qo5392 65xb9q r91ehr em8d0v 1kx60rc 1n8hb96 15t9kli 1iz7gbk 1atljbz eubdc yyvovz 1mi5u71 w3rkaf 1p6anfw pkharf 1eb5jgw 1pe3pea yosj9c evn1e9 rrcudz dbozpd 14gfmlq 1o7trcs adlhb4 hcib8t 4xb9x1 17yg843 1hg1hdu kz9nqe z7lzm0 wi48h0 os58m2 ect2dm 1hipxkh 1cgn3lv ruaspp 17h8ziz 1pb5o7w 1y2cu33 p1dvl6 16jv6hb 5bdubr mfwrfv 1g99xyq y4cf8a elbm7f 1ysdk7i kt9wlt 1xir693 10b6thp cho92m 16fqzm2 1lcaowc avaain 12hccii y8nd8l 1pscgow 1i3wv16 15p4tz0 hhyfju 9e78hl glvxc9 rdw702 12r3co1 1uz1ca8 1r4i92e ti0g6y b25wgn 1qxltt owfrse swmefo 1lex7d6 1wwe1mi 1i342d0 pzujhk 1m43ich 1tuqo8l 1acn58b kfs8io j8q3ty lqxdi4 isu8nh 1izbchs 3tss6n 1e7l74i awenke 1mbvac 109rq7o 3tlap1 1hd9axk 13b893w 1xjlcua tttgpl 1f9ehwl 8y9hd2 7dgi4u wl67q8 yi9s71 940o8p 11vxpqc w6hc5l 194i6pr 10hq5cq 5zzwsk klul57 vkpbou heqd82 dcwwkt er9oa0 6vr3s5 14ukgk6 1w0fo28 gf0nnr 15f6w0y ibz96v 1ttos39 zdnpsd wwzlz2 13er5zy mhxc3l wx7qhb 1e9i83y 14mz37s 19b1897 1ykr3rf 1997rrz 41bl8c eqj3ju a22k0z eirr0n 1rdrlpf 1x0hldo 1a53cuj 1shzr3u 1mbiar2 clan40 1v9xu6e sa2wgi 1tlk9ix 1o00huv 177xkn2 v5uj1c pqd2bn 1rhgqks cwgamd mpib28 1x82knj cumgmz 1b0b5qy 121waft 1i1yotf 121iobs 1okfq0v 1la72oj 10maeve j2e14o bx6dku eqij51 1ye338w 11gvlio 5r9j9 1dl6o1v 1pfni0w dnk6tr 1sibelm bi3vbd 1ei6oe5 o4w3q 1mp48zh 79fz17 1dcubs6 106n9m1 7miaum biszai 1hxj7jq pdz5dh 1769awk 1s9f32v fg1cwd veksfe 14ifi9m 9zdshs gavx50 12urb0b 18hfuhz 14tkj09 66hogn 1pfte1u 19ua8kq 7vng58 zu1fd9 1pp81zm pu1sy6 yg4zrc k1vhee fossqd j3w6wb 1giivcq ddf1wi xf43jl 3x1x0z 102ctxe hqoq27 9e1ukq xyss4m q76bkn 14gme47 n4owjk 1haxrmz 1ij4tou 10j4v47 1o3p705 1wxws1r 19eam1p 1lbz6ez vibzgs 10kck6o 1yduq3m 1ngqhfk i5gfxx ge5xgp 1v397f0 1hy529c kammsl c4kygy 91lgpk nosp2s 10rqwzg 1w2x6ij 11rhxc6 yqz51q 1dijbt5 qjynpy 1vrrbyb 1xyi04h 1wf840d 1creg26 ygowzy 5hi9qv sts64 1g9k069 1xnlu54 1bljy3y 4rr662 18yycfp 13lm9u3 1qbs42f">
+    .dcr-vg6br7 {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 1.0625rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 40px;
+      top: -40px;
+      line-height: 30px;
+      overflow: hidden;
+      padding: 0;
+      position: absolute;
+      background: #FFFFFF;
+      display: block;
+      text-align: center;
+      margin: 0;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      color: #000000;
+    }
+
+    .dcr-vg6br7:focus,
+    .dcr-vg6br7:active {
+      border: 5px solid #0077B6;
+      position: static;
+    }
+
+    .dcr-vg6br7:visited,
+    .dcr-vg6br7:active {
+      color: #000000;
+    }
+
+    .dcr-8h2mpe {
+      position: -webkit-sticky;
+      position: sticky;
+      top: 0;
+      z-index: 17;
+      background-color: white;
+    }
+
+    .dcr-1u9kji9 {
+      position: static;
+    }
+
+    @media (max-width: 739px) {
+      .dcr-1bn3p0w {
+        display: none;
+      }
+    }
+
+    .dcr-zzftu {
+      z-index: 1080;
+      width: 100%;
+      background-color: #F6F6F6;
+      min-height: 132px;
+      border-bottom: 1px solid #DCDCDC;
+      padding-bottom: 18px;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+      -webkit-box-pack: center;
+      -ms-flex-pack: center;
+      -webkit-justify-content: center;
+      justify-content: center;
+      position: -webkit-sticky;
+      position: sticky;
+      top: 0;
+    }
+
+    .dcr-zzftu .ad-slot__scroll {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      max-height: 24px;
+      background-color: #F6F6F6;
+      padding: 0 8px;
+      border-top: 1px solid #DCDCDC;
+      color: #707070;
+      text-align: left;
+      box-sizing: border-box;
+      position: relative;
+    }
+
+    .dcr-zzftu .ad-slot__scroll.visible {
+      visibility: initial;
+    }
+
+    .dcr-zzftu .ad-slot__scroll.hidden {
+      visibility: hidden;
+    }
+
+    .dcr-zzftu .ad-slot__close-button {
+      display: none;
+    }
+
+    .dcr-zzftu .ad-slot__scroll {
+      position: fixed;
+      bottom: 0;
+      width: 100%;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      max-height: 24px;
+      background-color: #F6F6F6;
+      padding: 0 8px;
+      border-top: 1px solid #DCDCDC;
+      color: #707070;
+      text-align: left;
+      box-sizing: border-box;
+    }
+
+    .dcr-zzftu .ad-slot:not[data-label-show='true']::before {
+      content: '';
+      display: block;
+      height: 24px;
+      visibility: hidden;
+    }
+
+    .dcr-zzftu .ad-slot[data-label-show='true']:not(.ad-slot--interscroller):not(.ad-slot--merchandising):not(.ad-slot--merchandising-high)::before {
+      content: attr(ad-label-text);
+      display: block;
+      position: relative;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      max-height: 24px;
+      background-color: #F6F6F6;
+      padding: 0 8px;
+      border-top: 1px solid #DCDCDC;
+      color: #707070;
+      text-align: left;
+      box-sizing: border-box;
+    }
+
+    .dcr-zzftu .ad-slot--merchandising[data-label-show='true']::before,
+    .dcr-zzftu .ad-slot--merchandising-high[data-label-show='true']::before {
+      content: attr(ad-label-text);
+      display: block;
+      position: relative;
+      max-width: 970px;
+      margin: auto;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      max-height: 24px;
+      background-color: #F6F6F6;
+      padding: 0 8px;
+      border-top: 1px solid #DCDCDC;
+      color: #707070;
+      text-align: left;
+      box-sizing: border-box;
+    }
+
+    .dcr-zzftu .ad-slot__adtest-cookie-clear-link {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      text-align: left;
+      position: absolute;
+      left: 268px;
+      top: 1px;
+      z-index: 10;
+      padding: 0;
+      border: 0;
+    }
+
+    .dcr-fks95w[top-above-nav-ad-rendered] {
+      width: -webkit-fit-content;
+      width: -moz-fit-content;
+      width: fit-content;
+      margin: auto;
+    }
+
+    .dcr-fks95w .ad-slot.ad-slot--collapse {
+      display: none;
+    }
+
+    .dcr-12433rp {
+      position: relative;
+      margin: 0 auto;
+      min-height: 90px;
+      text-align: left;
+      display: block;
+      min-width: 728px;
+    }
+
+    .dcr-12433rp .ad-slot__scroll {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      max-height: 24px;
+      background-color: #F6F6F6;
+      padding: 0 8px;
+      border-top: 1px solid #DCDCDC;
+      color: #707070;
+      text-align: left;
+      box-sizing: border-box;
+      position: relative;
+    }
+
+    .dcr-12433rp .ad-slot__scroll.visible {
+      visibility: initial;
+    }
+
+    .dcr-12433rp .ad-slot__scroll.hidden {
+      visibility: hidden;
+    }
+
+    .dcr-12433rp .ad-slot__close-button {
+      display: none;
+    }
+
+    .dcr-12433rp .ad-slot__scroll {
+      position: fixed;
+      bottom: 0;
+      width: 100%;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      max-height: 24px;
+      background-color: #F6F6F6;
+      padding: 0 8px;
+      border-top: 1px solid #DCDCDC;
+      color: #707070;
+      text-align: left;
+      box-sizing: border-box;
+    }
+
+    .dcr-12433rp .ad-slot:not[data-label-show='true']::before {
+      content: '';
+      display: block;
+      height: 24px;
+      visibility: hidden;
+    }
+
+    .dcr-12433rp .ad-slot[data-label-show='true']:not(.ad-slot--interscroller):not(.ad-slot--merchandising):not(.ad-slot--merchandising-high)::before {
+      content: attr(ad-label-text);
+      display: block;
+      position: relative;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      max-height: 24px;
+      background-color: #F6F6F6;
+      padding: 0 8px;
+      border-top: 1px solid #DCDCDC;
+      color: #707070;
+      text-align: left;
+      box-sizing: border-box;
+    }
+
+    .dcr-12433rp .ad-slot--merchandising[data-label-show='true']::before,
+    .dcr-12433rp .ad-slot--merchandising-high[data-label-show='true']::before {
+      content: attr(ad-label-text);
+      display: block;
+      position: relative;
+      max-width: 970px;
+      margin: auto;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      max-height: 24px;
+      background-color: #F6F6F6;
+      padding: 0 8px;
+      border-top: 1px solid #DCDCDC;
+      color: #707070;
+      text-align: left;
+      box-sizing: border-box;
+    }
+
+    .dcr-12433rp .ad-slot__adtest-cookie-clear-link {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      text-align: left;
+      position: absolute;
+      left: 268px;
+      top: 1px;
+      z-index: 10;
+      padding: 0;
+      border: 0;
+    }
+
+    .dcr-12433rp.ad-slot--fluid {
+      min-height: 250px;
+      line-height: 10px;
+      padding: 0;
+      margin: 0;
+    }
+
+    .dcr-12433rp .ad-slot.ad-slot--collapse {
+      display: none;
+    }
+
+    .dcr-12433rp.ad-slot--fluid {
+      width: 100%;
+    }
+
+    .dcr-1uyetce {
+      background-color: #052962;
+    }
+
+    .dcr-henwc {
+      background-color: #052962;
+    }
+
+    .dcr-1kfeu4u {
+      background-color: #041F4A;
+    }
+
+    .dcr-1kvcc9o {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      height: 30px;
+      background-color: #041F4A;
+      box-sizing: border-box;
+      padding-left: 10px;
+      position: relative;
+      margin: auto;
+    }
+
+    @media (min-width: 480px) {
+      .dcr-1kvcc9o {
+        padding-left: 20px;
+      }
+    }
+
+    @media (min-width: 740px) {
+      .dcr-1kvcc9o {
+        padding-left: 15px;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-1kvcc9o {
+        height: 35px;
+        -webkit-box-pack: end;
+        -ms-flex-pack: end;
+        -webkit-justify-content: flex-end;
+        justify-content: flex-end;
+        padding-right: 20px;
+      }
+    }
+
+    @media (min-width: 1300px) {
+      .dcr-1kvcc9o {
+        padding-right: 96px;
+      }
+    }
+
+    @media (min-width: 740px) {
+      .dcr-1kvcc9o {
+        max-width: 740px;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-1kvcc9o {
+        max-width: 980px;
+      }
+    }
+
+    @media (min-width: 1140px) {
+      .dcr-1kvcc9o {
+        max-width: 1140px;
+      }
+    }
+
+    @media (min-width: 1300px) {
+      .dcr-1kvcc9o {
+        max-width: 1300px;
+      }
+    }
+
+    .dcr-1492oy5 {
+      display: none;
+    }
+
+    @media (min-width: 980px) {
+      .dcr-1492oy5 {
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+      }
+    }
+
+    .dcr-1086n7e {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-align-items: center;
+      -webkit-box-align: center;
+      -ms-flex-align: center;
+      align-items: center;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 1.0625rem;
+      line-height: 1.35;
+      font-weight: 700;
+      --source-text-decoration-thickness: 2px;
+      font-size: 1rem;
+      height: -webkit-fit-content;
+      height: -moz-fit-content;
+      height: fit-content;
+      line-height: 1;
+      color: #FFE500;
+      -webkit-transition: color 80ms ease-out;
+      transition: color 80ms ease-out;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      padding: 7px 0;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-1086n7e {
+        padding: 7px 10px 7px 6px;
+      }
+    }
+
+    .dcr-1086n7e:hover,
+    .dcr-1086n7e:focus {
+      -webkit-text-decoration: underline;
+      text-decoration: underline;
+    }
+
+    .dcr-1086n7e svg {
+      fill: currentColor;
+      float: left;
+      height: 18px;
+      width: 18px;
+      margin: 0 4px 0 0;
+    }
+
+    .dcr-bi2aot {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-align-items: center;
+      -webkit-box-align: center;
+      -ms-flex-align: center;
+      align-items: center;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-bi2aot {
+        -webkit-align-items: stretch;
+        -webkit-box-align: stretch;
+        -ms-flex-align: stretch;
+        align-items: stretch;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-bi2aot:before {
+        content: '';
+        border-left: 1px solid #506991;
+        height: 24px;
+      }
+    }
+
+    .dcr-xg94hc {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-align-items: center;
+      -webkit-box-align: center;
+      -ms-flex-align: center;
+      align-items: center;
+      height: -webkit-fit-content;
+      height: -moz-fit-content;
+      height: fit-content;
+      position: relative;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 1.0625rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      font-size: 1rem;
+      line-height: 1;
+      color: #FFFFFF;
+      -webkit-transition: color 80ms ease-out;
+      transition: color 80ms ease-out;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      padding: 0;
+      z-index: 11;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-xg94hc {
+        padding: 7px 10px 7px 6px;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-xg94hc {
+        font-weight: bold;
+      }
+    }
+
+    .dcr-xg94hc:hover,
+    .dcr-xg94hc:focus {
+      -webkit-text-decoration: underline;
+      text-decoration: underline;
+    }
+
+    .dcr-xg94hc svg {
+      fill: currentColor;
+      float: left;
+      height: 18px;
+      width: 18px;
+      margin: 0 4px 0 0;
+    }
+
+    .dcr-1gd007l {
+      display: none;
+    }
+
+    .dcr-1gd007l:before {
+      content: '';
+      border-left: 1px solid #506991;
+      height: 24px;
+    }
+
+    @media (min-width: 980px) {
+      .dcr-1gd007l {
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+      }
+    }
+
+    .dcr-1yaip4y {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 1.0625rem;
+      line-height: 1.35;
+      font-weight: 700;
+      --source-text-decoration-thickness: 2px;
+      font-size: 1rem;
+      line-height: 1;
+      color: #FFFFFF;
+      -webkit-transition: color 80ms ease-out;
+      transition: color 80ms ease-out;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      padding: 7px 0;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-1yaip4y {
+        padding: 8px 10px 7px 6px;
+      }
+    }
+
+    .dcr-1yaip4y:hover,
+    .dcr-1yaip4y:focus {
+      -webkit-text-decoration: underline;
+      text-decoration: underline;
+    }
+
+    .dcr-j7jlyl {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-align-items: center;
+      -webkit-box-align: center;
+      -ms-flex-align: center;
+      align-items: center;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 1.0625rem;
+      line-height: 1.35;
+      font-weight: 700;
+      --source-text-decoration-thickness: 2px;
+      line-height: 1;
+      font-size: 1rem;
+      height: -webkit-fit-content;
+      height: -moz-fit-content;
+      height: fit-content;
+      color: #FFFFFF;
+      -webkit-transition: color 80ms ease-out;
+      transition: color 80ms ease-out;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      padding: 7px 0;
+      z-index: 10;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-j7jlyl {
+        padding: 7px 10px 7px 6px;
+      }
+    }
+
+    .dcr-j7jlyl:hover,
+    .dcr-j7jlyl:focus {
+      -webkit-text-decoration: underline;
+      text-decoration: underline;
+    }
+
+    .dcr-j7jlyl svg {
+      fill: currentColor;
+      float: left;
+      height: 18px;
+      width: 18px;
+      margin: 0 4px 0 0;
+    }
+
+    @media (max-width: 979px) {
+      .dcr-14f8c26 {
+        display: none;
+      }
+    }
+
+    .dcr-h39xrs {
+      z-index: 15;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      position: relative;
+    }
+
+    .dcr-h39xrs:before {
+      content: '';
+      border-left: 1px solid #506991;
+      height: 24px;
+    }
+
+    .dcr-g8r8o3 #checkbox-id-edition {
+      position: absolute;
+      overflow: hidden;
+      white-space: nowrap;
+      width: 1px;
+      height: 1px;
+      margin: -1px;
+      padding: 0;
+      border: 0;
+      clip: rect(1px, 1px, 1px, 1px);
+      -webkit-clip-path: inset(50%);
+      -webkit-clip-path: inset(50%);
+      clip-path: inset(50%);
+    }
+
+    .dcr-g8r8o3 #dropbox-id-edition {
+      display: none;
+    }
+
+    .dcr-g8r8o3 #checkbox-id-edition:checked+#dropbox-id-edition {
+      display: block;
+    }
+
+    .dcr-pzbwhq {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 1.0625rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      display: block;
+      cursor: pointer;
+      background: none;
+      border: none;
+      line-height: 1.2;
+      color: #FFFFFF;
+      -webkit-transition: color 80ms ease-out;
+      transition: color 80ms ease-out;
+      padding: 0px 10px 6px 5px;
+      margin: 1px 0 0;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      position: relative;
+      color: #FFFFFF;
+      padding-right: 0;
+      padding-bottom: 0;
+      margin-top: 0;
+      font-size: 1rem;
+      padding-top: 6px;
+    }
+
+    .dcr-pzbwhq:hover {
+      color: #FFE500;
+    }
+
+    .dcr-pzbwhq:hover:after {
+      -webkit-transform: translateY(0) rotate(45deg);
+      -moz-transform: translateY(0) rotate(45deg);
+      -ms-transform: translateY(0) rotate(45deg);
+      transform: translateY(0) rotate(45deg);
+    }
+
+    .dcr-pzbwhq:after {
+      content: '';
+      display: inline-block;
+      width: 5px;
+      height: 5px;
+      -webkit-transform: translateY(-2px) rotate(45deg);
+      -moz-transform: translateY(-2px) rotate(45deg);
+      -ms-transform: translateY(-2px) rotate(45deg);
+      transform: translateY(-2px) rotate(45deg);
+      border: 1px solid currentColor;
+      border-left: transparent;
+      border-top: transparent;
+      margin-left: 5px;
+      vertical-align: middle;
+      -webkit-transition: -webkit-transform 250ms ease-out;
+      transition: transform 250ms ease-out;
+    }
+
+    .dcr-pzbwhq:not(ul):hover {
+      color: #FFFFFF;
+      -webkit-text-decoration: underline;
+      text-decoration: underline;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-pzbwhq {
+        right: 0;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-pzbwhq {
+        font-weight: bold;
+      }
+    }
+
+    .dcr-1w7ojan {
+      z-index: 23;
+      list-style: none;
+      background-color: white;
+      padding: 6px 0;
+      box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
+      color: #FFFFFF;
+      padding-right: 0;
+      padding-bottom: 0;
+      margin-top: 0;
+      font-size: 1rem;
+      padding-top: 6px;
+    }
+
+    .dcr-1w7ojan li::before {
+      content: '\200B';
+      display: block;
+      height: 0;
+      width: 0;
+    }
+
+    @media (max-width: 739px) {
+      .dcr-1w7ojan {
+        position: fixed;
+        border-radius: 0;
+        top: 32px;
+        left: 0;
+        right: 0;
+        width: auto;
+        max-height: calc(100% - 50px);
+        overflow: auto;
+      }
+    }
+
+    @media (min-width: 740px) {
+      .dcr-1w7ojan {
+        position: absolute;
+        top: 100%;
+        width: 200px;
+        border-radius: 3px;
+      }
+    }
+
+    .dcr-1w7ojan:not(ul):hover {
+      color: #FFFFFF;
+      -webkit-text-decoration: underline;
+      text-decoration: underline;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-1w7ojan {
+        right: 0;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-1w7ojan {
+        font-weight: bold;
+      }
+    }
+
+    .dcr-1irynrj {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.9375rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      color: #121212;
+      position: relative;
+      -webkit-transition: color 80ms ease-out;
+      transition: color 80ms ease-out;
+      margin: -1px 0 0 0;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      display: block;
+      padding: 10px 18px 15px 30px;
+      font-weight: bold;
+    }
+
+    .dcr-1irynrj:hover {
+      background-color: #EDEDED;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+    }
+
+    .dcr-1irynrj:focus {
+      -webkit-text-decoration: underline;
+      text-decoration: underline;
+    }
+
+    .dcr-1irynrj:before {
+      content: '';
+      border-top: 1px solid #DCDCDC;
+      display: block;
+      position: absolute;
+      top: 0px;
+      left: 30px;
+      right: 0px;
+    }
+
+    .dcr-1irynrj:after {
+      content: '';
+      border: 2px solid #C70000;
+      border-top: 0px;
+      border-right: 0px;
+      position: absolute;
+      top: 19px;
+      left: 12px;
+      width: 10px;
+      height: 4px;
+      -webkit-transform: rotate(-45deg);
+      -moz-transform: rotate(-45deg);
+      -ms-transform: rotate(-45deg);
+      transform: rotate(-45deg);
+    }
+
+    .dcr-1irynrj:before {
+      content: none;
+    }
+
+    .dcr-16rjsjj {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.9375rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      color: #121212;
+      position: relative;
+      -webkit-transition: color 80ms ease-out;
+      transition: color 80ms ease-out;
+      margin: -1px 0 0 0;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      display: block;
+      padding: 10px 18px 15px 30px;
+    }
+
+    .dcr-16rjsjj:hover {
+      background-color: #EDEDED;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+    }
+
+    .dcr-16rjsjj:focus {
+      -webkit-text-decoration: underline;
+      text-decoration: underline;
+    }
+
+    .dcr-16rjsjj:before {
+      content: '';
+      border-top: 1px solid #DCDCDC;
+      display: block;
+      position: absolute;
+      top: 0px;
+      left: 30px;
+      right: 0px;
+    }
+
+    .dcr-127sebo {
+      position: relative;
+      margin: auto;
+      overflow: hidden;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-127sebo {
+        max-width: 740px;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-127sebo {
+        max-width: 980px;
+      }
+    }
+
+    @media (min-width: 1140px) {
+      .dcr-127sebo {
+        max-width: 1140px;
+      }
+    }
+
+    @media (min-width: 1300px) {
+      .dcr-127sebo {
+        max-width: 1300px;
+      }
+    }
+
+    .dcr-12xduix {
+      float: right;
+      margin-top: 6px;
+      margin-right: 54px;
+      margin-bottom: 10px;
+      width: 146px;
+      z-index: 9;
+    }
+
+    @media (min-width: 375px) {
+      .dcr-12xduix {
+        margin-right: 10px;
+        width: 195px;
+      }
+    }
+
+    @media (min-width: 480px) {
+      .dcr-12xduix {
+        margin-right: 20px;
+      }
+    }
+
+    @media (min-width: 740px) {
+      .dcr-12xduix {
+        width: 224px;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-12xduix {
+        margin-top: 5px;
+        margin-bottom: 12px;
+        position: relative;
+        width: 295px;
+      }
+    }
+
+    @media (min-width: 1300px) {
+      .dcr-12xduix {
+        margin-right: 96px;
+      }
+    }
+
+    .dcr-1ppwqv1 {
+      position: absolute;
+      overflow: hidden;
+      white-space: nowrap;
+      width: 1px;
+      height: 1px;
+      margin: -1px;
+      padding: 0;
+      border: 0;
+      clip: rect(1px, 1px, 1px, 1px);
+      -webkit-clip-path: inset(50%);
+      -webkit-clip-path: inset(50%);
+      clip-path: inset(50%);
+    }
+
+    .dcr-1z074wr {
+      position: relative;
+      margin: auto;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-1z074wr {
+        max-width: 740px;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-1z074wr {
+        max-width: 980px;
+      }
+    }
+
+    @media (min-width: 1140px) {
+      .dcr-1z074wr {
+        max-width: 1140px;
+      }
+    }
+
+    @media (min-width: 1300px) {
+      .dcr-1z074wr {
+        max-width: 1300px;
+      }
+    }
+
+    @media (min-width: 740px) {
+      .dcr-1z074wr {
+        border-left: 1px solid #506991;
+        border-right: 1px solid #506991;
+      }
+    }
+
+    .dcr-x2bp9n {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: row;
+      -ms-flex-direction: row;
+      flex-direction: row;
+      -webkit-box-pack: justify;
+      -webkit-justify-content: space-between;
+      justify-content: space-between;
+    }
+
+    .dcr-1yaxlqk {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: row;
+      -ms-flex-direction: row;
+      flex-direction: row;
+      -webkit-box-pack: justify;
+      -webkit-justify-content: space-between;
+      justify-content: space-between;
+    }
+
+    .dcr-1yaxlqk:after {
+      content: '';
+      display: table;
+      clear: both;
+    }
+
+    .dcr-sy54ny {
+      position: absolute;
+      overflow: hidden;
+      white-space: nowrap;
+      width: 1px;
+      height: 1px;
+      margin: -1px;
+      padding: 0;
+      border: 0;
+      clip: rect(1px, 1px, 1px, 1px);
+      -webkit-clip-path: inset(50%);
+      -webkit-clip-path: inset(50%);
+      clip-path: inset(50%);
+    }
+
+    .dcr-1ikbe4v {
+      clear: right;
+      margin: 0;
+      list-style: none;
+      list-style-image: none;
+      padding-left: 10px;
+    }
+
+    @media (min-width: 480px) {
+      .dcr-1ikbe4v {
+        padding-left: 20px;
+      }
+    }
+
+    .dcr-1ikbe4v li {
+      float: left;
+      display: block;
+      position: relative;
+      width: auto;
+    }
+
+    @media (min-width: 980px) {
+      .dcr-1ikbe4v li {
+        width: 134px;
+      }
+    }
+
+    @media (min-width: 1140px) {
+      .dcr-1ikbe4v li {
+        width: 160px;
+      }
+    }
+
+    .dcr-1ikbe4v li::before {
+      content: '\200B';
+      display: block;
+      height: 0;
+      width: 0;
+    }
+
+    .dcr-1ikbe4v:after {
+      content: '';
+      border-top: 1px solid #506991;
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      height: 36px;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-1ikbe4v:after {
+        border-bottom: 0;
+        height: 49px;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-1ikbe4v:after {
+        height: 42px;
+      }
+    }
+
+    .dcr-1aeyz4o:first-of-type {
+      margin-left: -20px;
+      width: auto;
+    }
+
+    @media (min-width: 980px) {
+      .dcr-1aeyz4o:first-of-type {
+        width: 144px;
+      }
+    }
+
+    @media (min-width: 1140px) {
+      .dcr-1aeyz4o:first-of-type {
+        width: 171px;
+      }
+    }
+
+    .dcr-1aeyz4o:first-of-type a {
+      padding-left: 20px;
+    }
+
+    @media (max-width: 979px) {
+      .dcr-1aeyz4o:last-child a:before {
+        content: none;
+      }
+    }
+
+    .dcr-h2gqsd {
+      font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+      font-size: 1.0625rem;
+      line-height: 1.15;
+      font-weight: 500;
+      --source-text-decoration-thickness: 2px;
+      box-sizing: border-box;
+      font-weight: 900;
+      color: #FFFFFF;
+      cursor: pointer;
+      display: block;
+      font-size: 15.4px;
+      height: 36px;
+      padding-top: 9px;
+      padding-right: 5px;
+      padding-bottom: 0;
+      padding-left: 5px;
+      position: relative;
+      overflow: hidden;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      z-index: 1;
+    }
+
+    @media (min-width: 375px) {
+      .dcr-h2gqsd {
+        font-size: 15.7px;
+        padding-top: 9px;
+        padding-right: 5px;
+        padding-bottom: 0;
+        padding-left: 5px;
+      }
+    }
+
+    @media (min-width: 480px) {
+      .dcr-h2gqsd {
+        font-size: 18px;
+        padding-top: 9px;
+        padding-right: 5px;
+        padding-bottom: 0;
+        padding-left: 5px;
+      }
+    }
+
+    @media (min-width: 740px) {
+      .dcr-h2gqsd {
+        font-size: 22px;
+        height: 48px;
+        padding-top: 9px;
+        padding-right: 20px;
+        padding-bottom: 0;
+        padding-left: 9px;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-h2gqsd {
+        padding-top: 5px;
+        height: 42px;
+      }
+    }
+
+    @media (min-width: 1300px) {
+      .dcr-h2gqsd {
+        padding-top: 7px;
+        font-size: 24px;
+      }
+    }
+
+    .dcr-h2gqsd:focus:after {
+      -webkit-transform: translateY(4px);
+      -moz-transform: translateY(4px);
+      -ms-transform: translateY(4px);
+      transform: translateY(4px);
+    }
+
+    .dcr-h2gqsd:hover {
+      -webkit-text-decoration: none;
+      text-decoration: none;
+    }
+
+    .dcr-h2gqsd:hover:after {
+      -webkit-transform: translateY(4px);
+      -moz-transform: translateY(4px);
+      -ms-transform: translateY(4px);
+      transform: translateY(4px);
+    }
+
+    .dcr-h2gqsd:after {
+      border-top: 4px solid #FF5943;
+      left: 0;
+      right: 1px;
+      top: -4px;
+      content: '';
+      display: block;
+      position: absolute;
+      -webkit-transition: -webkit-transform 0.3s ease-in-out;
+      transition: transform 0.3s ease-in-out;
+    }
+
+    @media (min-width: 980px) {
+      #top-nav-input-checkbox:checked~ul li .dcr-h2gqsd:before {
+        bottom: 0;
+      }
+    }
+
+    #top-nav-input-checkbox:checked~ul li .dcr-h2gqsd:hover,
+    #top-nav-input-checkbox:checked~ul li .dcr-h2gqsd:focus {
+      -webkit-text-decoration: underline;
+      text-decoration: underline;
+      color: #FFE500;
+    }
+
+    #top-nav-input-checkbox:checked~ul li .dcr-h2gqsd:after {
+      -webkit-transform: translateY(4px);
+      -moz-transform: translateY(4px);
+      -ms-transform: translateY(4px);
+      transform: translateY(4px);
+    }
+
+    .dcr-h2gqsd:after {
+      -webkit-transform: translateY(4px);
+      -moz-transform: translateY(4px);
+      -ms-transform: translateY(4px);
+      transform: translateY(4px);
+    }
+
+    .dcr-h2gqsd:focus:after {
+      -webkit-transform: translateY(4px);
+      -moz-transform: translateY(4px);
+      -ms-transform: translateY(4px);
+      transform: translateY(4px);
+    }
+
+    .dcr-h2gqsd:hover {
+      -webkit-text-decoration: none;
+      text-decoration: none;
+    }
+
+    .dcr-h2gqsd:hover:after {
+      -webkit-transform: translateY(4px);
+      -moz-transform: translateY(4px);
+      -ms-transform: translateY(4px);
+      transform: translateY(4px);
+    }
+
+    .dcr-h2gqsd:before {
+      content: '';
+      display: block;
+      position: absolute;
+      right: 0;
+      top: 0;
+      bottom: 0;
+      width: 1px;
+      background-color: #506991;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-h2gqsd:before {
+        bottom: 17px;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-h2gqsd:before {
+        bottom: 0.6em;
+      }
+    }
+
+    .dcr-c8vw16 {
+      font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+      font-size: 1.0625rem;
+      line-height: 1.15;
+      font-weight: 500;
+      --source-text-decoration-thickness: 2px;
+      box-sizing: border-box;
+      font-weight: 900;
+      color: #FFFFFF;
+      cursor: pointer;
+      display: block;
+      font-size: 15.4px;
+      height: 36px;
+      padding-top: 9px;
+      padding-right: 5px;
+      padding-bottom: 0;
+      padding-left: 5px;
+      position: relative;
+      overflow: hidden;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      z-index: 1;
+    }
+
+    @media (min-width: 375px) {
+      .dcr-c8vw16 {
+        font-size: 15.7px;
+        padding-top: 9px;
+        padding-right: 5px;
+        padding-bottom: 0;
+        padding-left: 5px;
+      }
+    }
+
+    @media (min-width: 480px) {
+      .dcr-c8vw16 {
+        font-size: 18px;
+        padding-top: 9px;
+        padding-right: 5px;
+        padding-bottom: 0;
+        padding-left: 5px;
+      }
+    }
+
+    @media (min-width: 740px) {
+      .dcr-c8vw16 {
+        font-size: 22px;
+        height: 48px;
+        padding-top: 9px;
+        padding-right: 20px;
+        padding-bottom: 0;
+        padding-left: 9px;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-c8vw16 {
+        padding-top: 5px;
+        height: 42px;
+      }
+    }
+
+    @media (min-width: 1300px) {
+      .dcr-c8vw16 {
+        padding-top: 7px;
+        font-size: 24px;
+      }
+    }
+
+    .dcr-c8vw16:focus:after {
+      -webkit-transform: translateY(4px);
+      -moz-transform: translateY(4px);
+      -ms-transform: translateY(4px);
+      transform: translateY(4px);
+    }
+
+    .dcr-c8vw16:hover {
+      -webkit-text-decoration: none;
+      text-decoration: none;
+    }
+
+    .dcr-c8vw16:hover:after {
+      -webkit-transform: translateY(4px);
+      -moz-transform: translateY(4px);
+      -ms-transform: translateY(4px);
+      transform: translateY(4px);
+    }
+
+    .dcr-c8vw16:after {
+      border-top: 4px solid #FF7F0F;
+      left: 0;
+      right: 1px;
+      top: -4px;
+      content: '';
+      display: block;
+      position: absolute;
+      -webkit-transition: -webkit-transform 0.3s ease-in-out;
+      transition: transform 0.3s ease-in-out;
+    }
+
+    @media (min-width: 980px) {
+      #top-nav-input-checkbox:checked~ul li .dcr-c8vw16:before {
+        bottom: 0;
+      }
+    }
+
+    #top-nav-input-checkbox:checked~ul li .dcr-c8vw16:hover,
+    #top-nav-input-checkbox:checked~ul li .dcr-c8vw16:focus {
+      -webkit-text-decoration: underline;
+      text-decoration: underline;
+      color: #FFE500;
+    }
+
+    #top-nav-input-checkbox:checked~ul li .dcr-c8vw16:after {
+      -webkit-transform: translateY(4px);
+      -moz-transform: translateY(4px);
+      -ms-transform: translateY(4px);
+      transform: translateY(4px);
+    }
+
+    .dcr-c8vw16:before {
+      content: '';
+      display: block;
+      position: absolute;
+      right: 0;
+      top: 0;
+      bottom: 0;
+      width: 1px;
+      background-color: #506991;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-c8vw16:before {
+        bottom: 17px;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-c8vw16:before {
+        bottom: 0.6em;
+      }
+    }
+
+    .dcr-a6bcsq {
+      font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+      font-size: 1.0625rem;
+      line-height: 1.15;
+      font-weight: 500;
+      --source-text-decoration-thickness: 2px;
+      box-sizing: border-box;
+      font-weight: 900;
+      color: #FFFFFF;
+      cursor: pointer;
+      display: block;
+      font-size: 15.4px;
+      height: 36px;
+      padding-top: 9px;
+      padding-right: 5px;
+      padding-bottom: 0;
+      padding-left: 5px;
+      position: relative;
+      overflow: hidden;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      z-index: 1;
+    }
+
+    @media (min-width: 375px) {
+      .dcr-a6bcsq {
+        font-size: 15.7px;
+        padding-top: 9px;
+        padding-right: 5px;
+        padding-bottom: 0;
+        padding-left: 5px;
+      }
+    }
+
+    @media (min-width: 480px) {
+      .dcr-a6bcsq {
+        font-size: 18px;
+        padding-top: 9px;
+        padding-right: 5px;
+        padding-bottom: 0;
+        padding-left: 5px;
+      }
+    }
+
+    @media (min-width: 740px) {
+      .dcr-a6bcsq {
+        font-size: 22px;
+        height: 48px;
+        padding-top: 9px;
+        padding-right: 20px;
+        padding-bottom: 0;
+        padding-left: 9px;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-a6bcsq {
+        padding-top: 5px;
+        height: 42px;
+      }
+    }
+
+    @media (min-width: 1300px) {
+      .dcr-a6bcsq {
+        padding-top: 7px;
+        font-size: 24px;
+      }
+    }
+
+    .dcr-a6bcsq:focus:after {
+      -webkit-transform: translateY(4px);
+      -moz-transform: translateY(4px);
+      -ms-transform: translateY(4px);
+      transform: translateY(4px);
+    }
+
+    .dcr-a6bcsq:hover {
+      -webkit-text-decoration: none;
+      text-decoration: none;
+    }
+
+    .dcr-a6bcsq:hover:after {
+      -webkit-transform: translateY(4px);
+      -moz-transform: translateY(4px);
+      -ms-transform: translateY(4px);
+      transform: translateY(4px);
+    }
+
+    .dcr-a6bcsq:after {
+      border-top: 4px solid #00B2FF;
+      left: 0;
+      right: 1px;
+      top: -4px;
+      content: '';
+      display: block;
+      position: absolute;
+      -webkit-transition: -webkit-transform 0.3s ease-in-out;
+      transition: transform 0.3s ease-in-out;
+    }
+
+    @media (min-width: 980px) {
+      #top-nav-input-checkbox:checked~ul li .dcr-a6bcsq:before {
+        bottom: 0;
+      }
+    }
+
+    #top-nav-input-checkbox:checked~ul li .dcr-a6bcsq:hover,
+    #top-nav-input-checkbox:checked~ul li .dcr-a6bcsq:focus {
+      -webkit-text-decoration: underline;
+      text-decoration: underline;
+      color: #FFE500;
+    }
+
+    #top-nav-input-checkbox:checked~ul li .dcr-a6bcsq:after {
+      -webkit-transform: translateY(4px);
+      -moz-transform: translateY(4px);
+      -ms-transform: translateY(4px);
+      transform: translateY(4px);
+    }
+
+    .dcr-a6bcsq:before {
+      content: '';
+      display: block;
+      position: absolute;
+      right: 0;
+      top: 0;
+      bottom: 0;
+      width: 1px;
+      background-color: #506991;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-a6bcsq:before {
+        bottom: 17px;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-a6bcsq:before {
+        bottom: 0.6em;
+      }
+    }
+
+    .dcr-1tabvac {
+      font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+      font-size: 1.0625rem;
+      line-height: 1.15;
+      font-weight: 500;
+      --source-text-decoration-thickness: 2px;
+      box-sizing: border-box;
+      font-weight: 900;
+      color: #FFFFFF;
+      cursor: pointer;
+      display: block;
+      font-size: 15.4px;
+      height: 36px;
+      padding-top: 9px;
+      padding-right: 5px;
+      padding-bottom: 0;
+      padding-left: 5px;
+      position: relative;
+      overflow: hidden;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      z-index: 1;
+    }
+
+    @media (min-width: 375px) {
+      .dcr-1tabvac {
+        font-size: 15.7px;
+        padding-top: 9px;
+        padding-right: 5px;
+        padding-bottom: 0;
+        padding-left: 5px;
+      }
+    }
+
+    @media (min-width: 480px) {
+      .dcr-1tabvac {
+        font-size: 18px;
+        padding-top: 9px;
+        padding-right: 5px;
+        padding-bottom: 0;
+        padding-left: 5px;
+      }
+    }
+
+    @media (min-width: 740px) {
+      .dcr-1tabvac {
+        font-size: 22px;
+        height: 48px;
+        padding-top: 9px;
+        padding-right: 20px;
+        padding-bottom: 0;
+        padding-left: 9px;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-1tabvac {
+        padding-top: 5px;
+        height: 42px;
+      }
+    }
+
+    @media (min-width: 1300px) {
+      .dcr-1tabvac {
+        padding-top: 7px;
+        font-size: 24px;
+      }
+    }
+
+    .dcr-1tabvac:focus:after {
+      -webkit-transform: translateY(4px);
+      -moz-transform: translateY(4px);
+      -ms-transform: translateY(4px);
+      transform: translateY(4px);
+    }
+
+    .dcr-1tabvac:hover {
+      -webkit-text-decoration: none;
+      text-decoration: none;
+    }
+
+    .dcr-1tabvac:hover:after {
+      -webkit-transform: translateY(4px);
+      -moz-transform: translateY(4px);
+      -ms-transform: translateY(4px);
+      transform: translateY(4px);
+    }
+
+    .dcr-1tabvac:after {
+      border-top: 4px solid #EACCA0;
+      left: 0;
+      right: 1px;
+      top: -4px;
+      content: '';
+      display: block;
+      position: absolute;
+      -webkit-transition: -webkit-transform 0.3s ease-in-out;
+      transition: transform 0.3s ease-in-out;
+    }
+
+    @media (min-width: 980px) {
+      #top-nav-input-checkbox:checked~ul li .dcr-1tabvac:before {
+        bottom: 0;
+      }
+    }
+
+    #top-nav-input-checkbox:checked~ul li .dcr-1tabvac:hover,
+    #top-nav-input-checkbox:checked~ul li .dcr-1tabvac:focus {
+      -webkit-text-decoration: underline;
+      text-decoration: underline;
+      color: #FFE500;
+    }
+
+    #top-nav-input-checkbox:checked~ul li .dcr-1tabvac:after {
+      -webkit-transform: translateY(4px);
+      -moz-transform: translateY(4px);
+      -ms-transform: translateY(4px);
+      transform: translateY(4px);
+    }
+
+    .dcr-1tabvac:before {
+      content: '';
+      display: block;
+      position: absolute;
+      right: 0;
+      top: 0;
+      bottom: 0;
+      width: 1px;
+      background-color: #506991;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-1tabvac:before {
+        bottom: 17px;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-1tabvac:before {
+        bottom: 0.6em;
+      }
+    }
+
+    .dcr-1t1n4fm {
+      font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+      font-size: 1.0625rem;
+      line-height: 1.15;
+      font-weight: 500;
+      --source-text-decoration-thickness: 2px;
+      box-sizing: border-box;
+      font-weight: 900;
+      color: #FFFFFF;
+      cursor: pointer;
+      display: block;
+      font-size: 15.4px;
+      height: 36px;
+      padding-top: 9px;
+      padding-right: 5px;
+      padding-bottom: 0;
+      padding-left: 5px;
+      position: relative;
+      overflow: hidden;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      z-index: 1;
+    }
+
+    @media (min-width: 375px) {
+      .dcr-1t1n4fm {
+        font-size: 15.7px;
+        padding-top: 9px;
+        padding-right: 5px;
+        padding-bottom: 0;
+        padding-left: 5px;
+      }
+    }
+
+    @media (min-width: 480px) {
+      .dcr-1t1n4fm {
+        font-size: 18px;
+        padding-top: 9px;
+        padding-right: 5px;
+        padding-bottom: 0;
+        padding-left: 5px;
+      }
+    }
+
+    @media (min-width: 740px) {
+      .dcr-1t1n4fm {
+        font-size: 22px;
+        height: 48px;
+        padding-top: 9px;
+        padding-right: 20px;
+        padding-bottom: 0;
+        padding-left: 9px;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-1t1n4fm {
+        padding-top: 5px;
+        height: 42px;
+      }
+    }
+
+    @media (min-width: 1300px) {
+      .dcr-1t1n4fm {
+        padding-top: 7px;
+        font-size: 24px;
+      }
+    }
+
+    .dcr-1t1n4fm:focus:after {
+      -webkit-transform: translateY(4px);
+      -moz-transform: translateY(4px);
+      -ms-transform: translateY(4px);
+      transform: translateY(4px);
+    }
+
+    .dcr-1t1n4fm:hover {
+      -webkit-text-decoration: none;
+      text-decoration: none;
+    }
+
+    .dcr-1t1n4fm:hover:after {
+      -webkit-transform: translateY(4px);
+      -moz-transform: translateY(4px);
+      -ms-transform: translateY(4px);
+      transform: translateY(4px);
+    }
+
+    .dcr-1t1n4fm:after {
+      border-top: 4px solid #FFABDB;
+      left: 0;
+      right: 1px;
+      top: -4px;
+      content: '';
+      display: block;
+      position: absolute;
+      -webkit-transition: -webkit-transform 0.3s ease-in-out;
+      transition: transform 0.3s ease-in-out;
+    }
+
+    @media (min-width: 980px) {
+      #top-nav-input-checkbox:checked~ul li .dcr-1t1n4fm:before {
+        bottom: 0;
+      }
+    }
+
+    #top-nav-input-checkbox:checked~ul li .dcr-1t1n4fm:hover,
+    #top-nav-input-checkbox:checked~ul li .dcr-1t1n4fm:focus {
+      -webkit-text-decoration: underline;
+      text-decoration: underline;
+      color: #FFE500;
+    }
+
+    #top-nav-input-checkbox:checked~ul li .dcr-1t1n4fm:after {
+      -webkit-transform: translateY(4px);
+      -moz-transform: translateY(4px);
+      -ms-transform: translateY(4px);
+      transform: translateY(4px);
+    }
+
+    .dcr-1t1n4fm:before {
+      content: '';
+      display: block;
+      position: absolute;
+      right: 0;
+      top: 0;
+      bottom: 0;
+      width: 1px;
+      background-color: #506991;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-1t1n4fm:before {
+        bottom: 17px;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-1t1n4fm:before {
+        bottom: 0.6em;
+      }
+    }
+
+    .dcr-1kuh7tf {
+      font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+      font-size: 1.5rem;
+      line-height: 1.15;
+      font-weight: 500;
+      --source-text-decoration-thickness: 3px;
+      font-weight: 300;
+      color: #FFFFFF;
+      cursor: pointer;
+      display: none;
+      position: relative;
+      overflow: hidden;
+      border: 0;
+      background-color: transparent;
+      height: 48px;
+      padding-left: 9px;
+      padding-right: 20px;
+    }
+
+    @media (min-width: 980px) {
+      .dcr-1kuh7tf {
+        display: block;
+        padding-top: 5px;
+        height: 42px;
+      }
+    }
+
+    .dcr-1kuh7tf:hover,
+    .dcr-1kuh7tf:focus {
+      color: #FFE500;
+    }
+
+    .dcr-1kuh7tf:hover svg,
+    .dcr-1kuh7tf:focus svg {
+      -webkit-transform: translateY(2px);
+      -moz-transform: translateY(2px);
+      -ms-transform: translateY(2px);
+      transform: translateY(2px);
+    }
+
+    .dcr-1nvgr5i {
+      position: absolute;
+      overflow: hidden;
+      white-space: nowrap;
+      width: 1px;
+      height: 1px;
+      margin: -1px;
+      padding: 0;
+      border: 0;
+      clip: rect(1px, 1px, 1px, 1px);
+      -webkit-clip-path: inset(50%);
+      -webkit-clip-path: inset(50%);
+      clip-path: inset(50%);
+    }
+
+    .dcr-a2u3ka {
+      display: block;
+      height: 100%;
+    }
+
+    #top-nav-input-checkbox:checked~div label .dcr-a2u3ka svg {
+      -webkit-transform: translateY(-2px) rotate(-180deg);
+      -moz-transform: translateY(-2px) rotate(-180deg);
+      -ms-transform: translateY(-2px) rotate(-180deg);
+      transform: translateY(-2px) rotate(-180deg);
+    }
+
+    #top-nav-input-checkbox:checked~div label:hover .dcr-a2u3ka svg,
+    #top-nav-input-checkbox:checked~div label:focus .dcr-a2u3ka svg {
+      -webkit-transform: translateY(-4px) rotate(-180deg);
+      -moz-transform: translateY(-4px) rotate(-180deg);
+      -ms-transform: translateY(-4px) rotate(-180deg);
+      transform: translateY(-4px) rotate(-180deg);
+    }
+
+    .dcr-a2u3ka svg {
+      position: absolute;
+      right: 2px;
+      top: 14px;
+      fill: currentColor;
+      height: 16px;
+      width: 16px;
+      -webkit-transition: -webkit-transform 250ms ease-out;
+      transition: transform 250ms ease-out;
+    }
+
+    .dcr-13vr4eh {
+      background-color: #FFE500;
+      color: #121212;
+      cursor: pointer;
+      height: 42px;
+      min-width: 42px;
+      position: absolute;
+      border: 0;
+      border-radius: 50%;
+      right: 5px;
+      bottom: 58px;
+    }
+
+    @media (min-width: 375px) {
+      .dcr-13vr4eh {
+        bottom: -3px;
+        right: 5px;
+      }
+    }
+
+    @media (min-width: 480px) {
+      .dcr-13vr4eh {
+        right: 18px;
+      }
+    }
+
+    @media (min-width: 740px) {
+      .dcr-13vr4eh {
+        bottom: 3px;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-13vr4eh {
+        display: none;
+      }
+    }
+
+    #top-nav-input-checkbox:checked~div .dcr-13vr4eh {
+      z-index: 22;
+    }
+
+    .dcr-13vr4eh:focus {
+      outline: none;
+    }
+
+    .dcr-120u0k1 {
+      background-color: currentColor;
+      top: 50%;
+      right: 0;
+      margin-top: -1px;
+      margin-left: auto;
+      margin-right: auto;
+      height: 2px;
+      left: 0;
+      position: absolute;
+      width: 20px;
+    }
+
+    #top-nav-input-checkbox:checked~div .dcr-120u0k1 {
+      background-color: transparent;
+    }
+
+    .dcr-120u0k1:before {
+      height: 2px;
+      left: 0;
+      position: absolute;
+      width: 20px;
+      content: '';
+      background-color: currentColor;
+      top: -6px;
+    }
+
+    #top-nav-input-checkbox:checked~div .dcr-120u0k1:before {
+      top: 0;
+      -webkit-transform: rotate(-45deg);
+      -moz-transform: rotate(-45deg);
+      -ms-transform: rotate(-45deg);
+      transform: rotate(-45deg);
+    }
+
+    .dcr-120u0k1:after {
+      height: 2px;
+      left: 0;
+      position: absolute;
+      width: 20px;
+      content: '';
+      background-color: currentColor;
+      bottom: -6px;
+    }
+
+    #top-nav-input-checkbox:checked~div .dcr-120u0k1:after {
+      bottom: 0;
+      -webkit-transform: rotate(45deg);
+      -moz-transform: rotate(45deg);
+      -ms-transform: rotate(45deg);
+      transform: rotate(45deg);
+    }
+
+    .dcr-mebke {
+      background-color: rgba(0, 0, 0, 0.5);
+      z-index: 21;
+      left: 0;
+      top: 0;
+    }
+
+    @media (min-width: 980px) {
+      .dcr-mebke {
+        display: none;
+      }
+    }
+
+    @media (min-width: 980px) {
+      #top-nav-input-checkbox:checked~div .dcr-mebke {
+        display: block;
+        overflow: visible;
+      }
+    }
+
+    @media (max-width: 979px) {
+      #top-nav-input-checkbox:checked~div .dcr-mebke {
+        -webkit-transform: translateX(0%);
+        -moz-transform: translateX(0%);
+        -ms-transform: translateX(0%);
+        transform: translateX(0%);
+      }
+    }
+
+    @media (max-width: 979px) {
+      .dcr-mebke {
+        -webkit-transform: translateX(-110%);
+        -moz-transform: translateX(-110%);
+        -ms-transform: translateX(-110%);
+        transform: translateX(-110%);
+        -webkit-transition: -webkit-transform 0.4s cubic-bezier(0.23, 1, 0.32, 1);
+        transition: transform 0.4s cubic-bezier(0.23, 1, 0.32, 1);
+        box-shadow: 3px 0 16px rgba(0, 0, 0, 0.4);
+        bottom: 0;
+        height: 100%;
+        overflow: auto;
+        position: fixed;
+        right: 0;
+        will-change: transform;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-mebke {
+        display: none;
+      }
+    }
+
+    .dcr-18m7gh9 {
+      background-color: #052962;
+      box-sizing: border-box;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 1.25rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 3px;
+      margin-right: 29px;
+      left: 0;
+      top: 0;
+      z-index: 20;
+      overflow: hidden;
+    }
+
+    @media (min-width: 980px) {
+      .dcr-18m7gh9 {
+        position: absolute;
+        padding-bottom: 0;
+        padding-top: 0;
+        top: 100%;
+        left: 0;
+        right: 0;
+        width: 100%;
+      }
+
+      @supports (width: 100vw) {
+        .dcr-18m7gh9 {
+          left: 50%;
+          right: 50%;
+          width: 100vw;
+          margin-left: -50vw;
+          margin-right: -50vw;
         }
       }
 
@@ -1205,13 +3548,111 @@ https://workforus.theguardian.com/careers/product-engineering/
           opacity: 1;
         }
       }
-    </style>
-    <style
-      data-emotion="dcr vg6br7 1uyetce 1s8spa1 henwc 1kfeu4u 1kvcc9o 1492oy5 1086n7e bi2aot xg94hc 1gd007l 1yaip4y j7jlyl 14f8c26 h39xrs g8r8o3 pzbwhq 1w7ojan 1irynrj 16rjsjj 127sebo 12xduix 1ppwqv1 1z074wr x2bp9n 1yaxlqk sy54ny 1ikbe4v 1aeyz4o h2gqsd c8vw16 a6bcsq 1tabvac 1t1n4fm 1kuh7tf 1nvgr5i a2u3ka 13vr4eh 120u0k1 mebke 18m7gh9 1kn7o79 1y4qg42 1acea34 1fqnu7z nqw243 9ra8aa 13wwvzl 4hq641 16d24hr 15vcq54 bu7bnv 1xxnrhn 11zodys 1efvfp0 xlajkp hmp1vw 1kltmkq 8lx8k9 19s2ze7 1ay3cld g8v7m4 19ilr9m 1xcf7cw 190ztmi 1p0hins a7qyd9 12vycz3 e1bf28 r07hem 1sks1z0 b3zdlu jv36lp 17sb2rc vwltw3 6sdrzu pt8pb9 4phbzi nnfu1a wzkd0n efuz1g v339xn 1ykr3rf 108h94l 8qb2rj 1ghj19n 1kx60rc 1n8hb96 15t9kli 1iz7gbk 1atljbz eubdc owfrse kfs8io 1lex7d6 1mi5u71 w3rkaf 1aqutk9 pkharf 1eb5jgw zy43z4 yosj9c evn1e9 rrcudz dbozpd 14gfmlq 1vrphsc mfwrfv 9zdshs 4xb9x1 j8q3ty gf0nnr z7lzm0 1usgdx0 os58m2 zvsguo ibz96v 1ttos39 1cgn3lv 17h8ziz 82y01u 1y2cu33 p1dvl6 1wwe1mi 1i342d0 pdz5dh 1ysdk7i kt9wlt 14tkj09 gavx50 dnk6tr 12urb0b 7p7qko 41bl8c glvxc9 11vxpqc w6hc5l 194i6pr rdw702 1mbvac 109rq7o 3tlap1 elbm7f kz9nqe 1hipxkh 1e3r6sy 1p6anfw 1o7trcs adlhb4 isu8nh 1q1d8mj heqd82 3tss6n ye9dm5 awenke 12hccii zu1fd9 1pp81zm pu1sy6 yg4zrc k1vhee fossqd j3w6wb 1giivcq ddf1wi xf43jl 3x1x0z 1h1ezso 18411a1 21isvz vi7os3 1q2dk60 fo4w6z ygjxgh 102ctxe hqoq27 1oz7hnm xyss4m q76bkn t7d6p1 n4owjk 1fxs032 1ij4tou t2dtan zdnpsd 1w58byr 10j4v47 1o3p705 1wxws1r 19eam1p yi9s71 1lbz6ez vibzgs qprpng 1yduq3m 1ngqhfk 10kck6o i5gfxx 13wfre 170pumn 1v397f0 1hy529c kammsl c4kygy 91lgpk 10rqwzg 1w2x6ij 11rhxc6 yqz51q 1dijbt5 qjynpy 1vrrbyb 1xyi04h 1wf840d 1creg26 ygowzy 5hi9qv sts64 1g9k069 1xnlu54 1bljy3y 4rr662 18yycfp 13lm9u3 1qbs42f"
-    >
-      .dcr-vg6br7 {
-        font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue,
-          Helvetica, Arial, Lucida Grande, sans-serif;
+    }
+
+    .dcr-wzkd0n:hover,
+    .dcr-wzkd0n:focus {
+      color: #FFE500;
+    }
+
+    .dcr-wzkd0n>* {
+      pointer-events: none;
+    }
+
+    .dcr-1h92x0c {
+      background-color: transparent;
+    }
+
+    .dcr-188zz3t {
+      position: relative;
+      margin: auto;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-188zz3t {
+        max-width: 740px;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-188zz3t {
+        max-width: 980px;
+      }
+    }
+
+    @media (min-width: 1140px) {
+      .dcr-188zz3t {
+        max-width: 1140px;
+      }
+    }
+
+    @media (min-width: 1300px) {
+      .dcr-188zz3t {
+        max-width: 1300px;
+      }
+    }
+
+    @media (min-width: 740px) {
+      .dcr-188zz3t {
+        border-left: 1px solid #DCDCDC;
+        border-right: 1px solid #DCDCDC;
+      }
+    }
+
+    .dcr-v6jxf0 {
+      height: 36px;
+      overflow: hidden;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-box-pack: justify;
+      -webkit-justify-content: space-between;
+      justify-content: space-between;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-v6jxf0 {
+        height: 42px;
+      }
+    }
+
+    .dcr-1gt8egs {
+      list-style: none;
+      padding: 0 5px;
+    }
+
+    @media (min-width: 480px) {
+      .dcr-1gt8egs {
+        padding: 0 15px;
+      }
+    }
+
+    .dcr-1gt8egs li {
+      float: left;
+      display: block;
+    }
+
+    .dcr-qo5392 {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.9375rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      font-size: 14px;
+      font-weight: 500;
+      color: #121212;
+      padding: 0 5px;
+      height: 36px;
+      line-height: 36px;
+      float: left;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-qo5392 {
+        font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
         font-size: 1.0625rem;
         line-height: 1.35;
         font-weight: 400;
@@ -1242,29 +3683,23 @@ https://workforus.theguardian.com/careers/product-engineering/
         color: #000000;
       }
 
-      .dcr-1uyetce {
-        background-color: #052962;
-      }
+    .dcr-65xb9q {
+      display: block;
+    }
 
-      .dcr-henwc {
-        background-color: #052962;
-      }
+    .dcr-r91ehr {
+      display: grid;
+      grid-template-rows: [headline-start show-hide-start] auto [show-hide-end headline-end content-toggleable-start content-start] auto [content-end content-toggleable-end show-more-start] auto [show-more-end];
+      grid-template-columns: [decoration-start] 0px [content-start title-start] repeat(3, minmax(0, 1fr)) [hide-start] minmax(0, 1fr) [content-end title-end hide-end] 0px [decoration-end];
+      grid-auto-flow: dense;
+      -webkit-column-gap: 10px;
+      column-gap: 10px;
+    }
 
-      .dcr-1kfeu4u {
-        background-color: #041f4a;
-      }
-
-      .dcr-1kvcc9o {
-        display: -webkit-box;
-        display: -webkit-flex;
-        display: -ms-flexbox;
-        display: flex;
-        height: 30px;
-        background-color: #041f4a;
-        box-sizing: border-box;
-        padding-left: 10px;
-        position: relative;
-        margin: auto;
+    @supports not (display: grid) {
+      .dcr-r91ehr {
+        padding: 0 12px;
+        margin: 0 auto;
       }
 
       @media (min-width: 480px) {
@@ -1324,13 +3759,19 @@ https://workforus.theguardian.com/careers/product-engineering/
         display: none;
       }
 
-      @media (min-width: 980px) {
-        .dcr-1492oy5 {
-          display: -webkit-box;
-          display: -webkit-flex;
-          display: -ms-flexbox;
-          display: flex;
-        }
+    .dcr-em8d0v {
+      grid-row: 1/-1;
+      grid-column: decoration;
+      border-width: 1px;
+      border-color: #DCDCDC;
+      border-style: none;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-em8d0v {
+        margin: 0 -20px;
+        border-left-style: solid;
+        border-right-style: solid;
       }
 
       .dcr-1086n7e {
@@ -1634,8 +4075,37 @@ https://workforus.theguardian.com/careers/product-engineering/
         padding-top: 6px;
       }
 
-      .dcr-pzbwhq:hover {
-        color: #ffe500;
+    .dcr-1atljbz {
+      margin-left: 0;
+    }
+
+    .dcr-eubdc {
+      font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+      font-size: 1.5rem;
+      line-height: 1.15;
+      font-weight: 700;
+      --source-text-decoration-thickness: 3px;
+      color: #121212;
+      padding-bottom: 4px;
+      padding-top: 6px;
+      overflow-wrap: break-word;
+    }
+
+    .dcr-yyvovz {
+      margin: 0;
+      grid-column: content;
+      grid-row: content;
+      padding-top: 8px;
+    }
+
+    .hidden>.dcr-yyvovz {
+      display: none;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-yyvovz {
+        margin-left: -10px;
+        margin-right: -10px;
       }
 
       .dcr-pzbwhq:hover:after {
@@ -1663,22 +4133,141 @@ https://workforus.theguardian.com/careers/product-engineering/
         transition: transform 250ms ease-out;
       }
 
-      .dcr-pzbwhq:not(ul):hover {
-        color: #ffffff;
-        -webkit-text-decoration: underline;
-        text-decoration: underline;
+    .dcr-1p6anfw {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+      -webkit-box-pack: justify;
+      -webkit-justify-content: space-between;
+      justify-content: space-between;
+      width: 100%;
+      position: relative;
+      color: inherit;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      background-color: #F6F6F6;
+    }
+
+    .dcr-1p6anfw:hover .image-overlay {
+      position: absolute;
+      top: 0;
+      width: 100%;
+      height: 100%;
+      left: 0;
+      background-color: #121212;
+      opacity: 0.1;
+    }
+
+    .dcr-1p6anfw:hover {
+      background-color: #EDEDED;
+    }
+
+    .dcr-1p6anfw:before {
+      background-color: #C70000;
+      content: '';
+      height: 1px;
+      z-index: 2;
+      width: 100%;
+    }
+
+    .dcr-pkharf {
+      position: absolute;
+      z-index: 1;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
+      background-color: transparent;
+    }
+
+    .dcr-pkharf:focus {
+      outline: 0;
+    }
+
+    html:not(.src-focus-disabled) .dcr-pkharf:focus {
+      box-shadow: 0 0 0 5px #0077B6;
+    }
+
+    .dcr-1eb5jgw {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-basis: 100%;
+      -ms-flex-preferred-size: 100%;
+      flex-basis: 100%;
+      width: 100%;
+      -webkit-flex-direction: row-reverse;
+      -ms-flex-direction: row-reverse;
+      flex-direction: row-reverse;
+    }
+
+    @media (max-width: 739px) {
+      .dcr-1eb5jgw {
+        -webkit-flex-direction: column;
+        -ms-flex-direction: column;
+        flex-direction: column;
       }
 
-      @media (min-width: 740px) {
-        .dcr-pzbwhq {
-          right: 0;
-        }
+    .dcr-1pe3pea {
+      -webkit-flex-basis: 66%;
+      -ms-flex-preferred-size: 66%;
+      flex-basis: 66%;
+      position: relative;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-1pe3pea {
+        -webkit-align-self: flex-start;
+        -ms-flex-item-align: flex-start;
+        align-self: flex-start;
       }
 
-      @media (min-width: 980px) {
-        .dcr-pzbwhq {
-          font-weight: bold;
-        }
+    .dcr-1pe3pea img {
+      width: 100%;
+      display: block;
+    }
+
+    .dcr-yosj9c {
+      display: block;
+      padding-top: 60%;
+      position: relative;
+    }
+
+    .dcr-yosj9c>* {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+    }
+
+    .dcr-evn1e9 {
+      display: block;
+    }
+
+    .dcr-rrcudz {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+      -webkit-box-pack: justify;
+      -webkit-justify-content: space-between;
+      justify-content: space-between;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-rrcudz {
+        -webkit-flex-basis: 34%;
+        -ms-flex-preferred-size: 34%;
+        flex-basis: 34%;
       }
 
       .dcr-1w7ojan {
@@ -1715,13 +4304,39 @@ https://workforus.theguardian.com/careers/product-engineering/
         }
       }
 
-      @media (min-width: 740px) {
-        .dcr-1w7ojan {
-          position: absolute;
-          top: 100%;
-          width: 200px;
-          border-radius: 3px;
-        }
+    .dcr-1o7trcs {
+      color: #C70000;
+      font-weight: 700;
+      margin-right: 4px;
+    }
+
+    .dcr-adlhb4 {
+      color: #121212;
+    }
+
+    .dcr-hcib8t {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+      color: #121212;
+      font-family: GuardianTextEgyptian, Guardian Text Egyptian Web, Georgia, serif;
+      font-size: 0.9375rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      font-size: 14px;
+      padding-left: 5px;
+      padding-right: 5px;
+      padding-bottom: 8px;
+    }
+
+    @media (max-width: 979px) {
+      .dcr-hcib8t {
+        display: none;
       }
 
       .dcr-1w7ojan:not(ul):hover {
@@ -1730,249 +4345,4405 @@ https://workforus.theguardian.com/careers/product-engineering/
         text-decoration: underline;
       }
 
-      @media (min-width: 740px) {
-        .dcr-1w7ojan {
-          right: 0;
-        }
-      }
+    .dcr-17yg843 {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-box-pack: justify;
+      -webkit-justify-content: space-between;
+      justify-content: space-between;
+      -webkit-align-items: center;
+      -webkit-box-align: center;
+      -ms-flex-align: center;
+      align-items: center;
+    }
 
-      @media (min-width: 980px) {
-        .dcr-1w7ojan {
-          font-weight: bold;
-        }
-      }
+    .dcr-1hg1hdu {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.15;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      margin-top: -4px;
+      color: #707070;
+      padding-left: 5px;
+      padding-right: 5px;
+    }
 
-      .dcr-1irynrj {
-        font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue,
-          Helvetica, Arial, Lucida Grande, sans-serif;
-        font-size: 0.9375rem;
-        line-height: 1.35;
-        font-weight: 400;
-        --source-text-decoration-thickness: 2px;
-        color: #121212;
-        position: relative;
-        -webkit-transition: color 80ms ease-out;
-        transition: color 80ms ease-out;
-        margin: -1px 0 0 0;
-        -webkit-text-decoration: none;
-        text-decoration: none;
-        display: block;
-        padding: 10px 18px 15px 30px;
-        font-weight: bold;
+    @media (max-width: 739px) {
+      .dcr-1hg1hdu {
+        line-height: 1.25;
       }
+    }
 
-      .dcr-1irynrj:hover {
-        background-color: #ededed;
-        -webkit-text-decoration: none;
-        text-decoration: none;
+    .dcr-1hg1hdu svg {
+      fill: #707070;
+      margin-bottom: -1px;
+      height: 11px;
+      width: 11px;
+      margin-right: 2px;
+    }
+
+    .dcr-1hg1hdu>time {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+    }
+
+    .dcr-kz9nqe {
+      position: relative;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      margin-left: 5px;
+      margin-right: 5px;
+      margin-bottom: 5px;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+    }
+
+    .dcr-z7lzm0 {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+      -webkit-flex: 1;
+      -ms-flex: 1;
+      flex: 1;
+      padding-top: 2px;
+      position: relative;
+      margin-top: 8px;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-z7lzm0 {
+        margin-bottom: 4px;
       }
+    }
 
-      .dcr-1irynrj:focus {
-        -webkit-text-decoration: underline;
-        text-decoration: underline;
+    .dcr-wi48h0 {
+      font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+      font-size: 1.0625rem;
+      line-height: 1.15;
+      font-weight: 500;
+      --source-text-decoration-thickness: 2px;
+      font-size: 14px;
+      padding-top: 1px;
+    }
+
+    .dcr-wi48h0:before {
+      display: block;
+      position: absolute;
+      top: 0;
+      left: 0;
+      content: '';
+      border-top: 1px solid #DCDCDC;
+      width: 120px;
+    }
+
+    @media (min-width: 740px) and (max-width: 979px) {
+      .dcr-wi48h0:before {
+        width: 100px;
       }
+    }
 
-      .dcr-1irynrj:before {
+    .dcr-os58m2 {
+      position: relative;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 1.0625rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      cursor: pointer;
+      -webkit-text-decoration: underline;
+      text-decoration: underline;
+      text-underline-position: under;
+      text-underline-offset: 5%;
+      display: inline;
+      -webkit-align-items: center;
+      -webkit-box-align: center;
+      -ms-flex-align: center;
+      align-items: center;
+      color: #0077B6;
+      z-index: 2;
+      color: inherit;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      font-family: inherit;
+      font-size: inherit;
+      font-weight: 500;
+      line-height: inherit;
+    }
+
+    .dcr-os58m2:focus {
+      outline: 0;
+    }
+
+    html:not(.src-focus-disabled) .dcr-os58m2:focus {
+      box-shadow: 0 0 0 5px #0077B6;
+    }
+
+    .dcr-os58m2:hover {
+      text-decoration-thickness: var(--source-text-decoration-thickness, auto);
+    }
+
+    .dcr-os58m2:hover {
+      color: #0077B6;
+    }
+
+    .dcr-os58m2:hover {
+      color: inherit;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+    }
+
+    .dcr-os58m2:hover .show-underline {
+      -webkit-text-decoration: underline;
+      text-decoration: underline;
+    }
+
+    .dcr-ect2dm {
+      color: #C70000;
+      font-weight: 700;
+      margin-right: 4px;
+      display: inline-block;
+    }
+
+    .dcr-1hipxkh {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+      -webkit-flex: 1;
+      -ms-flex: 1;
+      flex: 1;
+      padding-top: 2px;
+      position: relative;
+      margin-top: 8px;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-1hipxkh {
+        margin-bottom: 4px;
+      }
+    }
+
+    @media (max-width: 739px) {
+      .dcr-1hipxkh {
+        margin-bottom: 8px;
+      }
+    }
+
+    .dcr-1cgn3lv {
+      position: relative;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      row-gap: 12px;
+      -webkit-flex-basis: 25%;
+      -ms-flex-preferred-size: 25%;
+      flex-basis: 25%;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-1cgn3lv:before {
         content: '';
-        border-top: 1px solid #dcdcdc;
         display: block;
         position: absolute;
-        top: 0px;
-        left: 30px;
-        right: 0px;
-      }
-
-      .dcr-1irynrj:after {
-        content: '';
-        border: 2px solid #c70000;
-        border-top: 0px;
-        border-right: 0px;
-        position: absolute;
-        top: 19px;
-        left: 12px;
-        width: 10px;
-        height: 4px;
-        -webkit-transform: rotate(-45deg);
-        -moz-transform: rotate(-45deg);
-        -ms-transform: rotate(-45deg);
-        transform: rotate(-45deg);
-      }
-
-      .dcr-1irynrj:before {
-        content: none;
-      }
-
-      .dcr-16rjsjj {
-        font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue,
-          Helvetica, Arial, Lucida Grande, sans-serif;
-        font-size: 0.9375rem;
-        line-height: 1.35;
-        font-weight: 400;
-        --source-text-decoration-thickness: 2px;
-        color: #121212;
-        position: relative;
-        -webkit-transition: color 80ms ease-out;
-        transition: color 80ms ease-out;
-        margin: -1px 0 0 0;
-        -webkit-text-decoration: none;
-        text-decoration: none;
-        display: block;
-        padding: 10px 18px 15px 30px;
-      }
-
-      .dcr-16rjsjj:hover {
-        background-color: #ededed;
-        -webkit-text-decoration: none;
-        text-decoration: none;
-      }
-
-      .dcr-16rjsjj:focus {
-        -webkit-text-decoration: underline;
-        text-decoration: underline;
-      }
-
-      .dcr-16rjsjj:before {
-        content: '';
-        border-top: 1px solid #dcdcdc;
-        display: block;
-        position: absolute;
-        top: 0px;
-        left: 30px;
-        right: 0px;
-      }
-
-      .dcr-127sebo {
-        position: relative;
-        margin: auto;
-        overflow: hidden;
-      }
-
-      @media (min-width: 740px) {
-        .dcr-127sebo {
-          max-width: 740px;
-        }
-      }
-
-      @media (min-width: 980px) {
-        .dcr-127sebo {
-          max-width: 980px;
-        }
-      }
-
-      @media (min-width: 1140px) {
-        .dcr-127sebo {
-          max-width: 1140px;
-        }
-      }
-
-      @media (min-width: 1300px) {
-        .dcr-127sebo {
-          max-width: 1300px;
-        }
-      }
-
-      .dcr-12xduix {
-        float: right;
-        margin-top: 6px;
-        margin-right: 54px;
-        margin-bottom: 10px;
-        width: 146px;
-        z-index: 9;
-      }
-
-      @media (min-width: 375px) {
-        .dcr-12xduix {
-          margin-right: 10px;
-          width: 195px;
-        }
-      }
-
-      @media (min-width: 480px) {
-        .dcr-12xduix {
-          margin-right: 20px;
-        }
-      }
-
-      @media (min-width: 740px) {
-        .dcr-12xduix {
-          width: 224px;
-        }
-      }
-
-      @media (min-width: 980px) {
-        .dcr-12xduix {
-          margin-top: 5px;
-          margin-bottom: 12px;
-          position: relative;
-          width: 295px;
-        }
-      }
-
-      @media (min-width: 1300px) {
-        .dcr-12xduix {
-          margin-right: 96px;
-        }
-      }
-
-      .dcr-1ppwqv1 {
-        position: absolute;
-        overflow: hidden;
-        white-space: nowrap;
+        top: 0;
+        bottom: 0;
+        left: 0;
         width: 1px;
-        height: 1px;
-        margin: -1px;
-        padding: 0;
-        border: 0;
-        clip: rect(1px, 1px, 1px, 1px);
-        -webkit-clip-path: inset(50%);
-        -webkit-clip-path: inset(50%);
-        clip-path: inset(50%);
+        height: 100%;
+        border-left: 1px solid #DCDCDC;
       }
+    }
 
-      .dcr-1z074wr {
-        position: relative;
-        margin: auto;
+      {
+      padding-left: 10px;
+      padding-right: 10px;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-1cgn3lv {
+        padding-left: 10px;
+        padding-right: 10px;
       }
+    }
 
-      @media (min-width: 740px) {
-        .dcr-1z074wr {
-          max-width: 740px;
-        }
-      }
+    .dcr-ruaspp {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+      -webkit-box-pack: justify;
+      -webkit-justify-content: space-between;
+      justify-content: space-between;
+      width: 100%;
+      position: relative;
+      color: inherit;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      background-color: #AB0613;
+    }
 
-      @media (min-width: 980px) {
-        .dcr-1z074wr {
-          max-width: 980px;
-        }
-      }
+    .dcr-ruaspp:hover .image-overlay {
+      position: absolute;
+      top: 0;
+      width: 100%;
+      height: 100%;
+      left: 0;
+      background-color: #121212;
+      opacity: 0.1;
+    }
 
-      @media (min-width: 1140px) {
-        .dcr-1z074wr {
-          max-width: 1140px;
-        }
-      }
+    .dcr-ruaspp:hover {
+      -webkit-filter: brightness(90%);
+      filter: brightness(90%);
+    }
 
-      @media (min-width: 1300px) {
-        .dcr-1z074wr {
-          max-width: 1300px;
-        }
-      }
+    .dcr-ruaspp:before {
+      background-color: #C70000;
+      content: '';
+      height: 1px;
+      z-index: 2;
+      width: 100%;
+    }
 
-      @media (min-width: 740px) {
-        .dcr-1z074wr {
-          border-left: 1px solid #506991;
-          border-right: 1px solid #506991;
-        }
-      }
+    .dcr-17h8ziz {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-basis: 100%;
+      -ms-flex-preferred-size: 100%;
+      flex-basis: 100%;
+      width: 100%;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+    }
 
-      .dcr-x2bp9n {
-        display: -webkit-box;
-        display: -webkit-flex;
-        display: -ms-flexbox;
-        display: flex;
+    @media (max-width: 739px) {
+      .dcr-17h8ziz {
         -webkit-flex-direction: row;
         -ms-flex-direction: row;
         flex-direction: row;
+      }
+    }
+
+    .dcr-1pb5o7w {
+      position: relative;
+    }
+
+    @media (max-width: 739px) {
+      .dcr-1pb5o7w {
+        width: 125px;
+        -webkit-flex-shrink: 0;
+        -ms-flex-negative: 0;
+        flex-shrink: 0;
+        margin-top: 4px;
+        margin-right: 0;
+        margin-bottom: 4px;
+        margin-left: 4px;
+        -webkit-flex-basis: unset;
+        -ms-flex-preferred-size: unset;
+        flex-basis: unset;
+        -webkit-align-self: flex-start;
+        -ms-flex-item-align: flex-start;
+        align-self: flex-start;
+      }
+    }
+
+    .dcr-1pb5o7w img {
+      width: 100%;
+      display: block;
+    }
+
+    .dcr-1y2cu33 {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+      -webkit-box-pack: justify;
+      -webkit-justify-content: space-between;
+      justify-content: space-between;
+      -webkit-box-flex: 1;
+      -webkit-flex-grow: 1;
+      -ms-flex-positive: 1;
+      flex-grow: 1;
+    }
+
+    .dcr-p1dvl6 {
+      font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+      font-size: 1.25rem;
+      line-height: 1.15;
+      font-weight: 500;
+      --source-text-decoration-thickness: 3px;
+    }
+
+    @media (max-width: 979px) {
+      .dcr-p1dvl6 {
+        font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+        font-size: 1.0625rem;
+        line-height: 1.15;
+        font-weight: 500;
+        --source-text-decoration-thickness: 2px;
+      }
+    }
+
+    .dcr-16jv6hb {
+      color: #FFBAC8;
+      font-weight: 700;
+      margin-right: 4px;
+    }
+
+    .dcr-5bdubr {
+      color: #FFBAC8;
+    }
+
+    .dcr-5bdubr:before {
+      border-radius: 62.5rem;
+      display: inline-block;
+      position: relative;
+      background-color: currentColor;
+      width: 0.75em;
+      height: 0.75em;
+      content: '';
+      margin-right: 0.1875rem;
+      vertical-align: initial;
+    }
+
+    .dcr-5bdubr[data-animate='true'] {
+      -webkit-animation: animation-111ynch 1s infinite;
+      animation: animation-111ynch 1s infinite;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .dcr-5bdubr[data-animate='true'] {
+        -webkit-animation: none;
+        animation: none;
+      }
+    }
+
+    .dcr-mfwrfv {
+      color: #FFFFFF;
+    }
+
+    .dcr-1g99xyq {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.15;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      margin-top: -4px;
+      color: #FFFFFF;
+      padding-left: 5px;
+      padding-right: 5px;
+    }
+
+    @media (max-width: 739px) {
+      .dcr-1g99xyq {
+        line-height: 1.25;
+      }
+    }
+
+    .dcr-1g99xyq svg {
+      fill: #FFFFFF;
+      margin-bottom: -1px;
+      height: 11px;
+      width: 11px;
+      margin-right: 2px;
+    }
+
+    .dcr-1g99xyq>time {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+    }
+
+    .dcr-y4cf8a {
+      position: relative;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: row;
+      -ms-flex-direction: row;
+      flex-direction: row;
+      row-gap: 12px;
+    }
+
+    @media (max-width: 739px) {
+      .dcr-y4cf8a {
+        -webkit-flex-direction: column;
+        -ms-flex-direction: column;
+        flex-direction: column;
+        width: 100%;
+      }
+    }
+
+    @media (min-width: 740px) {
+      .dcr-y4cf8a {
+        -webkit-box-flex-wrap: wrap;
+        -webkit-flex-wrap: wrap;
+        -ms-flex-wrap: wrap;
+        flex-wrap: wrap;
+      }
+    }
+
+    .dcr-elbm7f {
+      position: relative;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      row-gap: 12px;
+      -webkit-flex-basis: 25%;
+      -ms-flex-preferred-size: 25%;
+      flex-basis: 25%;
+    }
+
+      {
+      padding-left: 10px;
+      padding-right: 10px;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-elbm7f {
+        padding-left: 10px;
+        padding-right: 10px;
+      }
+    }
+
+    .dcr-1ysdk7i {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      position: absolute;
+      bottom: 4px;
+      left: 4px;
+    }
+
+    .dcr-kt9wlt {
+      background-color: #FFE500;
+      border-radius: 50%;
+      width: 28px;
+      height: 28px;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-align-items: center;
+      -webkit-box-align: center;
+      -ms-flex-align: center;
+      align-items: center;
+      -webkit-box-pack: center;
+      -ms-flex-pack: center;
+      -webkit-justify-content: center;
+      justify-content: center;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-kt9wlt {
+        width: 28px;
+        height: 28px;
+      }
+    }
+
+    .dcr-kt9wlt svg {
+      -webkit-transform: translateX(1px);
+      -moz-transform: translateX(1px);
+      -ms-transform: translateX(1px);
+      transform: translateX(1px);
+      width: 26px;
+      height: 26px;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-kt9wlt svg {
+        width: 26px;
+        height: 26px;
+      }
+    }
+
+    .dcr-1xir693 {
+      position: relative;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 1.0625rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      cursor: pointer;
+      -webkit-text-decoration: underline;
+      text-decoration: underline;
+      text-underline-position: under;
+      text-underline-offset: 5%;
+      display: inline;
+      -webkit-align-items: center;
+      -webkit-box-align: center;
+      -ms-flex-align: center;
+      align-items: center;
+      color: #0077B6;
+      z-index: 2;
+      color: inherit;
+      font-family: inherit;
+      font-size: inherit;
+      line-height: inherit;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+    }
+
+    .dcr-1xir693:focus {
+      outline: 0;
+    }
+
+    html:not(.src-focus-disabled) .dcr-1xir693:focus {
+      box-shadow: 0 0 0 5px #0077B6;
+    }
+
+    .dcr-1xir693:hover {
+      text-decoration-thickness: var(--source-text-decoration-thickness, auto);
+    }
+
+    .dcr-1xir693:hover {
+      color: #0077B6;
+    }
+
+    .dcr-10b6thp {
+      font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+      font-size: 1.0625rem;
+      line-height: 1.15;
+      font-weight: 500;
+      --source-text-decoration-thickness: 2px;
+      font-size: 14px;
+      padding-top: 1px;
+    }
+
+    .dcr-10b6thp:before {
+      display: block;
+      position: absolute;
+      top: 0;
+      left: 0;
+      content: '';
+      border-top: 1px solid #FFBAC8;
+      width: 120px;
+    }
+
+    @media (min-width: 740px) and (max-width: 979px) {
+      .dcr-10b6thp:before {
+        width: 100px;
+      }
+    }
+
+    .dcr-cho92m {
+      color: #FFBAC8;
+      font-weight: 700;
+      margin-right: 4px;
+      display: inline-block;
+    }
+
+    .dcr-16fqzm2 {
+      position: relative;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      row-gap: 12px;
+      -webkit-flex-basis: 50%;
+      -ms-flex-preferred-size: 50%;
+      flex-basis: 50%;
+    }
+
+    .dcr-1lcaowc {
+      position: relative;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: row;
+      -ms-flex-direction: row;
+      flex-direction: row;
+      row-gap: 12px;
+    }
+
+    @media (max-width: 739px) {
+      .dcr-1lcaowc {
+        -webkit-flex-direction: column;
+        -ms-flex-direction: column;
+        flex-direction: column;
+        width: 100%;
+      }
+    }
+
+    @media (min-width: 740px) {
+      .dcr-1lcaowc:before {
+        content: '';
+        display: block;
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        left: 0;
+        width: 1px;
+        height: 100%;
+        border-left: 1px solid #DCDCDC;
+      }
+    }
+
+    @media (min-width: 740px) {
+      .dcr-1lcaowc {
+        -webkit-box-flex-wrap: wrap;
+        -webkit-flex-wrap: wrap;
+        -ms-flex-wrap: wrap;
+        flex-wrap: wrap;
+      }
+    }
+
+    .dcr-avaain {
+      position: relative;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      row-gap: 12px;
+      -webkit-flex-basis: 50%;
+      -ms-flex-preferred-size: 50%;
+      flex-basis: 50%;
+      -webkit-box-flex: 1;
+      -webkit-flex-grow: 1;
+      -ms-flex-positive: 1;
+      flex-grow: 1;
+    }
+
+      {
+      padding-left: 10px;
+      padding-right: 10px;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-avaain {
+        padding-left: 10px;
+        padding-right: 10px;
+      }
+    }
+
+    .dcr-12hccii {
+      font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+      font-size: 1.0625rem;
+      line-height: 1.15;
+      font-weight: 500;
+      --source-text-decoration-thickness: 2px;
+    }
+
+    .dcr-y8nd8l {
+      position: relative;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      row-gap: 12px;
+      -webkit-flex-basis: 50%;
+      -ms-flex-preferred-size: 50%;
+      flex-basis: 50%;
+      -webkit-box-flex: 1;
+      -webkit-flex-grow: 1;
+      -ms-flex-positive: 1;
+      flex-grow: 1;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-y8nd8l:before {
+        content: '';
+        display: block;
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        left: 0;
+        width: 1px;
+        height: 100%;
+        height: calc(100% + 12px);
+        border-left: 1px solid #DCDCDC;
+      }
+    }
+
+      {
+      padding-left: 10px;
+      padding-right: 10px;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-y8nd8l {
+        padding-left: 10px;
+        padding-right: 10px;
+      }
+    }
+
+    .dcr-1pscgow {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+      -webkit-box-pack: justify;
+      -webkit-justify-content: space-between;
+      justify-content: space-between;
+      width: 100%;
+      position: relative;
+      color: inherit;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      background-color: #F6F6F6;
+    }
+
+    .dcr-1pscgow:hover .image-overlay {
+      position: absolute;
+      top: 0;
+      width: 100%;
+      height: 100%;
+      left: 0;
+      background-color: #121212;
+      opacity: 0.1;
+    }
+
+    .dcr-1pscgow:hover {
+      background-color: #EDEDED;
+    }
+
+    .dcr-1pscgow:before {
+      background-color: #866D50;
+      content: '';
+      height: 1px;
+      z-index: 2;
+      width: 100%;
+    }
+
+    .dcr-1i3wv16 {
+      color: #866D50;
+      font-weight: 700;
+      margin-right: 4px;
+    }
+
+    .dcr-15p4tz0 {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+      -webkit-box-pack: justify;
+      -webkit-justify-content: space-between;
+      justify-content: space-between;
+      width: 100%;
+      position: relative;
+      color: inherit;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      background-color: #F6F6F6;
+    }
+
+    .dcr-15p4tz0:hover .image-overlay {
+      position: absolute;
+      top: 0;
+      width: 100%;
+      height: 100%;
+      left: 0;
+      background-color: #121212;
+      opacity: 0.1;
+    }
+
+    .dcr-15p4tz0:hover {
+      background-color: #EDEDED;
+    }
+
+    .dcr-15p4tz0:before {
+      background-color: #BB3B80;
+      content: '';
+      height: 1px;
+      z-index: 2;
+      width: 100%;
+    }
+
+    .dcr-hhyfju {
+      color: #BB3B80;
+      font-weight: 700;
+      margin-right: 4px;
+    }
+
+    .dcr-9e78hl {
+      position: relative;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      row-gap: 12px;
+      -webkit-flex-basis: 50%;
+      -ms-flex-preferred-size: 50%;
+      flex-basis: 50%;
+      -webkit-box-flex: 1;
+      -webkit-flex-grow: 1;
+      -ms-flex-positive: 1;
+      flex-grow: 1;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-9e78hl:before {
+        content: '';
+        display: block;
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        left: 0;
+        width: 1px;
+        height: 100%;
+        border-left: 1px solid #DCDCDC;
+      }
+    }
+
+      {
+      padding-left: 10px;
+      padding-right: 10px;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-9e78hl {
+        padding-left: 10px;
+        padding-right: 10px;
+      }
+    }
+
+    .dcr-glvxc9 {
+      grid-row: show-more;
+      grid-column: content;
+      padding-bottom: 36px;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-glvxc9 {
+        margin-left: -10px;
+        margin-right: -10px;
+      }
+    }
+
+    .dcr-rdw702 {
+      display: none;
+      padding-top: 8px;
+    }
+
+    @media (min-width: 1140px) {
+      .dcr-rdw702 {
+        display: block;
+        -webkit-align-self: end;
+        -ms-flex-item-align: end;
+        align-self: end;
+        grid-row: treats;
+        grid-column: title;
+      }
+    }
+
+    .hidden>.dcr-rdw702 {
+      display: none;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-12r3co1 {
+        display: none;
+      }
+    }
+
+    .dcr-1uz1ca8 .ad-slot__scroll {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      max-height: 24px;
+      background-color: #F6F6F6;
+      padding: 0 8px;
+      border-top: 1px solid #DCDCDC;
+      color: #707070;
+      text-align: left;
+      box-sizing: border-box;
+      position: relative;
+    }
+
+    .dcr-1uz1ca8 .ad-slot__scroll.visible {
+      visibility: initial;
+    }
+
+    .dcr-1uz1ca8 .ad-slot__scroll.hidden {
+      visibility: hidden;
+    }
+
+    .dcr-1uz1ca8 .ad-slot__close-button {
+      display: none;
+    }
+
+    .dcr-1uz1ca8 .ad-slot__scroll {
+      position: fixed;
+      bottom: 0;
+      width: 100%;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      max-height: 24px;
+      background-color: #F6F6F6;
+      padding: 0 8px;
+      border-top: 1px solid #DCDCDC;
+      color: #707070;
+      text-align: left;
+      box-sizing: border-box;
+    }
+
+    .dcr-1uz1ca8 .ad-slot:not[data-label-show='true']::before {
+      content: '';
+      display: block;
+      height: 24px;
+      visibility: hidden;
+    }
+
+    .dcr-1uz1ca8 .ad-slot[data-label-show='true']:not(.ad-slot--interscroller):not(.ad-slot--merchandising):not(.ad-slot--merchandising-high)::before {
+      content: attr(ad-label-text);
+      display: block;
+      position: relative;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      max-height: 24px;
+      background-color: #F6F6F6;
+      padding: 0 8px;
+      border-top: 1px solid #DCDCDC;
+      color: #707070;
+      text-align: left;
+      box-sizing: border-box;
+    }
+
+    .dcr-1uz1ca8 .ad-slot--merchandising[data-label-show='true']::before,
+    .dcr-1uz1ca8 .ad-slot--merchandising-high[data-label-show='true']::before {
+      content: attr(ad-label-text);
+      display: block;
+      position: relative;
+      max-width: 970px;
+      margin: auto;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      max-height: 24px;
+      background-color: #F6F6F6;
+      padding: 0 8px;
+      border-top: 1px solid #DCDCDC;
+      color: #707070;
+      text-align: left;
+      box-sizing: border-box;
+    }
+
+    .dcr-1uz1ca8 .ad-slot__adtest-cookie-clear-link {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      text-align: left;
+      position: absolute;
+      left: 268px;
+      top: 1px;
+      z-index: 10;
+      padding: 0;
+      border: 0;
+    }
+
+    .dcr-1uz1ca8.ad-slot--fluid {
+      min-height: 250px;
+      line-height: 10px;
+      padding: 0;
+      margin: 0;
+    }
+
+    .dcr-1uz1ca8 .ad-slot.ad-slot--collapse {
+      display: none;
+    }
+
+    .dcr-1r4i92e {
+      position: relative;
+      min-height: 274px;
+      min-width: 300px;
+      width: 300px;
+      margin: 12px auto;
+    }
+
+    .dcr-1r4i92e .ad-slot__scroll {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      max-height: 24px;
+      background-color: #F6F6F6;
+      padding: 0 8px;
+      border-top: 1px solid #DCDCDC;
+      color: #707070;
+      text-align: left;
+      box-sizing: border-box;
+      position: relative;
+    }
+
+    .dcr-1r4i92e .ad-slot__scroll.visible {
+      visibility: initial;
+    }
+
+    .dcr-1r4i92e .ad-slot__scroll.hidden {
+      visibility: hidden;
+    }
+
+    .dcr-1r4i92e .ad-slot__close-button {
+      display: none;
+    }
+
+    .dcr-1r4i92e .ad-slot__scroll {
+      position: fixed;
+      bottom: 0;
+      width: 100%;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      max-height: 24px;
+      background-color: #F6F6F6;
+      padding: 0 8px;
+      border-top: 1px solid #DCDCDC;
+      color: #707070;
+      text-align: left;
+      box-sizing: border-box;
+    }
+
+    .dcr-1r4i92e .ad-slot:not[data-label-show='true']::before {
+      content: '';
+      display: block;
+      height: 24px;
+      visibility: hidden;
+    }
+
+    .dcr-1r4i92e .ad-slot[data-label-show='true']:not(.ad-slot--interscroller):not(.ad-slot--merchandising):not(.ad-slot--merchandising-high)::before {
+      content: attr(ad-label-text);
+      display: block;
+      position: relative;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      max-height: 24px;
+      background-color: #F6F6F6;
+      padding: 0 8px;
+      border-top: 1px solid #DCDCDC;
+      color: #707070;
+      text-align: left;
+      box-sizing: border-box;
+    }
+
+    .dcr-1r4i92e .ad-slot--merchandising[data-label-show='true']::before,
+    .dcr-1r4i92e .ad-slot--merchandising-high[data-label-show='true']::before {
+      content: attr(ad-label-text);
+      display: block;
+      position: relative;
+      max-width: 970px;
+      margin: auto;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      max-height: 24px;
+      background-color: #F6F6F6;
+      padding: 0 8px;
+      border-top: 1px solid #DCDCDC;
+      color: #707070;
+      text-align: left;
+      box-sizing: border-box;
+    }
+
+    .dcr-1r4i92e .ad-slot__adtest-cookie-clear-link {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      text-align: left;
+      position: absolute;
+      left: 268px;
+      top: 1px;
+      z-index: 10;
+      padding: 0;
+      border: 0;
+    }
+
+    .dcr-1r4i92e.ad-slot--fluid {
+      min-height: 250px;
+      line-height: 10px;
+      padding: 0;
+      margin: 0;
+    }
+
+    .dcr-1r4i92e .ad-slot.ad-slot--collapse {
+      display: none;
+    }
+
+    .dcr-ti0g6y {
+      display: grid;
+      grid-template-rows: [headline-start show-hide-start] auto [show-hide-end headline-end content-toggleable-start content-start] auto [content-end content-toggleable-end show-more-start] auto [show-more-end];
+      grid-template-columns: [decoration-start] 0px [content-start title-start] repeat(3, minmax(0, 1fr)) [hide-start] minmax(0, 1fr) [content-end title-end hide-end] 0px [decoration-end];
+      grid-auto-flow: dense;
+      -webkit-column-gap: 10px;
+      column-gap: 10px;
+      background-color: #f2f2f2;
+    }
+
+    @supports not (display: grid) {
+      .dcr-ti0g6y {
+        padding: 0 12px;
+        margin: 0 auto;
+      }
+
+      @media (min-width: 480px) {
+        .dcr-ti0g6y {
+          padding: 0 20px;
+        }
+      }
+
+      @media (min-width: 740px) {
+        .dcr-ti0g6y {
+          width: 700px;
+        }
+      }
+
+      @media (min-width: 980px) {
+        .dcr-ti0g6y {
+          width: 940px;
+        }
+      }
+
+      @media (min-width: 1140px) {
+        .dcr-ti0g6y {
+          width: 1100px;
+        }
+      }
+
+      @media (min-width: 1300px) {
+        .dcr-ti0g6y {
+          width: 1260px;
+        }
+      }
+    }
+
+    @media (min-width: 480px) {
+      .dcr-ti0g6y {
+        -webkit-column-gap: 20px;
+        column-gap: 20px;
+      }
+    }
+
+    @media (min-width: 740px) {
+      .dcr-ti0g6y {
+        grid-template-columns: minmax(0, 1fr) [decoration-start content-start title-start] repeat(11, 40px) [hide-start] 40px [decoration-end content-end title-end hide-end] minmax(0, 1fr);
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-ti0g6y {
+        grid-template-columns: minmax(0, 1fr) [decoration-start content-start title-start] repeat(11, 60px) [hide-start] 60px [decoration-end content-end title-end hide-end] minmax(0, 1fr);
+      }
+    }
+
+    @media (min-width: 1140px) {
+      .dcr-ti0g6y {
+        grid-template-rows: [headline-start show-hide-start content-start] auto [show-hide-end content-toggleable-start] auto [headline-end treats-start] auto [content-end content-toggleable-end treats-end show-more-start] auto [show-more-end];
+        grid-template-columns: minmax(0, 1fr) [decoration-start title-start] repeat(2, 60px) [title-end content-start] repeat(11, 60px) [hide-start] 60px [decoration-end hide-end content-end] minmax(0, 1fr);
+      }
+    }
+
+    @media (min-width: 1300px) {
+      .dcr-ti0g6y {
+        grid-template-rows: [headline-start content-start content-toggleable-start show-hide-start] auto [show-hide-end] auto [headline-end treats-start] auto [content-end content-toggleable-end treats-end show-more-start] auto [show-more-end];
+        grid-template-columns: minmax(0, 1fr) [decoration-start title-start] repeat(3, 60px) [title-end content-start] repeat(12, 60px) [content-end hide-start] 60px [decoration-end hide-end] minmax(0, 1fr);
+      }
+    }
+
+    .dcr-b25wgn {
+      grid-row: 1/-1;
+      grid-column: decoration;
+      border-width: 1px;
+      border-color: #DCDCDC;
+      border-style: none;
+      border-top-style: solid;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-b25wgn {
+        margin: 0 -20px;
+        border-left-style: solid;
+        border-right-style: solid;
+      }
+    }
+
+    .dcr-1qxltt {
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      color: #121212;
+      margin-bottom: 8px;
+    }
+
+    .dcr-1qxltt:hover {
+      -webkit-text-decoration: underline;
+      text-decoration: underline;
+    }
+
+    .dcr-owfrse {
+      grid-row: show-hide;
+      grid-column: hide;
+      justify-self: end;
+    }
+
+    .dcr-swmefo {
+      position: relative;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 1.0625rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      cursor: pointer;
+      -webkit-text-decoration: underline;
+      text-decoration: underline;
+      text-underline-position: under;
+      text-underline-offset: 5%;
+      display: inline;
+      -webkit-align-items: center;
+      -webkit-box-align: center;
+      -ms-flex-align: center;
+      align-items: center;
+      border: none;
+      background: transparent;
+      padding: 0;
+      color: #121212;
+      color: #333333;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.875rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      margin-top: 8px;
+      margin-right: 10px;
+      margin-bottom: 8px;
+      position: relative;
+      -webkit-align-items: bottom;
+      -webkit-box-align: bottom;
+      -ms-flex-align: bottom;
+      align-items: bottom;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+    }
+
+    .dcr-swmefo:focus {
+      outline: 0;
+    }
+
+    html:not(.src-focus-disabled) .dcr-swmefo:focus {
+      box-shadow: 0 0 0 5px #0077B6;
+    }
+
+    .dcr-swmefo:hover {
+      text-decoration-thickness: var(--source-text-decoration-thickness, auto);
+    }
+
+    .dcr-swmefo:hover {
+      color: #121212;
+    }
+
+    .dcr-1lex7d6 {
+      margin: 0;
+      grid-column: content;
+      grid-row: content-toggleable;
+      padding-top: 8px;
+    }
+
+    .hidden>.dcr-1lex7d6 {
+      display: none;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-1lex7d6 {
+        margin-left: -10px;
+        margin-right: -10px;
+      }
+    }
+
+    .dcr-1wwe1mi {
+      position: relative;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: row;
+      -ms-flex-direction: row;
+      flex-direction: row;
+      row-gap: 12px;
+    }
+
+    @media (max-width: 739px) {
+      .dcr-1wwe1mi {
+        -webkit-flex-direction: column;
+        -ms-flex-direction: column;
+        flex-direction: column;
+        width: 100%;
+      }
+    }
+
+    .dcr-1i342d0 {
+      position: relative;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      row-gap: 12px;
+      -webkit-flex: 1;
+      -ms-flex: 1;
+      flex: 1;
+    }
+
+      {
+      padding-left: 10px;
+      padding-right: 10px;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-1i342d0 {
+        padding-left: 10px;
+        padding-right: 10px;
+      }
+    }
+
+    .dcr-pzujhk {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+      -webkit-box-pack: justify;
+      -webkit-justify-content: space-between;
+      justify-content: space-between;
+      width: 100%;
+      position: relative;
+      color: inherit;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      background-color: #DCDCDC;
+    }
+
+    .dcr-pzujhk:hover .image-overlay {
+      position: absolute;
+      top: 0;
+      width: 100%;
+      height: 100%;
+      left: 0;
+      background-color: #121212;
+      opacity: 0.1;
+    }
+
+    .dcr-pzujhk:hover {
+      -webkit-filter: brightness(95%);
+      filter: brightness(95%);
+    }
+
+    .dcr-pzujhk:before {
+      background-color: #8B0000;
+      content: '';
+      height: 1px;
+      z-index: 2;
+      width: 100%;
+    }
+
+    .dcr-1m43ich {
+      color: #8B0000;
+      font-weight: 700;
+      margin-right: 4px;
+    }
+
+    .dcr-1tuqo8l {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.15;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      margin-top: -4px;
+      color: #121212;
+      padding-left: 5px;
+      padding-right: 5px;
+    }
+
+    @media (max-width: 739px) {
+      .dcr-1tuqo8l {
+        line-height: 1.25;
+      }
+    }
+
+    .dcr-1tuqo8l svg {
+      fill: #121212;
+      margin-bottom: -1px;
+      height: 11px;
+      width: 11px;
+      margin-right: 2px;
+    }
+
+    .dcr-1tuqo8l>time {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+    }
+
+    .dcr-1acn58b {
+      position: relative;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      row-gap: 12px;
+      -webkit-flex: 1;
+      -ms-flex: 1;
+      flex: 1;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-1acn58b:before {
+        content: '';
+        display: block;
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        left: 0;
+        width: 1px;
+        height: 100%;
+        border-left: 1px solid rgba(153, 153, 153, 0.4);
+      }
+    }
+
+      {
+      padding-left: 10px;
+      padding-right: 10px;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-1acn58b {
+        padding-left: 10px;
+        padding-right: 10px;
+      }
+    }
+
+    .dcr-kfs8io {
+      position: relative;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 1.0625rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      cursor: pointer;
+      -webkit-text-decoration: underline;
+      text-decoration: underline;
+      text-underline-position: under;
+      text-underline-offset: 5%;
+      display: inline;
+      -webkit-align-items: center;
+      -webkit-box-align: center;
+      -ms-flex-align: center;
+      align-items: center;
+      border: none;
+      background: transparent;
+      padding: 0;
+      color: #121212;
+      color: #707070;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.875rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      margin-top: 8px;
+      margin-right: 10px;
+      margin-bottom: 8px;
+      position: relative;
+      -webkit-align-items: bottom;
+      -webkit-box-align: bottom;
+      -ms-flex-align: bottom;
+      align-items: bottom;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+    }
+
+    .dcr-kfs8io:focus {
+      outline: 0;
+    }
+
+    html:not(.src-focus-disabled) .dcr-kfs8io:focus {
+      box-shadow: 0 0 0 5px #0077B6;
+    }
+
+    .dcr-kfs8io:hover {
+      text-decoration-thickness: var(--source-text-decoration-thickness, auto);
+    }
+
+    .dcr-kfs8io:hover {
+      color: #121212;
+    }
+
+    .dcr-j8q3ty {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-box-pack: end;
+      -ms-flex-pack: end;
+      -webkit-justify-content: flex-end;
+      justify-content: flex-end;
+    }
+
+    .dcr-lqxdi4 {
+      position: relative;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: row-reverse;
+      -ms-flex-direction: row-reverse;
+      flex-direction: row-reverse;
+      row-gap: 12px;
+    }
+
+    @media (max-width: 739px) {
+      .dcr-lqxdi4 {
+        -webkit-flex-direction: column;
+        -ms-flex-direction: column;
+        flex-direction: column;
+        width: 100%;
+      }
+    }
+
+    .dcr-isu8nh {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+      color: #121212;
+      font-family: GuardianTextEgyptian, Guardian Text Egyptian Web, Georgia, serif;
+      font-size: 0.9375rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      font-size: 14px;
+      padding-left: 5px;
+      padding-right: 5px;
+      padding-bottom: 8px;
+    }
+
+    @media (max-width: 739px) {
+      .dcr-isu8nh {
+        display: none;
+      }
+    }
+
+    .dcr-1izbchs {
+      position: relative;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      row-gap: 12px;
+      -webkit-flex-basis: 100%;
+      -ms-flex-preferred-size: 100%;
+      flex-basis: 100%;
+    }
+
+      {
+      padding-left: 10px;
+      padding-right: 10px;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-1izbchs {
+        padding-left: 10px;
+        padding-right: 10px;
+      }
+    }
+
+    .dcr-3tss6n {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-basis: 100%;
+      -ms-flex-preferred-size: 100%;
+      flex-basis: 100%;
+      width: 100%;
+      -webkit-flex-direction: row;
+      -ms-flex-direction: row;
+      flex-direction: row;
+    }
+
+    @media (max-width: 739px) {
+      .dcr-3tss6n {
+        -webkit-flex-direction: column;
+        -ms-flex-direction: column;
+        flex-direction: column;
+      }
+    }
+
+    .dcr-1e7l74i {
+      -webkit-flex-basis: 25%;
+      -ms-flex-preferred-size: 25%;
+      flex-basis: 25%;
+      position: relative;
+    }
+
+    @media (min-width: 740px) and (max-width: 979px) {
+      .dcr-1e7l74i {
+        -webkit-flex-basis: 40%;
+        -ms-flex-preferred-size: 40%;
+        flex-basis: 40%;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-1e7l74i {
+        -webkit-flex-basis: 30%;
+        -ms-flex-preferred-size: 30%;
+        flex-basis: 30%;
+      }
+    }
+
+    @media (max-width: 739px) {
+      .dcr-1e7l74i {
+        display: none;
+      }
+    }
+
+    @media (min-width: 740px) {
+      .dcr-1e7l74i {
+        -webkit-align-self: flex-start;
+        -ms-flex-item-align: flex-start;
+        align-self: flex-start;
+      }
+    }
+
+    .dcr-1e7l74i img {
+      width: 100%;
+      display: block;
+    }
+
+    .dcr-awenke {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+      -webkit-box-pack: justify;
+      -webkit-justify-content: space-between;
+      justify-content: space-between;
+      -webkit-flex-basis: 75%;
+      -ms-flex-preferred-size: 75%;
+      flex-basis: 75%;
+    }
+
+    @media (min-width: 740px) and (max-width: 979px) {
+      .dcr-awenke {
+        -webkit-flex-basis: 60%;
+        -ms-flex-preferred-size: 60%;
+        flex-basis: 60%;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-awenke {
+        -webkit-flex-basis: 70%;
+        -ms-flex-preferred-size: 70%;
+        flex-basis: 70%;
+      }
+    }
+
+    .dcr-1mbvac {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+    }
+
+    .dcr-109rq7o {
+      margin-top: 12px;
+      border-left: 1px solid #DCDCDC;
+      border-top: 1px solid #DCDCDC;
+      padding-top: 4px;
+      padding-left: 8px;
+    }
+
+    .dcr-3tlap1 {
+      position: relative;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 1.0625rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      cursor: pointer;
+      -webkit-text-decoration: underline;
+      text-decoration: underline;
+      text-underline-position: under;
+      text-underline-offset: 5%;
+      display: inline;
+      -webkit-align-items: center;
+      -webkit-box-align: center;
+      -ms-flex-align: center;
+      align-items: center;
+      color: #121212;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+    }
+
+    .dcr-3tlap1:focus {
+      outline: 0;
+    }
+
+    html:not(.src-focus-disabled) .dcr-3tlap1:focus {
+      box-shadow: 0 0 0 5px #0077B6;
+    }
+
+    .dcr-3tlap1:hover {
+      text-decoration-thickness: var(--source-text-decoration-thickness, auto);
+    }
+
+    .dcr-3tlap1:hover {
+      color: #121212;
+    }
+
+    .dcr-1hd9axk {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+      -webkit-box-pack: justify;
+      -webkit-justify-content: space-between;
+      justify-content: space-between;
+      width: 100%;
+      position: relative;
+      color: inherit;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      background-color: #FEF9F5;
+    }
+
+    .dcr-1hd9axk:hover .image-overlay {
+      position: absolute;
+      top: 0;
+      width: 100%;
+      height: 100%;
+      left: 0;
+      background-color: #121212;
+      opacity: 0.1;
+    }
+
+    .dcr-1hd9axk:hover {
+      background-color: #fdf0e8;
+    }
+
+    .dcr-1hd9axk:before {
+      background-color: #C74600;
+      content: '';
+      height: 1px;
+      z-index: 2;
+      width: 100%;
+    }
+
+    .dcr-13b893w {
+      height: 1em;
+      width: 1.5em;
+      margin-right: 3px;
+      vertical-align: baseline;
+      fill: #C74600;
+    }
+
+    .dcr-1xjlcua {
+      display: block;
+      font-style: italic;
+      font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+      font-size: 1.5rem;
+      line-height: 1.15;
+      font-weight: 500;
+      --source-text-decoration-thickness: 3px;
+      color: #C74600;
+    }
+
+    @media (max-width: 979px) {
+      .dcr-1xjlcua {
+        font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+        font-size: 1.25rem;
+        line-height: 1.15;
+        font-weight: 500;
+        --source-text-decoration-thickness: 3px;
+      }
+    }
+
+    .dcr-tttgpl {
+      -webkit-flex: 1;
+      -ms-flex: 1;
+      flex: 1;
+      -webkit-align-self: flex-end;
+      -ms-flex-item-align: flex-end;
+      align-self: flex-end;
+    }
+
+    .dcr-1f9ehwl {
+      display: block;
+      font-style: italic;
+      font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+      font-size: 1.25rem;
+      line-height: 1.15;
+      font-weight: 500;
+      --source-text-decoration-thickness: 3px;
+      color: #C74600;
+    }
+
+    @media (max-width: 979px) {
+      .dcr-1f9ehwl {
+        font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+        font-size: 1.0625rem;
+        line-height: 1.15;
+        font-weight: 500;
+        --source-text-decoration-thickness: 2px;
+      }
+    }
+
+    .dcr-8y9hd2 {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+      -webkit-box-pack: justify;
+      -webkit-justify-content: space-between;
+      justify-content: space-between;
+      width: 100%;
+      position: relative;
+      color: inherit;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      background-color: #FEF9F5;
+    }
+
+    .dcr-8y9hd2:hover .image-overlay {
+      position: absolute;
+      top: 0;
+      width: 100%;
+      height: 100%;
+      left: 0;
+      background-color: #121212;
+      opacity: 0.1;
+    }
+
+    .dcr-8y9hd2:hover {
+      background-color: #fdf0e8;
+    }
+
+    .dcr-8y9hd2:before {
+      background-color: #BB3B80;
+      content: '';
+      height: 1px;
+      z-index: 2;
+      width: 100%;
+    }
+
+    .dcr-7dgi4u {
+      height: 1em;
+      width: 1.5em;
+      margin-right: 3px;
+      vertical-align: baseline;
+      fill: #BB3B80;
+    }
+
+    .dcr-wl67q8 {
+      display: block;
+      font-style: italic;
+      font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+      font-size: 1.0625rem;
+      line-height: 1.15;
+      font-weight: 500;
+      --source-text-decoration-thickness: 2px;
+      color: #BB3B80;
+    }
+
+    .dcr-yi9s71 {
+      display: block;
+      font-style: italic;
+      font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+      font-size: 1.0625rem;
+      line-height: 1.15;
+      font-weight: 500;
+      --source-text-decoration-thickness: 2px;
+      color: #C74600;
+    }
+
+    .dcr-940o8p {
+      color: #C74600;
+      font-weight: 700;
+      margin-right: 4px;
+    }
+
+    .dcr-11vxpqc {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+    }
+
+    .dcr-w6hc5l {
+      display: -webkit-inline-box;
+      display: -webkit-inline-flex;
+      display: -ms-inline-flexbox;
+      display: inline-flex;
+      -webkit-box-pack: justify;
+      -webkit-justify-content: space-between;
+      justify-content: space-between;
+      -webkit-align-items: center;
+      -webkit-box-align: center;
+      -ms-flex-align: center;
+      align-items: center;
+      box-sizing: border-box;
+      border: none;
+      background: transparent;
+      cursor: pointer;
+      -webkit-transition: .3s ease-in-out;
+      transition: .3s ease-in-out;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      white-space: nowrap;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.9375rem;
+      line-height: 1.35;
+      font-weight: 700;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      min-height: 24px;
+      padding: 0 12px;
+      border-radius: 24px;
+      padding-bottom: 2px;
+      background-color: #052962;
+      color: #FFFFFF;
+      -webkit-flex-direction: row-reverse;
+      -ms-flex-direction: row-reverse;
+      flex-direction: row-reverse;
+      margin-top: 16px;
+      margin-right: 10px;
+      color: #FFFFFF;
+      background-color: #121212;
+      border-color: #121212;
+    }
+
+    .dcr-w6hc5l:disabled {
+      cursor: not-allowed;
+    }
+
+    .dcr-w6hc5l:focus {
+      outline: 0;
+    }
+
+    html:not(.src-focus-disabled) .dcr-w6hc5l:focus {
+      outline: 5px solid #0077B6;
+      outline-offset: 3px;
+    }
+
+    .dcr-w6hc5l:hover {
+      background-color: #234B8A;
+    }
+
+    .dcr-w6hc5l svg {
+      -webkit-flex: 0 0 auto;
+      -ms-flex: 0 0 auto;
+      flex: 0 0 auto;
+      display: block;
+      fill: currentColor;
+      position: relative;
+      width: 20px;
+      height: auto;
+    }
+
+    .dcr-w6hc5l .src-button-space {
+      width: 4px;
+    }
+
+    .dcr-w6hc5l svg {
+      margin-left: -4px;
+    }
+
+    .dcr-w6hc5l:hover {
+      background-color: #707070;
+      border-color: #707070;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-w6hc5l {
+        margin-left: 10px;
+      }
+    }
+
+    .dcr-194i6pr {
+      position: absolute;
+      overflow: hidden;
+      white-space: nowrap;
+      width: 1px;
+      height: 1px;
+      margin: -1px;
+      padding: 0;
+      border: 0;
+      clip: rect(1px, 1px, 1px, 1px);
+      -webkit-clip-path: inset(50%);
+      -webkit-clip-path: inset(50%);
+      clip-path: inset(50%);
+    }
+
+    .dcr-10hq5cq {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-box-pack: center;
+      -ms-flex-pack: center;
+      -webkit-justify-content: center;
+      justify-content: center;
+    }
+
+    .dcr-10hq5cq .ad-slot__scroll {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      max-height: 24px;
+      background-color: #F6F6F6;
+      padding: 0 8px;
+      border-top: 1px solid #DCDCDC;
+      color: #707070;
+      text-align: left;
+      box-sizing: border-box;
+      position: relative;
+    }
+
+    .dcr-10hq5cq .ad-slot__scroll.visible {
+      visibility: initial;
+    }
+
+    .dcr-10hq5cq .ad-slot__scroll.hidden {
+      visibility: hidden;
+    }
+
+    .dcr-10hq5cq .ad-slot__close-button {
+      display: none;
+    }
+
+    .dcr-10hq5cq .ad-slot__scroll {
+      position: fixed;
+      bottom: 0;
+      width: 100%;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      max-height: 24px;
+      background-color: #F6F6F6;
+      padding: 0 8px;
+      border-top: 1px solid #DCDCDC;
+      color: #707070;
+      text-align: left;
+      box-sizing: border-box;
+    }
+
+    .dcr-10hq5cq .ad-slot:not[data-label-show='true']::before {
+      content: '';
+      display: block;
+      height: 24px;
+      visibility: hidden;
+    }
+
+    .dcr-10hq5cq .ad-slot[data-label-show='true']:not(.ad-slot--interscroller):not(.ad-slot--merchandising):not(.ad-slot--merchandising-high)::before {
+      content: attr(ad-label-text);
+      display: block;
+      position: relative;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      max-height: 24px;
+      background-color: #F6F6F6;
+      padding: 0 8px;
+      border-top: 1px solid #DCDCDC;
+      color: #707070;
+      text-align: left;
+      box-sizing: border-box;
+    }
+
+    .dcr-10hq5cq .ad-slot--merchandising[data-label-show='true']::before,
+    .dcr-10hq5cq .ad-slot--merchandising-high[data-label-show='true']::before {
+      content: attr(ad-label-text);
+      display: block;
+      position: relative;
+      max-width: 970px;
+      margin: auto;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      max-height: 24px;
+      background-color: #F6F6F6;
+      padding: 0 8px;
+      border-top: 1px solid #DCDCDC;
+      color: #707070;
+      text-align: left;
+      box-sizing: border-box;
+    }
+
+    .dcr-10hq5cq .ad-slot__adtest-cookie-clear-link {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      text-align: left;
+      position: absolute;
+      left: 268px;
+      top: 1px;
+      z-index: 10;
+      padding: 0;
+      border: 0;
+    }
+
+    .dcr-10hq5cq.ad-slot--fluid {
+      min-height: 250px;
+      line-height: 10px;
+      padding: 0;
+      margin: 0;
+    }
+
+    .dcr-10hq5cq .ad-slot.ad-slot--collapse {
+      display: none;
+    }
+
+    .dcr-5zzwsk {
+      position: relative;
+      min-height: 250px;
+    }
+
+    .dcr-5zzwsk .ad-slot__scroll {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      max-height: 24px;
+      background-color: #F6F6F6;
+      padding: 0 8px;
+      border-top: 1px solid #DCDCDC;
+      color: #707070;
+      text-align: left;
+      box-sizing: border-box;
+      position: relative;
+    }
+
+    .dcr-5zzwsk .ad-slot__scroll.visible {
+      visibility: initial;
+    }
+
+    .dcr-5zzwsk .ad-slot__scroll.hidden {
+      visibility: hidden;
+    }
+
+    .dcr-5zzwsk .ad-slot__close-button {
+      display: none;
+    }
+
+    .dcr-5zzwsk .ad-slot__scroll {
+      position: fixed;
+      bottom: 0;
+      width: 100%;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      max-height: 24px;
+      background-color: #F6F6F6;
+      padding: 0 8px;
+      border-top: 1px solid #DCDCDC;
+      color: #707070;
+      text-align: left;
+      box-sizing: border-box;
+    }
+
+    .dcr-5zzwsk .ad-slot:not[data-label-show='true']::before {
+      content: '';
+      display: block;
+      height: 24px;
+      visibility: hidden;
+    }
+
+    .dcr-5zzwsk .ad-slot[data-label-show='true']:not(.ad-slot--interscroller):not(.ad-slot--merchandising):not(.ad-slot--merchandising-high)::before {
+      content: attr(ad-label-text);
+      display: block;
+      position: relative;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      max-height: 24px;
+      background-color: #F6F6F6;
+      padding: 0 8px;
+      border-top: 1px solid #DCDCDC;
+      color: #707070;
+      text-align: left;
+      box-sizing: border-box;
+    }
+
+    .dcr-5zzwsk .ad-slot--merchandising[data-label-show='true']::before,
+    .dcr-5zzwsk .ad-slot--merchandising-high[data-label-show='true']::before {
+      content: attr(ad-label-text);
+      display: block;
+      position: relative;
+      max-width: 970px;
+      margin: auto;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      max-height: 24px;
+      background-color: #F6F6F6;
+      padding: 0 8px;
+      border-top: 1px solid #DCDCDC;
+      color: #707070;
+      text-align: left;
+      box-sizing: border-box;
+    }
+
+    .dcr-5zzwsk .ad-slot__adtest-cookie-clear-link {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      text-align: left;
+      position: absolute;
+      left: 268px;
+      top: 1px;
+      z-index: 10;
+      padding: 0;
+      border: 0;
+    }
+
+    .dcr-5zzwsk.ad-slot--fluid {
+      min-height: 250px;
+      line-height: 10px;
+      padding: 0;
+      margin: 0;
+    }
+
+    .dcr-5zzwsk .ad-slot.ad-slot--collapse {
+      display: none;
+    }
+
+    .dcr-5zzwsk.ad-slot--fluid {
+      width: 100%;
+    }
+
+    .dcr-klul57 {
+      position: relative;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      row-gap: 12px;
+      -webkit-flex-basis: 33.333%;
+      -ms-flex-preferred-size: 33.333%;
+      flex-basis: 33.333%;
+    }
+
+      {
+      padding-left: 10px;
+      padding-right: 10px;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-klul57 {
+        padding-left: 10px;
+        padding-right: 10px;
+      }
+    }
+
+    .dcr-vkpbou {
+      position: relative;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      row-gap: 12px;
+      -webkit-flex-basis: 33.333%;
+      -ms-flex-preferred-size: 33.333%;
+      flex-basis: 33.333%;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-vkpbou:before {
+        content: '';
+        display: block;
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        left: 0;
+        width: 1px;
+        height: 100%;
+        border-left: 1px solid #DCDCDC;
+      }
+    }
+
+      {
+      padding-left: 10px;
+      padding-right: 10px;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-vkpbou {
+        padding-left: 10px;
+        padding-right: 10px;
+      }
+    }
+
+    .dcr-heqd82 {
+      position: relative;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+      row-gap: 12px;
+    }
+
+    @media (max-width: 739px) {
+      .dcr-heqd82 {
+        -webkit-flex-direction: column;
+        -ms-flex-direction: column;
+        flex-direction: column;
+        width: 100%;
+      }
+    }
+
+    .dcr-dcwwkt {
+      position: relative;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      row-gap: 12px;
+      -webkit-flex: 1;
+      -ms-flex: 1;
+      flex: 1;
+    }
+
+    .dcr-er9oa0 {
+      position: relative;
+    }
+
+    .dcr-er9oa0 .ad-slot__scroll {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      max-height: 24px;
+      background-color: #F6F6F6;
+      padding: 0 8px;
+      border-top: 1px solid #DCDCDC;
+      color: #707070;
+      text-align: left;
+      box-sizing: border-box;
+      position: relative;
+    }
+
+    .dcr-er9oa0 .ad-slot__scroll.visible {
+      visibility: initial;
+    }
+
+    .dcr-er9oa0 .ad-slot__scroll.hidden {
+      visibility: hidden;
+    }
+
+    .dcr-er9oa0 .ad-slot__close-button {
+      display: none;
+    }
+
+    .dcr-er9oa0 .ad-slot__scroll {
+      position: fixed;
+      bottom: 0;
+      width: 100%;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      max-height: 24px;
+      background-color: #F6F6F6;
+      padding: 0 8px;
+      border-top: 1px solid #DCDCDC;
+      color: #707070;
+      text-align: left;
+      box-sizing: border-box;
+    }
+
+    .dcr-er9oa0 .ad-slot:not[data-label-show='true']::before {
+      content: '';
+      display: block;
+      height: 24px;
+      visibility: hidden;
+    }
+
+    .dcr-er9oa0 .ad-slot[data-label-show='true']:not(.ad-slot--interscroller):not(.ad-slot--merchandising):not(.ad-slot--merchandising-high)::before {
+      content: attr(ad-label-text);
+      display: block;
+      position: relative;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      max-height: 24px;
+      background-color: #F6F6F6;
+      padding: 0 8px;
+      border-top: 1px solid #DCDCDC;
+      color: #707070;
+      text-align: left;
+      box-sizing: border-box;
+    }
+
+    .dcr-er9oa0 .ad-slot--merchandising[data-label-show='true']::before,
+    .dcr-er9oa0 .ad-slot--merchandising-high[data-label-show='true']::before {
+      content: attr(ad-label-text);
+      display: block;
+      position: relative;
+      max-width: 970px;
+      margin: auto;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      max-height: 24px;
+      background-color: #F6F6F6;
+      padding: 0 8px;
+      border-top: 1px solid #DCDCDC;
+      color: #707070;
+      text-align: left;
+      box-sizing: border-box;
+    }
+
+    .dcr-er9oa0 .ad-slot__adtest-cookie-clear-link {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      text-align: left;
+      position: absolute;
+      left: 268px;
+      top: 1px;
+      z-index: 10;
+      padding: 0;
+      border: 0;
+    }
+
+    .dcr-er9oa0.ad-slot--fluid {
+      min-height: 250px;
+      line-height: 10px;
+      padding: 0;
+      margin: 0;
+    }
+
+    .dcr-er9oa0 .ad-slot.ad-slot--collapse {
+      display: none;
+    }
+
+    .dcr-6vr3s5 {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+      -webkit-box-pack: justify;
+      -webkit-justify-content: space-between;
+      justify-content: space-between;
+      width: 100%;
+      position: relative;
+      color: inherit;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      background-color: #F6F6F6;
+    }
+
+    .dcr-6vr3s5:hover .image-overlay {
+      position: absolute;
+      top: 0;
+      width: 100%;
+      height: 100%;
+      left: 0;
+      background-color: #121212;
+      opacity: 0.1;
+    }
+
+    .dcr-6vr3s5:hover {
+      background-color: #EDEDED;
+    }
+
+    .dcr-6vr3s5:before {
+      background-color: #0077B6;
+      content: '';
+      height: 1px;
+      z-index: 2;
+      width: 100%;
+    }
+
+    .dcr-14ukgk6 {
+      height: 1em;
+      width: 1.5em;
+      margin-right: 3px;
+      vertical-align: baseline;
+      fill: #0077B6;
+    }
+
+    .dcr-1w0fo28 {
+      display: block;
+      font-style: italic;
+      font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+      font-size: 1.5rem;
+      line-height: 1.15;
+      font-weight: 500;
+      --source-text-decoration-thickness: 3px;
+      color: #0077B6;
+    }
+
+    @media (max-width: 979px) {
+      .dcr-1w0fo28 {
+        font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+        font-size: 1.25rem;
+        line-height: 1.15;
+        font-weight: 500;
+        --source-text-decoration-thickness: 3px;
+      }
+    }
+
+    .dcr-gf0nnr {
+      position: relative;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      margin-left: 5px;
+      margin-right: 5px;
+      margin-bottom: 5px;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-gf0nnr {
+        -webkit-flex-direction: row;
+        -ms-flex-direction: row;
+        flex-direction: row;
+      }
+    }
+
+    .dcr-15f6w0y {
+      color: #0077B6;
+      font-weight: 700;
+      margin-right: 4px;
+      display: inline-block;
+    }
+
+    .dcr-ibz96v {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+      -webkit-flex: 1;
+      -ms-flex: 1;
+      flex: 1;
+      padding-top: 2px;
+      position: relative;
+      margin-top: 8px;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-ibz96v {
+        margin-bottom: 4px;
+      }
+    }
+
+    @media (min-width: 740px) {
+      .dcr-ibz96v {
+        margin-left: 10px;
+      }
+    }
+
+    .dcr-1ttos39 {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+      -webkit-flex: 1;
+      -ms-flex: 1;
+      flex: 1;
+      padding-top: 2px;
+      position: relative;
+      margin-top: 8px;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-1ttos39 {
+        margin-bottom: 4px;
+      }
+    }
+
+    @media (min-width: 740px) {
+      .dcr-1ttos39 {
+        margin-left: 10px;
+      }
+    }
+
+    @media (max-width: 739px) {
+      .dcr-1ttos39 {
+        margin-bottom: 8px;
+      }
+    }
+
+    .dcr-zdnpsd {
+      color: #0077B6;
+      font-weight: 700;
+      margin-right: 4px;
+    }
+
+    .dcr-wwzlz2 {
+      display: block;
+      font-style: italic;
+      font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+      font-size: 1.25rem;
+      line-height: 1.15;
+      font-weight: 500;
+      --source-text-decoration-thickness: 3px;
+      color: #0077B6;
+    }
+
+    @media (max-width: 979px) {
+      .dcr-wwzlz2 {
+        font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+        font-size: 1.0625rem;
+        line-height: 1.15;
+        font-weight: 500;
+        --source-text-decoration-thickness: 2px;
+      }
+    }
+
+    .dcr-13er5zy {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+      -webkit-box-pack: justify;
+      -webkit-justify-content: space-between;
+      justify-content: space-between;
+      width: 100%;
+      position: relative;
+      color: inherit;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      background-color: #005689;
+    }
+
+    .dcr-13er5zy:hover .image-overlay {
+      position: absolute;
+      top: 0;
+      width: 100%;
+      height: 100%;
+      left: 0;
+      background-color: #121212;
+      opacity: 0.1;
+    }
+
+    .dcr-13er5zy:hover {
+      -webkit-filter: brightness(90%);
+      filter: brightness(90%);
+    }
+
+    .dcr-13er5zy:before {
+      background-color: #0077B6;
+      content: '';
+      height: 1px;
+      z-index: 2;
+      width: 100%;
+    }
+
+    .dcr-mhxc3l {
+      color: #90DCFF;
+      font-weight: 700;
+      margin-right: 4px;
+    }
+
+    .dcr-wx7qhb {
+      color: #90DCFF;
+    }
+
+    .dcr-wx7qhb:before {
+      border-radius: 62.5rem;
+      display: inline-block;
+      position: relative;
+      background-color: currentColor;
+      width: 0.75em;
+      height: 0.75em;
+      content: '';
+      margin-right: 0.1875rem;
+      vertical-align: initial;
+    }
+
+    .dcr-wx7qhb[data-animate='true'] {
+      -webkit-animation: animation-111ynch 1s infinite;
+      animation: animation-111ynch 1s infinite;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .dcr-wx7qhb[data-animate='true'] {
+        -webkit-animation: none;
+        animation: none;
+      }
+    }
+
+    .dcr-1e9i83y {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+      -webkit-box-pack: justify;
+      -webkit-justify-content: space-between;
+      justify-content: space-between;
+      width: 100%;
+      position: relative;
+      color: inherit;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      background-color: #FEF9F5;
+    }
+
+    .dcr-1e9i83y:hover .image-overlay {
+      position: absolute;
+      top: 0;
+      width: 100%;
+      height: 100%;
+      left: 0;
+      background-color: #121212;
+      opacity: 0.1;
+    }
+
+    .dcr-1e9i83y:hover {
+      background-color: #fdf0e8;
+    }
+
+    .dcr-1e9i83y:before {
+      background-color: #0077B6;
+      content: '';
+      height: 1px;
+      z-index: 2;
+      width: 100%;
+    }
+
+    .dcr-14mz37s {
+      display: block;
+      font-style: italic;
+      font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+      font-size: 1.0625rem;
+      line-height: 1.15;
+      font-weight: 500;
+      --source-text-decoration-thickness: 2px;
+      color: #0077B6;
+    }
+
+    .dcr-1ykr3rf {
+      position: relative;
+      margin: auto;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-1ykr3rf {
+        max-width: 740px;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-1ykr3rf {
+        max-width: 980px;
+      }
+    }
+
+    @media (min-width: 1140px) {
+      .dcr-1ykr3rf {
+        max-width: 1140px;
+      }
+    }
+
+    @media (min-width: 1300px) {
+      .dcr-1ykr3rf {
+        max-width: 1300px;
+      }
+    }
+
+    .dcr-1997rrz {
+      overflow-y: hidden;
+      position: relative;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+    }
+
+    .dcr-41bl8c {
+      position: relative;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      row-gap: 12px;
+      -webkit-flex: 1;
+      -ms-flex: 1;
+      flex: 1;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-41bl8c:before {
+        content: '';
+        display: block;
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        left: 0;
+        width: 1px;
+        height: 100%;
+        border-left: 1px solid #DCDCDC;
+      }
+    }
+
+    @media (min-width: 740px) {
+      .dcr-41bl8c {
+        padding-left: 10px;
+        padding-right: 10px;
+      }
+    }
+
+    .dcr-1x0hldo {
+      position: relative;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      row-gap: 12px;
+      -webkit-flex-basis: 50%;
+      -ms-flex-preferred-size: 50%;
+      flex-basis: 50%;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-1x0hldo {
+        padding-left: 10px;
+        padding-right: 10px;
+      }
+    }
+
+    .dcr-1a53cuj {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-basis: 100%;
+      -ms-flex-preferred-size: 100%;
+      flex-basis: 100%;
+      width: 100%;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+    }
+
+    @media (max-width: 739px) {
+      .dcr-1a53cuj {
+        -webkit-flex-direction: column;
+        -ms-flex-direction: column;
+        flex-direction: column;
+      }
+    }
+
+    .dcr-1shzr3u {
+      position: relative;
+    }
+
+    .dcr-1shzr3u img {
+      width: 100%;
+      display: block;
+    }
+
+    .dcr-1mbiar2 {
+      padding-bottom: 8px;
+      padding-left: 5px;
+      padding-right: 5px;
+      padding-top: 0px;
+      -webkit-box-flex: 1;
+      -webkit-flex-grow: 1;
+      -ms-flex-positive: 1;
+      flex-grow: 1;
+    }
+
+    @media (min-width: 660px) {
+      .dcr-1mbiar2 {
+        padding-top: 1px;
+      }
+    }
+
+    @media (min-width: 740px) {
+      .dcr-1mbiar2 {
+        padding-top: 1px;
+      }
+    }
+
+    .dcr-clan40 {
+      background-color: #FFE500;
+      margin-top: 2px;
+      display: inline-block;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-clan40 {
+        margin-top: 4px;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-1v9xu6e {
+        display: none;
+      }
+    }
+
+    .dcr-sa2wgi {
+      padding: 0 2px;
+    }
+
+    .dcr-sa2wgi svg {
+      width: 12px;
+      height: 12px;
+    }
+
+    .dcr-1tlk9ix {
+      display: inline-block;
+      padding: 1px;
+    }
+
+    .dcr-1o00huv {
+      padding: 1px;
+    }
+
+    .dcr-1o00huv svg {
+      width: 16px;
+      height: 16px;
+    }
+
+    .dcr-177xkn2 {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-basis: 100%;
+      -ms-flex-preferred-size: 100%;
+      flex-basis: 100%;
+      width: 100%;
+      -webkit-flex-direction: row;
+      -ms-flex-direction: row;
+      flex-direction: row;
+    }
+
+    @media (max-width: 739px) {
+      .dcr-177xkn2 {
+        -webkit-flex-direction: row;
+        -ms-flex-direction: row;
+        flex-direction: row;
+      }
+    }
+
+    .dcr-v5uj1c {
+      -webkit-flex-basis: 25%;
+      -ms-flex-preferred-size: 25%;
+      flex-basis: 25%;
+      position: relative;
+    }
+
+    @media (min-width: 740px) and (max-width: 979px) {
+      .dcr-v5uj1c {
+        -webkit-flex-basis: 40%;
+        -ms-flex-preferred-size: 40%;
+        flex-basis: 40%;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-v5uj1c {
+        -webkit-flex-basis: 30%;
+        -ms-flex-preferred-size: 30%;
+        flex-basis: 30%;
+      }
+    }
+
+    @media (max-width: 739px) {
+      .dcr-v5uj1c {
+        width: 125px;
+        -webkit-flex-shrink: 0;
+        -ms-flex-negative: 0;
+        flex-shrink: 0;
+        margin-top: 4px;
+        margin-right: 0;
+        margin-bottom: 4px;
+        margin-left: 4px;
+        -webkit-flex-basis: unset;
+        -ms-flex-preferred-size: unset;
+        flex-basis: unset;
+        -webkit-align-self: flex-start;
+        -ms-flex-item-align: flex-start;
+        align-self: flex-start;
+      }
+    }
+
+    @media (min-width: 740px) {
+      .dcr-v5uj1c {
+        -webkit-align-self: flex-start;
+        -ms-flex-item-align: flex-start;
+        align-self: flex-start;
+      }
+    }
+
+    .dcr-v5uj1c img {
+      width: 100%;
+      display: block;
+    }
+
+    .dcr-pqd2bn {
+      position: relative;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      row-gap: 12px;
+      -webkit-flex-basis: 50%;
+      -ms-flex-preferred-size: 50%;
+      flex-basis: 50%;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-pqd2bn:before {
+        content: '';
+        display: block;
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        left: 0;
+        width: 1px;
+        height: 100%;
+        border-left: 1px solid #DCDCDC;
+      }
+    }
+
+      {
+      padding-left: 10px;
+      padding-right: 10px;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-pqd2bn {
+        padding-left: 10px;
+        padding-right: 10px;
+      }
+    }
+
+    .dcr-1rhgqks {
+      position: relative;
+      margin: auto;
+      border-top: 1px solid #DCDCDC;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-1rhgqks {
+        max-width: 740px;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-1rhgqks {
+        max-width: 980px;
+      }
+    }
+
+    @media (min-width: 1140px) {
+      .dcr-1rhgqks {
+        max-width: 1140px;
+      }
+    }
+
+    @media (min-width: 1300px) {
+      .dcr-1rhgqks {
+        max-width: 1300px;
+      }
+    }
+
+    @media (min-width: 740px) {
+      .dcr-1rhgqks {
+        border-left: 1px solid #DCDCDC;
+        border-right: 1px solid #DCDCDC;
+      }
+    }
+
+    .dcr-cwgamd {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+    }
+
+    @media (min-width: 1140px) {
+      .dcr-cwgamd {
+        -webkit-flex-direction: row;
+        -ms-flex-direction: row;
+        flex-direction: row;
+      }
+    }
+
+    @media (max-width: 739px) {
+      .dcr-cwgamd {
+        margin: 10px;
+      }
+    }
+
+    .dcr-mpib28 {
+      background-color: #69D1CA;
+      padding-top: 8px;
+      padding-bottom: 8px;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-box-pack: justify;
+      -webkit-justify-content: space-between;
+      justify-content: space-between;
+    }
+
+    @media (min-width: 1140px) and (max-width: 1299px) {
+      .dcr-mpib28 {
+        width: 170px;
+        -webkit-box-flex: 0;
+        -webkit-flex-grow: 0;
+        -ms-flex-positive: 0;
+        flex-grow: 0;
+        -webkit-flex-shrink: 0;
+        -ms-flex-negative: 0;
+        flex-shrink: 0;
+      }
+    }
+
+    @media (min-width: 1300px) {
+      .dcr-mpib28 {
+        width: 250px;
+        -webkit-box-flex: 0;
+        -webkit-flex-grow: 0;
+        -ms-flex-positive: 0;
+        flex-grow: 0;
+        -webkit-flex-shrink: 0;
+        -ms-flex-negative: 0;
+        flex-shrink: 0;
+      }
+    }
+
+    @media (min-width: 1140px) {
+      .dcr-mpib28 {
+        margin-bottom: 36px;
+      }
+    }
+
+    @media (max-width: 479px) {
+      .dcr-mpib28 {
+        padding-left: 10px;
+        padding-right: 10px;
+      }
+    }
+
+    @media (min-width: 480px) {
+      .dcr-mpib28 {
+        padding-left: 20px;
+        padding-right: 20px;
+      }
+    }
+
+    @media (min-width: 1140px) {
+      .dcr-mpib28 {
+        -webkit-flex-direction: column;
+        -ms-flex-direction: column;
+        flex-direction: column;
+      }
+    }
+
+    .dcr-1x82knj {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+    }
+
+    @media (min-width: 1300px) {
+      .dcr-1x82knj {
+        padding-top: 8px;
+      }
+    }
+
+    .dcr-cumgmz {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.875rem;
+      line-height: 1.35;
+      font-weight: 700;
+      --source-text-decoration-thickness: 2px;
+      padding-right: 16px;
+    }
+
+    .dcr-1b0b5qy {
+      position: relative;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.875rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+    }
+
+    .dcr-1b0b5qy [data-icon='chevronUp'] {
+      display: none;
+    }
+
+    .dcr-1b0b5qy [data-icon='chevronDown'] {
+      display: inline;
+    }
+
+    .dcr-1b0b5qy:is([open]) [data-icon='chevronDown'] {
+      display: none;
+    }
+
+    .dcr-1b0b5qy:is([open]) [data-icon='chevronUp'] {
+      display: inline;
+    }
+
+    .dcr-121waft {
+      list-style: none;
+      cursor: pointer;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+    }
+
+    .dcr-121waft::-webkit-details-marker {
+      display: none;
+    }
+
+    .dcr-1i1yotf {
+      position: absolute;
+      z-index: 14;
+    }
+
+    @media (max-width: 479px) {
+      .dcr-1i1yotf {
+        left: -107px;
+      }
+    }
+
+    .dcr-121iobs {
+      background-color: #000000;
+      color: #FFFFFF;
+      padding: 20px;
+    }
+
+    .dcr-1okfq0v {
+      display: -webkit-inline-box;
+      display: -webkit-inline-flex;
+      display: -ms-inline-flexbox;
+      display: inline-flex;
+      -webkit-box-pack: justify;
+      -webkit-justify-content: space-between;
+      justify-content: space-between;
+      -webkit-align-items: center;
+      -webkit-box-align: center;
+      -ms-flex-align: center;
+      align-items: center;
+      box-sizing: border-box;
+      border: none;
+      background: transparent;
+      cursor: pointer;
+      -webkit-transition: .3s ease-in-out;
+      transition: .3s ease-in-out;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      white-space: nowrap;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.9375rem;
+      line-height: 1.35;
+      font-weight: 700;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      min-height: 24px;
+      padding: 0 12px;
+      border-radius: 24px;
+      padding-bottom: 2px;
+      padding: 0;
+      background-color: transparent;
+      color: #052962;
+      -webkit-text-decoration: underline;
+      text-decoration: underline;
+      text-underline-offset: 4px;
+      border-radius: 0;
+      color: #69D1CA;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.875rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+    }
+
+    .dcr-1okfq0v:disabled {
+      cursor: not-allowed;
+    }
+
+    .dcr-1okfq0v:focus {
+      outline: 0;
+    }
+
+    html:not(.src-focus-disabled) .dcr-1okfq0v:focus {
+      outline: 5px solid #0077B6;
+      outline-offset: 3px;
+    }
+
+    .dcr-1okfq0v:hover {
+      text-decoration-thickness: 4px;
+    }
+
+    .dcr-1okfq0v svg {
+      -webkit-flex: 0 0 auto;
+      -ms-flex: 0 0 auto;
+      flex: 0 0 auto;
+      display: block;
+      fill: currentColor;
+      position: relative;
+      width: 20px;
+      height: auto;
+    }
+
+    .dcr-1okfq0v .src-button-space {
+      width: 4px;
+    }
+
+    .dcr-1okfq0v svg {
+      margin-right: -4px;
+    }
+
+    .dcr-1la72oj {
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      color: #FFFFFF;
+    }
+
+    .dcr-1la72oj:hover {
+      -webkit-text-decoration: underline;
+      text-decoration: underline;
+    }
+
+    .dcr-10maeve {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 1.25rem;
+      line-height: 1.35;
+      font-weight: 700;
+      --source-text-decoration-thickness: 3px;
+      color: inherit;
+      overflow-wrap: break-word;
+    }
+
+    .dcr-j2e14o {
+      position: relative;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 1.0625rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      cursor: pointer;
+      -webkit-text-decoration: underline;
+      text-decoration: underline;
+      text-underline-position: under;
+      text-underline-offset: 5%;
+      display: inline;
+      -webkit-align-items: center;
+      -webkit-box-align: center;
+      -ms-flex-align: center;
+      align-items: center;
+      color: #0077B6;
+      text-align: right;
+    }
+
+    .dcr-j2e14o:focus {
+      outline: 0;
+    }
+
+    html:not(.src-focus-disabled) .dcr-j2e14o:focus {
+      box-shadow: 0 0 0 5px #0077B6;
+    }
+
+    .dcr-j2e14o:hover {
+      text-decoration-thickness: var(--source-text-decoration-thickness, auto);
+    }
+
+    .dcr-j2e14o:hover {
+      color: #0077B6;
+    }
+
+    .dcr-bx6dku {
+      padding-top: 8px;
+      padding-bottom: 16px;
+      margin-bottom: 36px;
+      background-color: #EDEDED;
+      width: 100%;
+    }
+
+    @media (max-width: 479px) {
+      .dcr-bx6dku {
+        padding-left: 10px;
+        padding-right: 10px;
+      }
+    }
+
+    @media (min-width: 480px) and (max-width: 739px) {
+      .dcr-bx6dku {
+        padding-left: 20px;
+        padding-right: 20px;
+      }
+    }
+
+    @media (min-width: 740px) and (max-width: 1139px) {
+      .dcr-bx6dku {
+        padding-left: 10px;
+        padding-right: 10px;
+      }
+    }
+
+    @media (min-width: 1140px) and (max-width: 1299px) {
+      .dcr-bx6dku {
+        padding-right: 10px;
+      }
+    }
+
+    @media (min-width: 1300px) {
+      .dcr-bx6dku {
+        padding-right: 88px;
+      }
+    }
+
+    .dcr-eqij51 {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+      -webkit-box-pack: justify;
+      -webkit-justify-content: space-between;
+      justify-content: space-between;
+      width: 100%;
+      position: relative;
+      color: inherit;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      background-color: #F6F6F6;
+    }
+
+    .dcr-eqij51:hover .image-overlay {
+      position: absolute;
+      top: 0;
+      width: 100%;
+      height: 100%;
+      left: 0;
+      background-color: #121212;
+      opacity: 0.1;
+    }
+
+    .dcr-eqij51:hover {
+      -webkit-filter: brightness(90%);
+      filter: brightness(90%);
+    }
+
+    .dcr-eqij51:before {
+      background-color: #69D1CA;
+      content: '';
+      height: 1px;
+      z-index: 2;
+      width: 100%;
+    }
+
+    .dcr-1ye338w {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 1.25rem;
+      line-height: 1.15;
+      font-weight: 400;
+      --source-text-decoration-thickness: 3px;
+      padding-bottom: 4px;
+    }
+
+    @media (max-width: 979px) {
+      .dcr-1ye338w {
+        font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+        font-size: 1.0625rem;
+        line-height: 1.15;
+        font-weight: 400;
+        --source-text-decoration-thickness: 2px;
+      }
+    }
+
+    .dcr-11gvlio {
+      color: #0C7A73;
+      font-weight: 700;
+      margin-right: 4px;
+    }
+
+    .dcr-5r9j9 {
+      position: relative;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      row-gap: 12px;
+      -webkit-flex: 1;
+      -ms-flex: 1;
+      flex: 1;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-5r9j9:before {
+        content: '';
+        display: block;
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        left: 0;
+        width: 1px;
+        height: 100%;
+        border-left: 1px solid;
+      }
+    }
+
+      {
+      padding-left: 10px;
+      padding-right: 10px;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-5r9j9 {
+        padding-left: 10px;
+        padding-right: 10px;
+      }
+    }
+
+    .dcr-1dl6o1v {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+      -webkit-box-pack: justify;
+      -webkit-justify-content: space-between;
+      justify-content: space-between;
+      width: 100%;
+      position: relative;
+      color: inherit;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      background-color: #333333;
+    }
+
+    .dcr-1dl6o1v:hover .image-overlay {
+      position: absolute;
+      top: 0;
+      width: 100%;
+      height: 100%;
+      left: 0;
+      background-color: #121212;
+      opacity: 0.1;
+    }
+
+    .dcr-1dl6o1v:hover {
+      -webkit-filter: brightness(90%);
+      filter: brightness(90%);
+    }
+
+    .dcr-1dl6o1v:before {
+      background-color: #69D1CA;
+      content: '';
+      height: 1px;
+      z-index: 2;
+      width: 100%;
+    }
+
+    .dcr-1pfni0w {
+      color: #69D1CA;
+      font-weight: 700;
+      margin-right: 4px;
+    }
+
+    .dcr-dnk6tr {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-align-items: center;
+      -webkit-box-align: center;
+      -ms-flex-align: center;
+      align-items: center;
+      margin-top: 4px;
+    }
+
+    .dcr-1sibelm {
+      width: 24px;
+      height: 24px;
+      background-color: #69D1CA;
+      border-radius: 50%;
+      display: inline-block;
+    }
+
+    .dcr-1sibelm>svg {
+      width: 20px;
+      height: 20px;
+      margin-left: auto;
+      margin-right: auto;
+      margin-top: 2px;
+      display: block;
+      fill: #333333;
+    }
+
+    .dcr-bi3vbd {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.15;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      margin-top: -4px;
+      color: #DCDCDC;
+      padding-left: 5px;
+      padding-right: 5px;
+    }
+
+    @media (max-width: 739px) {
+      .dcr-bi3vbd {
+        line-height: 1.25;
+      }
+    }
+
+    .dcr-bi3vbd svg {
+      fill: #DCDCDC;
+      margin-bottom: -1px;
+      height: 11px;
+      width: 11px;
+      margin-right: 2px;
+    }
+
+    .dcr-bi3vbd>time {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 700;
+      --source-text-decoration-thickness: 2px;
+    }
+
+    .dcr-1ei6oe5 {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+      -webkit-align-items: end;
+      -webkit-box-align: end;
+      -ms-flex-align: end;
+      align-items: end;
+      padding: 8px 10px;
+    }
+
+    .dcr-o4w3q {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 700;
+      --source-text-decoration-thickness: 2px;
+      color: #707070;
+      margin-top: 12px;
+      margin-bottom: 4px;
+    }
+
+    .dcr-1mp48zh {
+      float: left;
+      height: 42px;
+    }
+
+    @media (min-width: 1140px) {
+      .dcr-1mp48zh {
+        height: 54px;
+      }
+    }
+
+    .dcr-79fz17 {
+      -webkit-text-decoration: none;
+      text-decoration: none;
+    }
+
+    .dcr-1dcubs6 {
+      display: block;
+      width: auto;
+      height: 42px;
+    }
+
+    @media (min-width: 1140px) {
+      .dcr-1dcubs6 {
+        height: 54px;
+      }
+    }
+
+    .dcr-1hxj7jq {
+      overflow-y: hidden;
+      position: relative;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+    }
+
+    .dcr-pdz5dh {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+      -webkit-box-pack: justify;
+      -webkit-justify-content: space-between;
+      justify-content: space-between;
+      width: 100%;
+      position: relative;
+      color: inherit;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      background-color: #333333;
+    }
+
+    .dcr-pdz5dh:hover .image-overlay {
+      position: absolute;
+      top: 0;
+      width: 100%;
+      height: 100%;
+      left: 0;
+      background-color: #121212;
+      opacity: 0.1;
+    }
+
+    .dcr-pdz5dh:hover {
+      -webkit-filter: brightness(90%);
+      filter: brightness(90%);
+    }
+
+    .dcr-pdz5dh:before {
+      background-color: #C70000;
+      content: '';
+      height: 1px;
+      z-index: 2;
+      width: 100%;
+    }
+
+    .dcr-1769awk {
+      width: 24px;
+      height: 24px;
+      background-color: #DCDCDC;
+      border-radius: 50%;
+      display: inline-block;
+    }
+
+    .dcr-1769awk>svg {
+      width: 20px;
+      height: 20px;
+      margin-left: auto;
+      margin-right: auto;
+      margin-top: 2px;
+      display: block;
+      fill: #333333;
+    }
+
+    .dcr-1s9f32v {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+      -webkit-box-pack: justify;
+      -webkit-justify-content: space-between;
+      justify-content: space-between;
+      width: 100%;
+      position: relative;
+      color: inherit;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      background-color: #F6F6F6;
+    }
+
+    .dcr-1s9f32v:hover .image-overlay {
+      position: absolute;
+      top: 0;
+      width: 100%;
+      height: 100%;
+      left: 0;
+      background-color: #121212;
+      opacity: 0.1;
+    }
+
+    .dcr-1s9f32v:hover {
+      background-color: #EDEDED;
+    }
+
+    .dcr-1s9f32v:before {
+      background-color: #AB0613;
+      content: '';
+      height: 1px;
+      z-index: 2;
+      width: 100%;
+    }
+
+    .dcr-fg1cwd {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+      -webkit-box-pack: justify;
+      -webkit-justify-content: space-between;
+      justify-content: space-between;
+      width: 100%;
+      position: relative;
+      color: inherit;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      background-color: #333333;
+    }
+
+    .dcr-fg1cwd:hover .image-overlay {
+      position: absolute;
+      top: 0;
+      width: 100%;
+      height: 100%;
+      left: 0;
+      background-color: #121212;
+      opacity: 0.1;
+    }
+
+    .dcr-fg1cwd:hover {
+      -webkit-filter: brightness(90%);
+      filter: brightness(90%);
+    }
+
+    .dcr-fg1cwd:before {
+      background-color: #866D50;
+      content: '';
+      height: 1px;
+      z-index: 2;
+      width: 100%;
+    }
+
+    .dcr-veksfe {
+      color: #EACCA0;
+      font-weight: 700;
+      margin-right: 4px;
+    }
+
+    .dcr-14ifi9m {
+      width: 24px;
+      height: 24px;
+      background-color: #EACCA0;
+      border-radius: 50%;
+      display: inline-block;
+    }
+
+    .dcr-14ifi9m>svg {
+      width: 20px;
+      height: 20px;
+      margin-left: auto;
+      margin-right: auto;
+      margin-top: 2px;
+      display: block;
+      fill: #333333;
+    }
+
+    .dcr-9zdshs {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+      color: #FFFFFF;
+      font-family: GuardianTextEgyptian, Guardian Text Egyptian Web, Georgia, serif;
+      font-size: 0.9375rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      font-size: 14px;
+      padding-left: 5px;
+      padding-right: 5px;
+      padding-bottom: 8px;
+    }
+
+    @media (max-width: 979px) {
+      .dcr-9zdshs {
+        display: none;
+      }
+    }
+
+    .dcr-gavx50 {
+      color: #FF9081;
+      font-weight: 700;
+      margin-right: 4px;
+    }
+
+    .dcr-12urb0b {
+      width: 24px;
+      height: 24px;
+      background-color: #FF9081;
+      border-radius: 50%;
+      display: inline-block;
+    }
+
+    .dcr-12urb0b>svg {
+      width: 20px;
+      height: 20px;
+      margin-left: auto;
+      margin-right: auto;
+      margin-top: 2px;
+      display: block;
+      fill: #333333;
+    }
+
+    .dcr-18hfuhz {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+      -webkit-box-pack: justify;
+      -webkit-justify-content: space-between;
+      justify-content: space-between;
+      width: 100%;
+      position: relative;
+      color: inherit;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      background-color: #333333;
+    }
+
+    .dcr-18hfuhz:hover .image-overlay {
+      position: absolute;
+      top: 0;
+      width: 100%;
+      height: 100%;
+      left: 0;
+      background-color: #121212;
+      opacity: 0.1;
+    }
+
+    .dcr-18hfuhz:hover {
+      -webkit-filter: brightness(90%);
+      filter: brightness(90%);
+    }
+
+    .dcr-18hfuhz:before {
+      background-color: #0077B6;
+      content: '';
+      height: 1px;
+      z-index: 2;
+      width: 100%;
+    }
+
+    .dcr-14tkj09 {
+      font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+      font-size: 1.0625rem;
+      line-height: 1.15;
+      font-weight: 500;
+      --source-text-decoration-thickness: 2px;
+    }
+
+    @media (max-width: 979px) {
+      .dcr-14tkj09 {
+        font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+        font-size: 1.0625rem;
+        line-height: 1.15;
+        font-weight: 500;
+        --source-text-decoration-thickness: 2px;
+      }
+    }
+
+    .dcr-66hogn {
+      width: 24px;
+      height: 24px;
+      background-color: #90DCFF;
+      border-radius: 50%;
+      display: inline-block;
+    }
+
+    .dcr-66hogn>svg {
+      width: 20px;
+      height: 20px;
+      margin-left: auto;
+      margin-right: auto;
+      margin-top: 2px;
+      display: block;
+      fill: #333333;
+    }
+
+    .dcr-1pfte1u {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+      -webkit-box-pack: justify;
+      -webkit-justify-content: space-between;
+      justify-content: space-between;
+      width: 100%;
+      position: relative;
+      color: inherit;
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      background-color: #333333;
+    }
+
+    .dcr-1pfte1u:hover .image-overlay {
+      position: absolute;
+      top: 0;
+      width: 100%;
+      height: 100%;
+      left: 0;
+      background-color: #121212;
+      opacity: 0.1;
+    }
+
+    .dcr-1pfte1u:hover {
+      -webkit-filter: brightness(90%);
+      filter: brightness(90%);
+    }
+
+    .dcr-1pfte1u:before {
+      background-color: #BB3B80;
+      content: '';
+      height: 1px;
+      z-index: 2;
+      width: 100%;
+    }
+
+    .dcr-19ua8kq {
+      color: #FFABDB;
+      font-weight: 700;
+      margin-right: 4px;
+    }
+
+    .dcr-7vng58 {
+      width: 24px;
+      height: 24px;
+      background-color: #FFABDB;
+      border-radius: 50%;
+      display: inline-block;
+    }
+
+    .dcr-7vng58>svg {
+      width: 20px;
+      height: 20px;
+      margin-left: auto;
+      margin-right: auto;
+      margin-top: 2px;
+      display: block;
+      fill: #333333;
+    }
+
+    .dcr-zu1fd9 {
+      position: relative;
+      margin: auto;
+      border-top: 1px solid #DCDCDC;
+      padding-left: 10px;
+      padding-right: 10px;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-zu1fd9 {
+        max-width: 740px;
+      }
+    }
+
+    @media (min-width: 980px) {
+      .dcr-zu1fd9 {
+        max-width: 980px;
+      }
+    }
+
+    @media (min-width: 1140px) {
+      .dcr-zu1fd9 {
+        max-width: 1140px;
+      }
+    }
+
+    @media (min-width: 1300px) {
+      .dcr-zu1fd9 {
+        max-width: 1300px;
+      }
+    }
+
+    @media (min-width: 740px) {
+      .dcr-zu1fd9 {
+        border-left: 1px solid #DCDCDC;
+        border-right: 1px solid #DCDCDC;
+      }
+    }
+
+    @media (min-width: 480px) {
+      .dcr-zu1fd9 {
+        padding-left: 20px;
+        padding-right: 20px;
+      }
+    }
+
+    .dcr-1pp81zm {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: row;
+      -ms-flex-direction: row;
+      flex-direction: row;
+      -webkit-box-pack: justify;
+      -webkit-justify-content: space-between;
+      justify-content: space-between;
+      gap: initial;
+      -ms-flex-positive: 1;
+    }
+
+    .dcr-pu1sy6 {
+      position: relative;
+      padding-right: 10px;
+    }
+
+    @media (max-width: 1139px) {
+      .dcr-pu1sy6 {
+        display: none;
+      }
+    }
+
+    @media (min-width: 1140px) and (max-width: 1299px) {
+      .dcr-pu1sy6 {
+        -webkit-flex-basis: 151px;
+        -ms-flex-preferred-size: 151px;
+        flex-basis: 151px;
+        -webkit-box-flex: 0;
+        -webkit-flex-grow: 0;
+        -ms-flex-positive: 0;
+        flex-grow: 0;
+        -webkit-flex-shrink: 0;
+        -ms-flex-negative: 0;
+        flex-shrink: 0;
+      }
+    }
+
+    @media (min-width: 1300px) {
+      .dcr-pu1sy6 {
+        -webkit-flex-basis: 230px;
+        -ms-flex-preferred-size: 230px;
+        flex-basis: 230px;
+        -webkit-box-flex: 0;
+        -webkit-flex-grow: 0;
+        -ms-flex-positive: 0;
+        flex-grow: 0;
+        -webkit-flex-shrink: 0;
+        -ms-flex-negative: 0;
+        flex-shrink: 0;
+      }
+    }
+
+    .dcr-yg4zrc {
+      height: 100%;
+    }
+
+    .dcr-k1vhee {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      height: 100%;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+      -webkit-box-pack: justify;
+      -webkit-justify-content: space-between;
+      justify-content: space-between;
+    }
+
+    .dcr-fossqd {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-box-flex: 1;
+      -webkit-flex-grow: 1;
+      -ms-flex-positive: 1;
+      flex-grow: 1;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+      width: 100%;
+    }
+
+    @media (min-width: 1300px) {
+      .dcr-fossqd {
+        margin-right: 68px;
+      }
+    }
+
+    .dcr-j3w6wb {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-box-pack: end;
+      -ms-flex-pack: end;
+      -webkit-justify-content: flex-end;
+      justify-content: flex-end;
+    }
+
+    @media (max-width: 1139px) {
+      .dcr-j3w6wb {
         -webkit-box-pack: justify;
         -webkit-justify-content: space-between;
         justify-content: space-between;
@@ -2012,8 +8783,403 @@ https://workforus.theguardian.com/careers/product-engineering/
         clip-path: inset(50%);
       }
 
-      .dcr-1ikbe4v {
-        clear: right;
+    .dcr-3x1x0z {
+      width: 100%;
+    }
+
+    .dcr-102ctxe {
+      position: absolute;
+      overflow: hidden;
+      white-space: nowrap;
+      width: 1px;
+      height: 1px;
+      margin: -1px;
+      padding: 0;
+      border: 0;
+      clip: rect(1px, 1px, 1px, 1px);
+      -webkit-clip-path: inset(50%);
+      -webkit-clip-path: inset(50%);
+      clip-path: inset(50%);
+    }
+
+    .dcr-hqoq27 {
+      display: grid;
+      grid-auto-flow: column;
+      grid-template-columns: 1fr;
+      grid-template-rows: auto auto auto auto auto auto auto auto auto auto;
+      border-left: 1px solid #DCDCDC;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-hqoq27 {
+        grid-template-columns: 1fr 1fr;
+        grid-template-rows: auto auto auto auto auto;
+      }
+    }
+
+    .dcr-9e1ukq {
+      position: relative;
+      border-right: 1px solid #DCDCDC;
+      min-height: 3.25rem;
+    }
+
+    @media (max-width: 1139px) {
+      .dcr-9e1ukq {
+        border-top: 1px solid #DCDCDC;
+      }
+    }
+
+    .dcr-9e1ukq:hover {
+      cursor: pointer;
+    }
+
+    .dcr-9e1ukq:hover,
+    .dcr-9e1ukq:focus {
+      background: #F6F6F6;
+    }
+
+    .dcr-xyss4m {
+      -webkit-text-decoration: none;
+      text-decoration: none;
+      color: #121212;
+      font-weight: 500;
+      font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+      font-size: 1.0625rem;
+      line-height: 1.15;
+      font-weight: 500;
+      --source-text-decoration-thickness: 2px;
+      display: block;
+    }
+
+    .dcr-q76bkn {
+      position: absolute;
+      top: 0.375rem;
+      left: 0.625rem;
+      fill: #121212;
+    }
+
+    .dcr-14gme47 {
+      padding: 0.1875rem 0.625rem 1.125rem 4.6875rem;
+      word-wrap: break-word;
+      overflow: hidden;
+    }
+
+    .dcr-n4owjk {
+      font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+      font-size: 1.0625rem;
+      line-height: 1.15;
+      font-weight: 500;
+      --source-text-decoration-thickness: 2px;
+    }
+
+    .dcr-1haxrmz {
+      position: relative;
+      border-top: 1px solid #DCDCDC;
+      border-right: 1px solid #DCDCDC;
+      min-height: 3.25rem;
+    }
+
+    @media (max-width: 1139px) {
+      .dcr-1haxrmz {
+        border-top: 1px solid #DCDCDC;
+      }
+    }
+
+    .dcr-1haxrmz:hover {
+      cursor: pointer;
+    }
+
+    .dcr-1haxrmz:hover,
+    .dcr-1haxrmz:focus {
+      background: #F6F6F6;
+    }
+
+    .dcr-1ij4tou {
+      color: #C70000;
+    }
+
+    .dcr-1ij4tou:before {
+      border-radius: 62.5rem;
+      display: inline-block;
+      position: relative;
+      background-color: currentColor;
+      width: 0.75em;
+      height: 0.75em;
+      content: '';
+      margin-right: 0.1875rem;
+      vertical-align: initial;
+    }
+
+    .dcr-1ij4tou[data-animate='true'] {
+      -webkit-animation: animation-111ynch 1s infinite;
+      animation: animation-111ynch 1s infinite;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .dcr-1ij4tou[data-animate='true'] {
+        -webkit-animation: none;
+        animation: none;
+      }
+    }
+
+    .dcr-10j4v47 {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+      border-left: 1px solid #DCDCDC;
+      border-right: 1px solid #DCDCDC;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-10j4v47 {
+        -webkit-flex-direction: row;
+        -ms-flex-direction: row;
+        flex-direction: row;
+      }
+    }
+
+    @media (min-width: 740px) {
+      .dcr-10j4v47 {
+        padding-top: 24px;
+      }
+    }
+
+    .dcr-1o3p705 {
+      position: relative;
+      padding-left: 10px;
+      padding-right: 10px;
+      padding-bottom: 12px;
+      border-top: 1px solid #DCDCDC;
+      min-height: 3.25rem;
+      -webkit-flex-basis: 100%;
+      -ms-flex-preferred-size: 100%;
+      flex-basis: 100%;
+    }
+
+    @media (min-width: 740px) {
+      .dcr-1o3p705 {
+        border-right: 1px solid #DCDCDC;
+      }
+    }
+
+    .dcr-1o3p705:hover {
+      cursor: pointer;
+    }
+
+    .dcr-1o3p705:hover,
+    .dcr-1o3p705:focus {
+      background: #F6F6F6;
+    }
+
+    .dcr-1wxws1r {
+      word-wrap: break-word;
+      overflow: hidden;
+    }
+
+    .dcr-19eam1p {
+      font-family: GH Guardian Headline, Guardian Egyptian Web, Georgia, serif;
+      font-size: 1.0625rem;
+      line-height: 1.15;
+      font-weight: 700;
+      --source-text-decoration-thickness: 2px;
+      padding-top: 4px;
+    }
+
+    .dcr-1lbz6ez {
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: row-reverse;
+      -ms-flex-direction: row-reverse;
+      flex-direction: row-reverse;
+      margin-left: 5px;
+      margin-top: 24px;
+    }
+
+    .dcr-vibzgs {
+      height: 90px;
+      width: 90px;
+    }
+
+    .dcr-10kck6o {
+      display: block;
+      border-radius: 100%;
+      height: 100%;
+      width: 100%;
+      overflow: hidden;
+      background-color: #FF5943;
+    }
+
+    .dcr-1yduq3m {
+      display: block;
+      object-fit: cover;
+      height: 100%;
+      width: 100%;
+    }
+
+    .dcr-1ngqhfk {
+      position: relative;
+      padding-left: 10px;
+      padding-right: 10px;
+      padding-bottom: 12px;
+      border-top: 1px solid #DCDCDC;
+      min-height: 3.25rem;
+      -webkit-flex-basis: 100%;
+      -ms-flex-preferred-size: 100%;
+      flex-basis: 100%;
+    }
+
+    .dcr-1ngqhfk:hover {
+      cursor: pointer;
+    }
+
+    .dcr-1ngqhfk:hover,
+    .dcr-1ngqhfk:focus {
+      background: #F6F6F6;
+    }
+
+    .dcr-i5gfxx {
+      margin: 6px 0 0 10px;
+    }
+
+    .dcr-ge5xgp {
+      position: relative;
+      min-height: 274px;
+      min-width: 300px;
+      width: 300px;
+      margin: 12px auto;
+      text-align: center;
+    }
+
+    .dcr-ge5xgp .ad-slot__scroll {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      max-height: 24px;
+      background-color: #F6F6F6;
+      padding: 0 8px;
+      border-top: 1px solid #DCDCDC;
+      color: #707070;
+      text-align: left;
+      box-sizing: border-box;
+      position: relative;
+    }
+
+    .dcr-ge5xgp .ad-slot__scroll.visible {
+      visibility: initial;
+    }
+
+    .dcr-ge5xgp .ad-slot__scroll.hidden {
+      visibility: hidden;
+    }
+
+    .dcr-ge5xgp .ad-slot__close-button {
+      display: none;
+    }
+
+    .dcr-ge5xgp .ad-slot__scroll {
+      position: fixed;
+      bottom: 0;
+      width: 100%;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      max-height: 24px;
+      background-color: #F6F6F6;
+      padding: 0 8px;
+      border-top: 1px solid #DCDCDC;
+      color: #707070;
+      text-align: left;
+      box-sizing: border-box;
+    }
+
+    .dcr-ge5xgp .ad-slot:not[data-label-show='true']::before {
+      content: '';
+      display: block;
+      height: 24px;
+      visibility: hidden;
+    }
+
+    .dcr-ge5xgp .ad-slot[data-label-show='true']:not(.ad-slot--interscroller):not(.ad-slot--merchandising):not(.ad-slot--merchandising-high)::before {
+      content: attr(ad-label-text);
+      display: block;
+      position: relative;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      max-height: 24px;
+      background-color: #F6F6F6;
+      padding: 0 8px;
+      border-top: 1px solid #DCDCDC;
+      color: #707070;
+      text-align: left;
+      box-sizing: border-box;
+    }
+
+    .dcr-ge5xgp .ad-slot--merchandising[data-label-show='true']::before,
+    .dcr-ge5xgp .ad-slot--merchandising-high[data-label-show='true']::before {
+      content: attr(ad-label-text);
+      display: block;
+      position: relative;
+      max-width: 970px;
+      margin: auto;
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      height: 24px;
+      max-height: 24px;
+      background-color: #F6F6F6;
+      padding: 0 8px;
+      border-top: 1px solid #DCDCDC;
+      color: #707070;
+      text-align: left;
+      box-sizing: border-box;
+    }
+
+    .dcr-ge5xgp .ad-slot__adtest-cookie-clear-link {
+      font-family: GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+      font-size: 0.75rem;
+      line-height: 1.35;
+      font-weight: 400;
+      --source-text-decoration-thickness: 2px;
+      text-align: left;
+      position: absolute;
+      left: 268px;
+      top: 1px;
+      z-index: 10;
+      padding: 0;
+      border: 0;
+    }
+
+    .dcr-ge5xgp.ad-slot--fluid {
+      min-height: 250px;
+      line-height: 10px;
+      padding: 0;
+      margin: 0;
+    }
+
+    .dcr-ge5xgp .ad-slot.ad-slot--collapse {
+      display: none;
+    }
+
+    @media (min-width: 980px) {
+      .dcr-ge5xgp {
         margin: 0;
         list-style: none;
         list-style-image: none;
@@ -9188,1856 +16354,12 @@ https://workforus.theguardian.com/careers/product-engineering/
     <div data-print-layout="hide" id="bannerandheader">
       <header class="dcr-1uyetce">
         <div class="dcr-1s8spa1">
-          <div class="dcr-henwc">
-            <gu-island
-              name="HeaderTopBar"
-              props='{"editionId":"UK","dataLinkName":"nav3 : topbar : edition-picker: toggle","idUrl":"https://profile.theguardian.com","mmaUrl":"https://manage.theguardian.com","discussionApiUrl":"https://discussion.theguardian.com/discussion-api","idApiUrl":"https://idapi.theguardian.com/","headerTopBarSearchCapiSwitch":false,"isInEuropeTest":false}'
-            >
-              <div class="dcr-1kfeu4u">
-                <div class="dcr-1kvcc9o">
-                  <div class="dcr-1492oy5">
-                    <a
-                      href="https://support.theguardian.com/subscribe?REFPVID=&amp;INTCMP=undefined&amp;acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentId%22%3A%22PrintSubscriptionsHeaderLink%22%2C%22componentType%22%3A%22ACQUISITIONS_HEADER%22%2C%22referrerPageviewId%22%3A%22%22%2C%22referrerUrl%22%3A%22%22%7D"
-                      data-link-name="nav3 : topbar : printsubs"
-                      class="dcr-1086n7e"
-                    >
-                      <svg
-                        width="18"
-                        height="18"
-                        viewBox="-4 -4 32 32"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M12,-4 a15,15 0,0,0 0,32 15,15 0,0,0 0,-32     M20 21L19 21H5L4 21V3L5 2H16L20 6V21Z     M18 8H6V9.5H18V8Z     M18 11H6V12.5H18V11Z     M13 14H6V15.5H13V14Z"
-                        />
-                      </svg>
-                      Print subscriptions
-                    </a>
-                  </div>
-                  <div class="dcr-bi2aot">
-                    <a
-                      href="https://profile.theguardian.com/signin?INTCMP=DOTCOM_NEWHEADER_SIGNIN&amp;ABCMP=ab-sign-in&amp;componentEventParams=componentType%3Didentityauthentication%26componentId%3Dguardian_signin_header"
-                      data-link-name="nav3 : topbar : signin"
-                      class="dcr-xg94hc"
-                    >
-                      <svg width="14" height="14" viewBox="0 0 14 14">
-                        <path
-                          d="M7 0C3.1 0 0 3.1 0 7c0 2 .9 3.9 2.4 5.2C3.6 13.4 5.3 14 7 14c1.7 0 3.4-.6 4.7-1.8C13.2 10.9 14 9 14 7c0-3.9-3.1-7-7-7zm0 1.8c1.3 0 2.1.8 2.1 2.1S8 6.3 7 6.3c-.8 0-2-1.1-2-2.4 0-1.4.7-2.1 2-2.1zm0 11.6c-1.7 0-3.3-.7-4.5-1.8l.8-3.2.5-.5c1-.4 2.1-.5 3.1-.5 1.1 0 2.1.2 3.1.5l.5.5.9 3.2c-1.1 1.2-2.7 1.8-4.4 1.8z"
-                        />
-                      </svg>
-                      Sign in
-                    </a>
-                  </div>
-                  <div class="dcr-1gd007l">
-                    <a
-                      href="https://jobs.theguardian.com"
-                      data-link-name="nav3 : job-cta"
-                      class="dcr-1yaip4y"
-                      >Search jobs</a
-                    >
-                  </div>
-                  <div class="dcr-1gd007l">
-                    <a
-                      href="https://www.google.co.uk/advanced_search?q=site:www.theguardian.com"
-                      data-link-name="nav3 : search"
-                      class="dcr-j7jlyl"
-                    >
-                      <svg width="18" height="18" viewBox="0 0 18 18">
-                        <path
-                          d="M6.5 1.6c2.7 0 4.9 2.2 4.9 4.9s-2.2 4.9-4.9 4.9-4.9-2.2-4.9-4.9 2.2-4.9 4.9-4.9m0-1.6c-3.6 0-6.5 2.9-6.5 6.5s2.9 6.5 6.5 6.5 6.5-2.9 6.5-6.5-2.9-6.5-6.5-6.5zm6.6 11.5l4.9 4.9-1.6 1.6-4.9-4.9v-.8l.8-.8h.8z"
-                        />
-                      </svg>
-                      Search
-                    </a>
-                  </div>
-                  <span class="dcr-14f8c26">
-                    <div class="dcr-h39xrs">
-                      <div class="dcr-g8r8o3">
-                        <label for="checkbox-id-edition" class="dcr-pzbwhq"
-                          >UK edition</label
-                        >
-                        <input
-                          type="checkbox"
-                          id="checkbox-id-edition"
-                          aria-checked="false"
-                          tabindex="-1"
-                        />
-                        <ul id="dropbox-id-edition" class="dcr-1w7ojan">
-                          <li>
-                            <a
-                              href="/preference/edition/uk"
-                              data-link-name="nav3 : topbar : edition-picker: UK"
-                              class="dcr-1irynrj"
-                              >UK edition</a
-                            >
-                          </li>
-                          <li>
-                            <a
-                              href="/preference/edition/us"
-                              data-link-name="nav3 : topbar : edition-picker: US"
-                              class="dcr-16rjsjj"
-                              >US edition</a
-                            >
-                          </li>
-                          <li>
-                            <a
-                              href="/preference/edition/au"
-                              data-link-name="nav3 : topbar : edition-picker: AU"
-                              class="dcr-16rjsjj"
-                              >Australia edition</a
-                            >
-                          </li>
-                          <li>
-                            <a
-                              href="/preference/edition/int"
-                              data-link-name="nav3 : topbar : edition-picker: INT"
-                              class="dcr-16rjsjj"
-                              >International edition</a
-                            >
-                          </li>
-                        </ul>
-                      </div>
-                    </div>
-                  </span>
-                </div>
-              </div>
-            </gu-island>
-            <div class="dcr-127sebo">
-              <gu-island
-                name="Snow"
-                deferUntil="hash"
-                props="{}"
-                clientOnly
-              ></gu-island>
-              <a href="/" data-link-name="nav3 : logo" class="dcr-12xduix">
-                <span class="dcr-1ppwqv1">The Guardian - Back to home</span>
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  viewBox="0 0 300 116"
-                  aria-hidden="true"
-                  fill="none"
-                >
-                  <path
-                    fill="#FFE500"
-                    d="M74 99.926h2.294l3.008 5.1c.233.401.466.834.698 1.3.244.455.46.877.649 1.267.221.466.437.926.648 1.381h.05c-.033-.477-.061-.959-.083-1.446-.022-.412-.045-.856-.067-1.332a60.14 60.14 0 0 1-.016-1.365v-4.905h1.861v11.712h-2.011l-3.308-5.669a33.815 33.815 0 0 1-.714-1.3 81.944 81.944 0 0 1-1.28-2.696h-.067l.1 1.478c.022.422.044.877.066 1.364.023.488.034.937.034 1.348v5.475H74V99.926ZM89.244 111.8c-1.463 0-2.543-.352-3.241-1.056-.687-.704-1.03-1.732-1.03-3.086v-.796c0-.715.099-1.332.298-1.852.2-.53.477-.964.831-1.299.355-.347.77-.601 1.247-.764.477-.173.997-.26 1.563-.26 1.307 0 2.249.331 2.825.991.576.661.865 1.679.865 3.054v1.088h-5.569c.011.488.072.888.183 1.202.11.304.272.542.482.715.222.173.493.292.815.357a5.76 5.76 0 0 0 1.13.098c.587 0 1.08-.054 1.48-.163.41-.119.808-.27 1.196-.454v1.413c-.3.184-.698.368-1.197.552-.487.173-1.114.26-1.878.26Zm-.35-7.651c-.232 0-.459.033-.68.098a1.29 1.29 0 0 0-.582.341c-.178.162-.322.395-.433.698-.11.293-.171.677-.182 1.154h3.59c0-.878-.144-1.479-.432-1.803-.288-.325-.715-.488-1.28-.488ZM93.42 102.85H95.5l.797 3.248c.09.347.178.759.266 1.235.09.466.167.91.233 1.332.078.498.155 1.007.233 1.527h.066c.067-.509.144-1.013.233-1.511.078-.422.16-.866.25-1.332.1-.476.199-.893.299-1.251l.897-3.248h1.795l.898 3.248c.089.347.183.759.282 1.235l.283 1.332c.1.498.188 1.007.266 1.527h.066l.233-1.511c.067-.422.139-.866.216-1.332.089-.476.178-.893.266-1.251l.781-3.248h1.812l-2.41 8.788h-2.028l-1.014-3.574a10.239 10.239 0 0 1-.266-1.121c-.066-.422-.127-.823-.183-1.202-.055-.433-.11-.882-.166-1.348h-.066c-.045.466-.094.915-.15 1.348a33.5 33.5 0 0 1-.2 1.202c-.077.422-.16.796-.249 1.121l-1.014 3.574h-2.077l-2.427-8.788ZM109.469 111.784a8.357 8.357 0 0 1-1.596-.146 5.052 5.052 0 0 1-1.297-.423v-1.559c.189.076.372.146.549.211.177.065.366.125.565.179.211.043.438.081.682.113.243.022.52.033.831.033.598 0 1.025-.081 1.28-.244a.824.824 0 0 0 .399-.731c0-.292-.073-.514-.217-.666-.133-.162-.443-.303-.93-.422l-.981-.227a4.134 4.134 0 0 1-.898-.309 2.395 2.395 0 0 1-.681-.487 2.1 2.1 0 0 1-.432-.731 3.17 3.17 0 0 1-.15-1.024c0-.812.26-1.456.781-1.933.532-.487 1.352-.731 2.46-.731.599 0 1.097.049 1.496.147.41.086.759.2 1.047.341v1.527a5.483 5.483 0 0 0-.997-.293 5.922 5.922 0 0 0-1.363-.146c-1.019 0-1.529.314-1.529.942 0 .292.078.514.233.666.166.141.443.255.831.341l.98.228c.854.195 1.452.487 1.796.877.343.39.515.969.515 1.738 0 .909-.288 1.592-.864 2.047-.577.454-1.413.682-2.51.682ZM114.412 102.85h1.928v.909h.083c.255-.314.599-.568 1.031-.763.432-.206.925-.309 1.479-.309.455 0 .887.071 1.297.211.41.13.77.352 1.08.666.31.315.554.731.732 1.251.188.509.282 1.148.282 1.917v.715c0 .779-.089 1.445-.266 1.998-.177.552-.432 1.001-.764 1.348a2.992 2.992 0 0 1-1.214.763 4.702 4.702 0 0 1-1.562.244c-.521 0-.953-.07-1.297-.211a4.212 4.212 0 0 1-.814-.471v3.817h-1.995V102.85Zm3.74 7.472c.344 0 .643-.043.898-.13.266-.087.487-.233.664-.439.178-.205.311-.476.399-.812.089-.336.133-.753.133-1.251v-.828c0-.498-.044-.91-.133-1.235-.077-.335-.199-.601-.365-.796a1.308 1.308 0 0 0-.632-.406 3.125 3.125 0 0 0-.881-.113c-.421 0-.792.059-1.114.178-.31.109-.548.222-.714.341v4.971c.166.13.404.249.714.357.311.109.654.163 1.031.163ZM126.149 111.8c-.798 0-1.44-.206-1.928-.617-.488-.412-.731-1.045-.731-1.901 0-.812.243-1.418.731-1.819.488-.412 1.169-.671 2.045-.78l1.994-.26v-.666c0-.281-.033-.514-.1-.698a.8.8 0 0 0-.332-.422c-.144-.109-.344-.185-.598-.228a5.401 5.401 0 0 0-.915-.065c-.421 0-.82.027-1.196.081-.366.055-.682.109-.948.163v-1.413c.809-.325 1.784-.488 2.926-.488 1.008 0 1.784.206 2.327.618.554.411.831 1.082.831 2.014v6.319h-1.646l-.166-.878h-.1c-.21.282-.487.526-.831.731-.343.206-.798.309-1.363.309Zm.615-1.413c.31 0 .593-.044.848-.13a1.94 1.94 0 0 0 .648-.374v-2.225l-1.546.146c-.82.076-1.23.536-1.23 1.381 0 .422.117.731.349.926.233.184.543.276.931.276ZM132.349 102.85h1.928v.909h.083c.255-.314.598-.568 1.031-.763.432-.206.925-.309 1.479-.309.454 0 .886.071 1.296.211.41.13.771.352 1.081.666.31.315.554.731.731 1.251.189.509.283 1.148.283 1.917v.715c0 .779-.089 1.445-.266 1.998-.178.552-.432 1.001-.765 1.348a2.988 2.988 0 0 1-1.213.763 4.708 4.708 0 0 1-1.563.244c-.521 0-.953-.07-1.296-.211a4.223 4.223 0 0 1-.815-.471v3.817h-1.994V102.85Zm3.74 7.472c.343 0 .642-.043.897-.13.266-.087.488-.233.665-.439.177-.205.31-.476.399-.812.089-.336.133-.753.133-1.251v-.828c0-.498-.044-.91-.133-1.235-.078-.335-.199-.601-.366-.796a1.3 1.3 0 0 0-.631-.406 3.13 3.13 0 0 0-.881-.113c-.421 0-.793.059-1.114.178-.31.109-.548.222-.715.341v4.971c.167.13.405.249.715.357.31.109.654.163 1.031.163ZM145.765 111.8c-1.463 0-2.544-.352-3.242-1.056-.687-.704-1.03-1.732-1.03-3.086v-.796c0-.715.1-1.332.299-1.852.199-.53.476-.964.831-1.299.355-.347.77-.601 1.247-.764.476-.173.997-.26 1.562-.26 1.308 0 2.25.331 2.826.991.576.661.864 1.679.864 3.054v1.088h-5.568c.011.488.072.888.183 1.202.111.304.271.542.482.715.221.173.493.292.814.357.322.065.698.098 1.131.098.587 0 1.08-.054 1.479-.163a7.98 7.98 0 0 0 1.197-.454v1.413c-.3.184-.698.368-1.197.552-.488.173-1.114.26-1.878.26Zm-.349-7.651c-.233 0-.46.033-.682.098-.21.054-.404.168-.582.341-.177.162-.321.395-.432.698-.111.293-.172.677-.183 1.154h3.591c0-.878-.144-1.479-.433-1.803-.288-.325-.714-.488-1.279-.488ZM150.673 102.85h1.911v1.202h.1c.111-.184.25-.358.416-.52a3.156 3.156 0 0 1 1.23-.698c.232-.076.465-.114.698-.114.277 0 .454.027.532.081v1.787a2.208 2.208 0 0 0-.349-.049 4.074 4.074 0 0 0-1.529.163 3.769 3.769 0 0 0-1.014.422v6.514h-1.995v-8.788ZM164.704 111.8c-1.297 0-2.305-.352-3.025-1.056-.721-.704-1.081-1.732-1.081-3.086v-.747c0-.693.105-1.3.316-1.82a3.81 3.81 0 0 1 .864-1.332 3.465 3.465 0 0 1 1.297-.796 4.81 4.81 0 0 1 1.645-.276c1.275 0 2.266.352 2.976 1.056.72.693 1.08 1.722 1.08 3.086v.748c0 .704-.105 1.321-.316 1.851-.199.52-.482.959-.847 1.316a3.58 3.58 0 0 1-1.28.796 4.942 4.942 0 0 1-1.629.26Zm.033-1.511c.632 0 1.114-.195 1.446-.584.344-.39.515-1.045.515-1.966v-.893c0-.553-.055-.997-.166-1.332-.1-.347-.244-.618-.432-.812a1.288 1.288 0 0 0-.632-.39 2.606 2.606 0 0 0-.781-.114c-.631 0-1.125.2-1.479.601-.355.401-.532 1.056-.532 1.965v.91c0 .542.05.986.149 1.332.111.336.261.601.449.796.189.184.405.314.649.39.254.065.526.097.814.097ZM171.111 104.393h-1.463v-1.543h1.463v-1.089c0-.953.266-1.651.798-2.095.543-.444 1.235-.666 2.077-.666.41 0 .759.032 1.047.097.3.055.527.125.682.212v1.364a3.477 3.477 0 0 0-.499-.081 4.522 4.522 0 0 0-.698-.049c-.465 0-.82.108-1.064.325-.232.217-.349.574-.349 1.072v.91h2.145v1.543h-2.145v7.245h-1.994v-7.245ZM183.96 111.751c-.377 0-.715-.038-1.014-.113a2.084 2.084 0 0 1-.781-.374 1.78 1.78 0 0 1-.499-.682c-.111-.293-.166-.65-.166-1.072v-5.117h-1.48v-1.543h1.48v-2.128h1.994v2.128h2.311v1.543h-2.311v4.808c0 .379.078.639.233.78.166.14.46.211.881.211.188 0 .416-.022.682-.065a2.87 2.87 0 0 0 .631-.163v1.332c-.188.12-.454.228-.798.325-.343.087-.731.13-1.163.13ZM187.327 99.146h1.995v4.597h.083a3.805 3.805 0 0 1 1.213-.747 3.934 3.934 0 0 1 1.546-.309c.831 0 1.452.19 1.862.569.421.379.632.996.632 1.852v6.53h-1.995v-6.043c0-.444-.094-.758-.283-.942-.188-.195-.57-.293-1.147-.293a3.8 3.8 0 0 0-1.013.147 4.3 4.3 0 0 0-.898.324v6.807h-1.995V99.146ZM200.565 111.8c-1.463 0-2.543-.352-3.242-1.056-.687-.704-1.03-1.732-1.03-3.086v-.796c0-.715.1-1.332.299-1.852.2-.53.477-.964.831-1.299.355-.347.77-.601 1.247-.764.476-.173.997-.26 1.562-.26 1.308 0 2.25.331 2.826.991.576.661.864 1.679.864 3.054v1.088h-5.568c.011.488.072.888.183 1.202.111.304.271.542.482.715.222.173.493.292.814.357.322.065.698.098 1.131.098.587 0 1.08-.054 1.479-.163a7.98 7.98 0 0 0 1.197-.454v1.413c-.299.184-.698.368-1.197.552-.488.173-1.114.26-1.878.26Zm-.349-7.651c-.233 0-.46.033-.682.098-.21.054-.404.168-.582.341-.177.162-.321.395-.432.698-.111.293-.172.677-.183 1.154h3.591c0-.878-.144-1.479-.432-1.803-.289-.325-.715-.488-1.28-.488ZM210.509 115c-.233 0-.482-.027-.748-.081-.255-.044-.449-.109-.582-.195v-1.381c.255.054.548.081.881.081.399 0 .726-.086.981-.26.266-.173.476-.465.631-.877l.316-.828-3.125-8.609h2.111l.981 2.859c.155.454.293.936.415 1.445.133.498.244.953.333 1.365.111.487.205.964.282 1.429h.05c.089-.465.189-.942.299-1.429.089-.412.194-.867.316-1.365.133-.509.277-.991.432-1.445l.931-2.859h1.978l-3.44 9.746c-.289.834-.665 1.44-1.131 1.819-.465.39-1.102.585-1.911.585ZM221.878 111.8c-1.463 0-2.543-.352-3.242-1.056-.687-.704-1.03-1.732-1.03-3.086v-.796c0-.715.1-1.332.299-1.852.199-.53.477-.964.831-1.299.355-.347.77-.601 1.247-.764.476-.173.997-.26 1.562-.26 1.308 0 2.25.331 2.826.991.576.661.864 1.679.864 3.054v1.088h-5.568c.011.488.072.888.183 1.202.111.304.271.542.482.715.221.173.493.292.814.357.322.065.698.098 1.131.098.587 0 1.08-.054 1.479-.163a7.98 7.98 0 0 0 1.197-.454v1.413c-.299.184-.698.368-1.197.552-.488.173-1.114.26-1.878.26Zm-.349-7.651c-.233 0-.46.033-.682.098-.21.054-.404.168-.582.341-.177.162-.321.395-.432.698-.111.293-.172.677-.183 1.154h3.591c0-.878-.144-1.479-.433-1.803-.288-.325-.714-.488-1.279-.488ZM228.997 111.8c-.798 0-1.441-.206-1.928-.617-.488-.412-.732-1.045-.732-1.901 0-.812.244-1.418.732-1.819.487-.412 1.169-.671 2.044-.78l1.995-.26v-.666c0-.281-.034-.514-.1-.698a.804.804 0 0 0-.332-.422c-.145-.109-.344-.185-.599-.228a5.388 5.388 0 0 0-.914-.065c-.421 0-.82.027-1.197.081a19.36 19.36 0 0 0-.947.163v-1.413c.809-.325 1.784-.488 2.925-.488 1.009 0 1.784.206 2.327.618.554.411.831 1.082.831 2.014v6.319h-1.645l-.166-.878h-.1a2.84 2.84 0 0 1-.831.731c-.344.206-.798.309-1.363.309Zm.615-1.413c.31 0 .593-.044.847-.13.266-.098.482-.222.649-.374v-2.225l-1.546.146c-.82.076-1.23.536-1.23 1.381 0 .422.116.731.349.926.233.184.543.276.931.276ZM235.113 102.85h1.912v1.202h.099c.111-.184.25-.358.416-.52a3.156 3.156 0 0 1 1.23-.698c.233-.076.465-.114.698-.114.277 0 .454.027.532.081v1.787a2.208 2.208 0 0 0-.349-.049 4.08 4.08 0 0 0-1.529.163 3.769 3.769 0 0 0-1.014.422v6.514h-1.995v-8.788Z"
-                  ></path>
-                  <path
-                    fill="#fff"
-                    d="m68.131 51.554 5.152-2.675V8.502h-3.896L59.87 21.091h-1.075l.607-14.032h41.262l.596 14.032h-1.129L90.806 8.502h-3.992v40.292l5.184 2.728v1.369H68.131v-1.337Zm37.27-1.784V5.02l-4.003-1.592V2.59L115.866 0h1.522v21.175l.404-.34c3.205-2.79 7.804-4.585 12.402-4.585 6.335 0 9.134 3.567 9.134 10.211v23.31l3.386 1.835v1.36h-18.917v-1.349l3.395-1.847V26.376c0-3.65-1.596-5.116-4.598-5.116-2.002 0-3.726.627-5.004 1.646v26.917l3.332 1.837v1.295h-18.927V51.67l3.406-1.9Zm48.331-13.745c.393 7.398 3.715 13.12 11.592 13.12 3.811 0 6.515-1.763 9.06-3.1V47.5c-1.97 2.686-6.962 6.454-13.914 6.454-12.21 0-18.449-6.762-18.449-18.48 0-11.453 6.824-18.585 17.853-18.585 10.369 0 15.755 5.169 15.755 18.776v.35h-21.897v.01Zm-.203-1.698 10.742-.658c0-9.16-1.576-15.242-4.727-15.242-3.343 0-6.015 7.058-6.015 15.9ZM0 70.808C0 51.33 12.934 44.399 27.338 44.399c6.11 0 11.88.977 15.105 2.314l.277 13.597h-1.373l-8.453-13.15c-1.447-.616-2.82-.86-5.354-.86-7.654 0-11.572 8.82-11.455 23.287.15 17.301 3.162 25.156 10.188 25.156 1.831 0 3.236-.276 4.216-.7V75.498l-4.642-2.653v-1.55h22.42v1.656L43.7 75.499v18.288c-3.79 1.476-10.188 2.877-16.937 2.877C10.39 96.664 0 89.096 0 70.808Zm47.478-9.086v-1.125l15.075-2.653 1.65.138v29.614c0 3.566 1.724 4.67 4.609 4.67 1.863 0 3.545-.7 4.886-2.303V63.505l-4.13-1.784v-1.167L84.642 57.9l1.511.138v33.945l4.067 1.698v1.083L75.348 96.59l-1.511-.138v-4.458h-.416c-2.757 2.537-6.61 4.734-11.294 4.734-7.229 0-10.54-4.256-10.54-10.71V63.507l-4.109-1.785Zm95.289-3.842 1.235.138v10.964h.34c1.608-8.035 5.163-11.038 9.496-11.038.692 0 1.448.063 1.863.275v11.22c-.692-.202-1.927-.276-3.098-.276-3.438 0-5.972.615-8.197 1.634v21.675l3.428 1.9v1.4h-19.545v-1.39l3.524-1.9V62.9l-4.131-1.23v-1.01l15.085-2.78Z"
-                  ></path>
-                  <path
-                    fill="#fff"
-                    d="M180.622 58.804v-11.57l-4.131-1.443v-.924l15.213-2.791 1.447.201v49.686l4.205 1.518v1.284l-15.01 2.016-1.171-.137v-4.108h-.34c-2.204 2.197-5.238 4.182-9.986 4.182-8.197 0-14.18-6.241-14.18-19.01 0-13.46 6.952-20.072 17.491-20.072 3.013 0 5.291.552 6.462 1.168Zm-.032 31.81V60.917c-.969-.616-1.661-1.38-4.163-1.295-4.066.138-6.578 6.273-6.578 17.184 0 9.819 1.809 15.306 7.228 15.126 1.522-.053 2.757-.595 3.513-1.316v-.002Zm33.48-32.766 1.309.138V92.46l3.439 1.9v1.4h-19.545v-1.39l3.513-1.9V63.43l-4.205-1.645v-1.147l15.489-2.79Zm1.384-9.31c0 3.642-3.098 6.38-6.675 6.38-3.715 0-6.611-2.749-6.611-6.38 0-3.64 2.896-6.453 6.611-6.453 3.577 0 6.675 2.813 6.675 6.454v-.001Zm45.999 43.934v-29.36l-4.131-1.443v-1.422l15.01-2.792 1.512.138v4.394h.415c3.236-2.887 8.059-4.734 12.807-4.734 6.536 0 9.432 3.09 9.432 9.957v25.198L300 94.36v1.4h-19.545v-1.39l3.513-1.9V67.9c0-3.778-1.65-5.285-4.748-5.285-2.001 0-3.641.51-5.163 1.634v28.213l3.438 1.9v1.4H257.94v-1.39l3.513-1.9Zm-21.685-18.448v-4.925c0-7.42-1.618-9.85-6.217-9.85-.543 0-1.011.063-1.554.137l-8.186 11.06h-1.15V60.269c3.513-1.083 7.91-2.357 13.733-2.357 10.006 0 15.829 2.77 15.829 11.124v24.01l3.588.944v.945c-1.416.88-4.258 1.687-7.377 1.687-4.94 0-7.303-1.613-8.389-4.32h-.341c-2.097 2.834-5.067 4.448-9.74 4.448-5.951 0-10.007-3.705-10.007-10.116 0-6.209 3.854-9.574 11.699-11.06l8.112-1.55Zm0 16.59v-14.84l-2.501.203c-3.929.34-5.344 2.834-5.344 8.364 0 5.997 1.958 7.557 4.737 7.557 1.554-.01 2.438-.478 3.108-1.284Zm-129.566-16.59v-4.925c0-7.42-1.618-9.85-6.227-9.85-.543 0-1.012.063-1.555.137l-8.186 11.06h-1.15V60.269c3.513-1.083 7.91-2.357 13.733-2.357 10.007 0 15.83 2.77 15.83 11.124v24.01l3.587.944v.945c-1.416.88-4.258 1.687-7.377 1.687-4.94 0-7.303-1.613-8.389-4.32h-.34c-2.097 2.834-5.078 4.448-9.741 4.448-5.95 0-10.007-3.705-10.007-10.116 0-6.209 3.854-9.574 11.7-11.06l8.122-1.55Zm0 16.59v-14.84l-2.501.203c-3.929.34-5.344 2.834-5.344 8.364 0 5.997 1.958 7.557 4.737 7.557 1.543-.01 2.427-.478 3.108-1.284Z"
-                  ></path>
-                </svg>
-              </a>
-              <gu-island
-                name="SupportTheG"
-                deferUntil="idle"
-                props='{"urls":{"contribute":"https://support.theguardian.com/contribute?INTCMP=header_support_contribute&amp;acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22header_support_contribute%22%7D","subscribe":"https://support.theguardian.com/subscribe?INTCMP=header_support_subscribe&amp;acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22header_support_subscribe%22%7D","support":"https://support.theguardian.com?INTCMP=header_support&amp;acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22header_support%22%7D","supporter":"https://support.theguardian.com/subscribe?INTCMP=header_supporter_cta&amp;acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22header_supporter_cta%22%7D"},"editionId":"UK","dataLinkNamePrefix":"nav3 : ","inHeader":true,"remoteHeader":true,"contributionsServiceUrl":"https://contributions.guardianapis.com"}'
-                clientOnly
-              ></gu-island>
-            </div>
-          </div>
-        </div>
-      </header>
-      <nav class="dcr-1uyetce">
-        <div class="dcr-1z074wr">
-          <div class="dcr-x2bp9n">
-            <script>
-              document.addEventListener('DOMContentLoaded', function () {
-                // Used to toggle data-link-name on label buttons
-                var navInputCheckbox = document.getElementById(
-                  'top-nav-input-checkbox'
-                );
-                var showMoreButton =
-                  document.getElementById('show-more-button');
-                var veggieBurger = document.getElementById('veggie-burger');
-                var expandedMenuClickableTags = document.querySelectorAll(
-                  '.selectableMenuItem'
-                );
-                var expandedMenu =
-                  document.getElementById('expanded-menu-root');
-
-                // We assume News is the 1st column
-                var firstColLabel = document.getElementById('News-button');
-                var firstColLink = document.querySelectorAll(
-                  '#newsLinks > li:nth-of-type(2) > a'
-                )[0];
-
-                var focusOnFirstNavElement = function () {
-                  // need to focus on first element in list, firstColLabel is not viewable on desktop
-                  if (
-                    window.getComputedStyle(firstColLabel).display === 'none'
-                  ) {
-                    firstColLink.focus();
-                  } else {
-                    firstColLabel.focus();
-                  }
-                };
-
-                if (!navInputCheckbox) return;
-                // Sticky nav replaces the nav so element no longer exists for users in test.
-
-                navInputCheckbox.addEventListener('click', function () {
-                  document.body.classList.toggle('nav-is-open');
-
-                  if (!navInputCheckbox.checked) {
-                    firstColLabel.setAttribute('aria-expanded', 'false');
-                    showMoreButton.setAttribute(
-                      'data-link-name',
-                      'nav2 : veggie-burger: show'
-                    );
-                    veggieBurger.setAttribute(
-                      'data-link-name',
-                      'nav2 : veggie-burger: show'
-                    );
-                    expandedMenuClickableTags.forEach(function (
-                      $selectableElement
-                    ) {
-                      $selectableElement.setAttribute('tabindex', '-1');
-                    });
-                  } else {
-                    firstColLabel.setAttribute('aria-expanded', 'true');
-                    showMoreButton.setAttribute(
-                      'data-link-name',
-                      'nav2 : veggie-burger: hide'
-                    );
-                    veggieBurger.setAttribute(
-                      'data-link-name',
-                      'nav2 : veggie-burger: hide'
-                    );
-                    expandedMenuClickableTags.forEach(function (
-                      $selectableElement
-                    ) {
-                      $selectableElement.setAttribute('tabindex', '0');
-                    });
-                    focusOnFirstNavElement();
-                  }
-                });
-                var toggleMainMenu = function (e) {
-                  navInputCheckbox.click();
-                };
-                // Close hide menu on press enter
-                var keydownToggleMainMenu = function (e) {
-                  // keyCode: 13 => Enter key | keyCode: 32 => Space key
-                  if (e.keyCode === 13 || e.keyCode === 32) {
-                    e.preventDefault();
-                    toggleMainMenu();
-                  }
-                };
-                showMoreButton.addEventListener(
-                  'keydown',
-                  keydownToggleMainMenu
-                );
-                veggieBurger.addEventListener('keydown', keydownToggleMainMenu);
-                // Accessibility to hide Nav when pressing escape key
-                document.addEventListener('keydown', function (e) {
-                  // keyCode: 27 => esc
-                  if (e.keyCode === 27) {
-                    if (navInputCheckbox.checked) {
-                      toggleMainMenu();
-                      if (
-                        window.getComputedStyle(veggieBurger).display === 'none'
-                      ) {
-                        showMoreButton.focus();
-                      } else {
-                        veggieBurger.focus();
-                      }
-                    }
-                  }
-                });
-                // onBlur close dialog
-                document.addEventListener('mousedown', function (e) {
-                  if (
-                    navInputCheckbox.checked &&
-                    !expandedMenu.contains(e.target)
-                  ) {
-                    toggleMainMenu();
-                  }
-                });
-              });
-            </script>
-            <div data-component="nav2" class="dcr-1yaxlqk">
-              <input
-                type="checkbox"
-                id="top-nav-input-checkbox"
-                name="more"
-                tabindex="-1"
-                aria-hidden="true"
-                role="button"
-                aria-expanded="false"
-                aria-haspopup="true"
-                class="dcr-sy54ny"
-              />
-              <ul data-testid="pillar-list" class="dcr-1ikbe4v">
-                <li class="dcr-1aeyz4o">
-                  <a
-                    id="navigation"
-                    href="/"
-                    data-link-name="nav2 : primary : News"
-                    class="dcr-h2gqsd"
-                    >News</a
-                  >
-                </li>
-                <li class="dcr-1aeyz4o">
-                  <a
-                    href="/commentisfree"
-                    data-link-name="nav2 : primary : Opinion"
-                    class="dcr-c8vw16"
-                    >Opinion</a
-                  >
-                </li>
-                <li class="dcr-1aeyz4o">
-                  <a
-                    href="/sport"
-                    data-link-name="nav2 : primary : Sport"
-                    class="dcr-a6bcsq"
-                    >Sport</a
-                  >
-                </li>
-                <li class="dcr-1aeyz4o">
-                  <a
-                    href="/culture"
-                    data-link-name="nav2 : primary : Culture"
-                    class="dcr-1tabvac"
-                    >Culture</a
-                  >
-                </li>
-                <li class="dcr-1aeyz4o">
-                  <a
-                    href="/lifeandstyle"
-                    data-link-name="nav2 : primary : Lifestyle"
-                    class="dcr-1t1n4fm"
-                    >Lifestyle</a
-                  >
-                </li>
-              </ul>
-              <div id="expanded-menu-root">
-                <label
-                  id="show-more-button"
-                  aria-label="Toggle main menu"
-                  for="top-nav-input-checkbox"
-                  data-link-name="nav2 : veggie-burger: show"
-                  tabindex="0"
-                  role="button"
-                  data-cy="nav-show-more-button"
-                  class="dcr-1kuh7tf"
-                >
-                  <span class="dcr-1nvgr5i">Show</span>
-                  <span class="dcr-a2u3ka">
-                    More
-                    <svg
-                      viewBox="-3 -3 30 30"
-                      xmlns="http://www.w3.org/2000/svg"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill-rule="evenodd"
-                        clip-rule="evenodd"
-                        d="m1 7.224 10.498 10.498h1.004L23 7.224l-.98-.954L12 14.708 1.98 6.27 1 7.224Z"
-                      ></path>
-                    </svg>
-                  </span>
-                </label>
-                <label
-                  id="veggie-burger"
-                  aria-label="Toggle main menu"
-                  for="top-nav-input-checkbox"
-                  data-link-name="nav2 : veggie-burger: show"
-                  tabindex="0"
-                  role="button"
-                  data-cy="veggie-burger"
-                  class="dcr-13vr4eh"
-                >
-                  <span class="dcr-1nvgr5i">Show More</span>
-                  <span class="dcr-120u0k1"></span>
-                </label>
-                <div id="expanded-menu" class="dcr-mebke">
-                  <div
-                    data-testid="expanded-menu"
-                    data-cy="expanded-menu"
-                    class="dcr-18m7gh9"
-                  >
-                    <ul
-                      role="menubar"
-                      data-cy="nav-menu-columns"
-                      class="dcr-1kn7o79"
-                    >
-                      <li role="none" class="dcr-1y4qg42">
-                        <script>
-                          document.addEventListener(
-                            'DOMContentLoaded',
-                            function () {
-                              var columnInput =
-                                document.getElementById('News-button');
-
-                              if (!columnInput) return;
-                              // Sticky nav replaces the nav so element no longer exists for users in test.
-
-                              columnInput.addEventListener(
-                                'keydown',
-                                function (e) {
-                                  // keyCode: 13 => Enter key | keyCode: 32 => Space key
-                                  if (e.keyCode === 13 || e.keyCode === 32) {
-                                    e.preventDefault();
-                                    document
-                                      .getElementById('News-checkbox-input')
-                                      .click();
-                                  }
-                                }
-                              );
-                            }
-                          );
-                        </script>
-                        <input
-                          type="checkbox"
-                          id="News-checkbox-input"
-                          tabindex="-1"
-                          aria-hidden="true"
-                          class="dcr-1acea34"
-                        />
-                        <label
-                          id="News-button"
-                          aria-label="Toggle News"
-                          for="News-checkbox-input"
-                          aria-haspopup="true"
-                          aria-controls="newsLinks"
-                          tabindex="-1"
-                          role="menuitem"
-                          data-cy="column-collapse-News"
-                          data-link-name="nav2 : column-toggle-News: show"
-                          class="selectableMenuItem dcr-1fqnu7z"
-                          >News</label
-                        >
-                        <ul
-                          role="menu"
-                          id="newsLinks"
-                          data-cy="newsLinks"
-                          class="dcr-nqw243"
-                        >
-                          <li role="none" class="dcr-9ra8aa">
-                            <a
-                              href="/"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : View all News"
-                              data-cy="column-collapse-sublink-News"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >View all News</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-4hq641">
-                            <a
-                              href="/uk-news"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : UK news"
-                              data-cy="column-collapse-sublink-UK"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >UK news</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-4hq641">
-                            <a
-                              href="/world"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : World news"
-                              data-cy="column-collapse-sublink-World"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >World news</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-4hq641">
-                            <a
-                              href="/environment/climate-crisis"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : Climate crisis"
-                              data-cy="column-collapse-sublink-Climate crisis"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >Climate crisis</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-4hq641">
-                            <a
-                              href="/email-newsletters"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : Newsletters"
-                              data-cy="column-collapse-sublink-Newsletters"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >Newsletters</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-4hq641">
-                            <a
-                              href="/football"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : Football"
-                              data-cy="column-collapse-sublink-Football"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >Football</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-4hq641">
-                            <a
-                              href="/world/coronavirus-outbreak"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : Coronavirus"
-                              data-cy="column-collapse-sublink-Coronavirus"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >Coronavirus</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-4hq641">
-                            <a
-                              href="/business"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : Business"
-                              data-cy="column-collapse-sublink-Business"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >Business</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-4hq641">
-                            <a
-                              href="/environment"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : Environment"
-                              data-cy="column-collapse-sublink-Environment"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >Environment</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-4hq641">
-                            <a
-                              href="/politics"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : UK politics"
-                              data-cy="column-collapse-sublink-UK politics"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >UK politics</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-4hq641">
-                            <a
-                              href="/education"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : Education"
-                              data-cy="column-collapse-sublink-Education"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >Education</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-4hq641">
-                            <a
-                              href="/society"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : Society"
-                              data-cy="column-collapse-sublink-Society"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >Society</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-4hq641">
-                            <a
-                              href="/science"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : Science"
-                              data-cy="column-collapse-sublink-Science"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >Science</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-4hq641">
-                            <a
-                              href="/technology"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : Tech"
-                              data-cy="column-collapse-sublink-Tech"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >Tech</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-4hq641">
-                            <a
-                              href="/global-development"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : Global development"
-                              data-cy="column-collapse-sublink-Global development"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >Global development</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-4hq641">
-                            <a
-                              href="/obituaries"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : Obituaries"
-                              data-cy="column-collapse-sublink-Obituaries"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >Obituaries</a
-                            >
-                          </li>
-                        </ul>
-                        <div class="dcr-16d24hr"></div>
-                      </li>
-                      <li role="none" class="dcr-1y4qg42">
-                        <script>
-                          document.addEventListener(
-                            'DOMContentLoaded',
-                            function () {
-                              var columnInput =
-                                document.getElementById('Opinion-button');
-
-                              if (!columnInput) return;
-                              // Sticky nav replaces the nav so element no longer exists for users in test.
-
-                              columnInput.addEventListener(
-                                'keydown',
-                                function (e) {
-                                  // keyCode: 13 => Enter key | keyCode: 32 => Space key
-                                  if (e.keyCode === 13 || e.keyCode === 32) {
-                                    e.preventDefault();
-                                    document
-                                      .getElementById('Opinion-checkbox-input')
-                                      .click();
-                                  }
-                                }
-                              );
-                            }
-                          );
-                        </script>
-                        <input
-                          type="checkbox"
-                          id="Opinion-checkbox-input"
-                          tabindex="-1"
-                          aria-hidden="true"
-                          class="dcr-1acea34"
-                        />
-                        <label
-                          id="Opinion-button"
-                          aria-label="Toggle Opinion"
-                          for="Opinion-checkbox-input"
-                          aria-haspopup="true"
-                          aria-controls="opinionLinks"
-                          tabindex="-1"
-                          role="menuitem"
-                          data-cy="column-collapse-Opinion"
-                          data-link-name="nav2 : column-toggle-Opinion: show"
-                          class="selectableMenuItem dcr-15vcq54"
-                          >Opinion</label
-                        >
-                        <ul
-                          role="menu"
-                          id="opinionLinks"
-                          data-cy="opinionLinks"
-                          class="dcr-bu7bnv"
-                        >
-                          <li role="none" class="dcr-9ra8aa">
-                            <a
-                              href="/commentisfree"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : View all Opinion"
-                              data-cy="column-collapse-sublink-Opinion"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >View all Opinion</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-4hq641">
-                            <a
-                              href="/profile/editorial"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : The Guardian view"
-                              data-cy="column-collapse-sublink-The Guardian view"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >The Guardian view</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-4hq641">
-                            <a
-                              href="/index/contributors"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : Columnists"
-                              data-cy="column-collapse-sublink-Columnists"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >Columnists</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-4hq641">
-                            <a
-                              href="/cartoons/archive"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : Cartoons"
-                              data-cy="column-collapse-sublink-Cartoons"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >Cartoons</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-4hq641">
-                            <a
-                              href="/type/video+tone/comment"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : Opinion videos"
-                              data-cy="column-collapse-sublink-Opinion videos"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >Opinion videos</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-4hq641">
-                            <a
-                              href="/tone/letters"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : Letters"
-                              data-cy="column-collapse-sublink-Letters"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >Letters</a
-                            >
-                          </li>
-                        </ul>
-                        <div class="dcr-1xxnrhn"></div>
-                      </li>
-                      <li role="none" class="dcr-1y4qg42">
-                        <script>
-                          document.addEventListener(
-                            'DOMContentLoaded',
-                            function () {
-                              var columnInput =
-                                document.getElementById('Sport-button');
-
-                              if (!columnInput) return;
-                              // Sticky nav replaces the nav so element no longer exists for users in test.
-
-                              columnInput.addEventListener(
-                                'keydown',
-                                function (e) {
-                                  // keyCode: 13 => Enter key | keyCode: 32 => Space key
-                                  if (e.keyCode === 13 || e.keyCode === 32) {
-                                    e.preventDefault();
-                                    document
-                                      .getElementById('Sport-checkbox-input')
-                                      .click();
-                                  }
-                                }
-                              );
-                            }
-                          );
-                        </script>
-                        <input
-                          type="checkbox"
-                          id="Sport-checkbox-input"
-                          tabindex="-1"
-                          aria-hidden="true"
-                          class="dcr-1acea34"
-                        />
-                        <label
-                          id="Sport-button"
-                          aria-label="Toggle Sport"
-                          for="Sport-checkbox-input"
-                          aria-haspopup="true"
-                          aria-controls="sportLinks"
-                          tabindex="-1"
-                          role="menuitem"
-                          data-cy="column-collapse-Sport"
-                          data-link-name="nav2 : column-toggle-Sport: show"
-                          class="selectableMenuItem dcr-11zodys"
-                          >Sport</label
-                        >
-                        <ul
-                          role="menu"
-                          id="sportLinks"
-                          data-cy="sportLinks"
-                          class="dcr-1efvfp0"
-                        >
-                          <li role="none" class="dcr-9ra8aa">
-                            <a
-                              href="/sport"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : View all Sport"
-                              data-cy="column-collapse-sublink-Sport"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >View all Sport</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-4hq641">
-                            <a
-                              href="/football"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : Football"
-                              data-cy="column-collapse-sublink-Football"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >Football</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-4hq641">
-                            <a
-                              href="/sport/cricket"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : Cricket"
-                              data-cy="column-collapse-sublink-Cricket"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >Cricket</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-4hq641">
-                            <a
-                              href="/sport/rugby-union"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : Rugby union"
-                              data-cy="column-collapse-sublink-Rugby union"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >Rugby union</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-4hq641">
-                            <a
-                              href="/sport/tennis"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : Tennis"
-                              data-cy="column-collapse-sublink-Tennis"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >Tennis</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-4hq641">
-                            <a
-                              href="/sport/cycling"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : Cycling"
-                              data-cy="column-collapse-sublink-Cycling"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >Cycling</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-4hq641">
-                            <a
-                              href="/sport/formulaone"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : F1"
-                              data-cy="column-collapse-sublink-F1"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >F1</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-4hq641">
-                            <a
-                              href="/sport/golf"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : Golf"
-                              data-cy="column-collapse-sublink-Golf"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >Golf</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-4hq641">
-                            <a
-                              href="/sport/boxing"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : Boxing"
-                              data-cy="column-collapse-sublink-Boxing"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >Boxing</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-4hq641">
-                            <a
-                              href="/sport/rugbyleague"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : Rugby league"
-                              data-cy="column-collapse-sublink-Rugby league"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >Rugby league</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-4hq641">
-                            <a
-                              href="/sport/horse-racing"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : Racing"
-                              data-cy="column-collapse-sublink-Racing"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >Racing</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-4hq641">
-                            <a
-                              href="/sport/us-sport"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : US sports"
-                              data-cy="column-collapse-sublink-US sports"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >US sports</a
-                            >
-                          </li>
-                        </ul>
-                        <div class="dcr-xlajkp"></div>
-                      </li>
-                      <li role="none" class="dcr-1y4qg42">
-                        <script>
-                          document.addEventListener(
-                            'DOMContentLoaded',
-                            function () {
-                              var columnInput =
-                                document.getElementById('Culture-button');
-
-                              if (!columnInput) return;
-                              // Sticky nav replaces the nav so element no longer exists for users in test.
-
-                              columnInput.addEventListener(
-                                'keydown',
-                                function (e) {
-                                  // keyCode: 13 => Enter key | keyCode: 32 => Space key
-                                  if (e.keyCode === 13 || e.keyCode === 32) {
-                                    e.preventDefault();
-                                    document
-                                      .getElementById('Culture-checkbox-input')
-                                      .click();
-                                  }
-                                }
-                              );
-                            }
-                          );
-                        </script>
-                        <input
-                          type="checkbox"
-                          id="Culture-checkbox-input"
-                          tabindex="-1"
-                          aria-hidden="true"
-                          class="dcr-1acea34"
-                        />
-                        <label
-                          id="Culture-button"
-                          aria-label="Toggle Culture"
-                          for="Culture-checkbox-input"
-                          aria-haspopup="true"
-                          aria-controls="cultureLinks"
-                          tabindex="-1"
-                          role="menuitem"
-                          data-cy="column-collapse-Culture"
-                          data-link-name="nav2 : column-toggle-Culture: show"
-                          class="selectableMenuItem dcr-hmp1vw"
-                          >Culture</label
-                        >
-                        <ul
-                          role="menu"
-                          id="cultureLinks"
-                          data-cy="cultureLinks"
-                          class="dcr-1kltmkq"
-                        >
-                          <li role="none" class="dcr-9ra8aa">
-                            <a
-                              href="/culture"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : View all Culture"
-                              data-cy="column-collapse-sublink-Culture"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >View all Culture</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-4hq641">
-                            <a
-                              href="/film"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : Film"
-                              data-cy="column-collapse-sublink-Film"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >Film</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-4hq641">
-                            <a
-                              href="/music"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : Music"
-                              data-cy="column-collapse-sublink-Music"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >Music</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-4hq641">
-                            <a
-                              href="/tv-and-radio"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : TV &amp; radio"
-                              data-cy="column-collapse-sublink-TV &amp; radio"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >TV &amp;radio</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-4hq641">
-                            <a
-                              href="/books"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : Books"
-                              data-cy="column-collapse-sublink-Books"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >Books</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-4hq641">
-                            <a
-                              href="/artanddesign"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : Art &amp; design"
-                              data-cy="column-collapse-sublink-Art &amp; design"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >Art &amp;design</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-4hq641">
-                            <a
-                              href="/stage"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : Stage"
-                              data-cy="column-collapse-sublink-Stage"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >Stage</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-4hq641">
-                            <a
-                              href="/games"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : Games"
-                              data-cy="column-collapse-sublink-Games"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >Games</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-4hq641">
-                            <a
-                              href="/music/classicalmusicandopera"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : Classical"
-                              data-cy="column-collapse-sublink-Classical"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >Classical</a
-                            >
-                          </li>
-                        </ul>
-                        <div class="dcr-8lx8k9"></div>
-                      </li>
-                      <li role="none" class="dcr-1y4qg42">
-                        <script>
-                          document.addEventListener(
-                            'DOMContentLoaded',
-                            function () {
-                              var columnInput =
-                                document.getElementById('Lifestyle-button');
-
-                              if (!columnInput) return;
-                              // Sticky nav replaces the nav so element no longer exists for users in test.
-
-                              columnInput.addEventListener(
-                                'keydown',
-                                function (e) {
-                                  // keyCode: 13 => Enter key | keyCode: 32 => Space key
-                                  if (e.keyCode === 13 || e.keyCode === 32) {
-                                    e.preventDefault();
-                                    document
-                                      .getElementById(
-                                        'Lifestyle-checkbox-input'
-                                      )
-                                      .click();
-                                  }
-                                }
-                              );
-                            }
-                          );
-                        </script>
-                        <input
-                          type="checkbox"
-                          id="Lifestyle-checkbox-input"
-                          tabindex="-1"
-                          aria-hidden="true"
-                          class="dcr-1acea34"
-                        />
-                        <label
-                          id="Lifestyle-button"
-                          aria-label="Toggle Lifestyle"
-                          for="Lifestyle-checkbox-input"
-                          aria-haspopup="true"
-                          aria-controls="lifestyleLinks"
-                          tabindex="-1"
-                          role="menuitem"
-                          data-cy="column-collapse-Lifestyle"
-                          data-link-name="nav2 : column-toggle-Lifestyle: show"
-                          class="selectableMenuItem dcr-19s2ze7"
-                          >Lifestyle</label
-                        >
-                        <ul
-                          role="menu"
-                          id="lifestyleLinks"
-                          data-cy="lifestyleLinks"
-                          class="dcr-1ay3cld"
-                        >
-                          <li role="none" class="dcr-9ra8aa">
-                            <a
-                              href="/lifeandstyle"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : View all Lifestyle"
-                              data-cy="column-collapse-sublink-Lifestyle"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >View all Lifestyle</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-4hq641">
-                            <a
-                              href="/fashion"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : Fashion"
-                              data-cy="column-collapse-sublink-Fashion"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >Fashion</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-4hq641">
-                            <a
-                              href="/food"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : Food"
-                              data-cy="column-collapse-sublink-Food"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >Food</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-4hq641">
-                            <a
-                              href="/tone/recipes"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : Recipes"
-                              data-cy="column-collapse-sublink-Recipes"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >Recipes</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-4hq641">
-                            <a
-                              href="/travel"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : Travel"
-                              data-cy="column-collapse-sublink-Travel"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >Travel</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-4hq641">
-                            <a
-                              href="/lifeandstyle/health-and-wellbeing"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : Health &amp; fitness"
-                              data-cy="column-collapse-sublink-Health &amp; fitness"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >Health &amp;fitness</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-4hq641">
-                            <a
-                              href="/lifeandstyle/women"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : Women"
-                              data-cy="column-collapse-sublink-Women"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >Women</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-4hq641">
-                            <a
-                              href="/lifeandstyle/men"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : Men"
-                              data-cy="column-collapse-sublink-Men"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >Men</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-4hq641">
-                            <a
-                              href="/lifeandstyle/love-and-sex"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : Love &amp; sex"
-                              data-cy="column-collapse-sublink-Love &amp; sex"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >Love &amp;sex</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-4hq641">
-                            <a
-                              href="/fashion/beauty"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : Beauty"
-                              data-cy="column-collapse-sublink-Beauty"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >Beauty</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-4hq641">
-                            <a
-                              href="/lifeandstyle/home-and-garden"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : Home &amp; garden"
-                              data-cy="column-collapse-sublink-Home &amp; garden"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >Home &amp;garden</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-4hq641">
-                            <a
-                              href="/money"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : Money"
-                              data-cy="column-collapse-sublink-Money"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >Money</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-4hq641">
-                            <a
-                              href="/technology/motoring"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : Cars"
-                              data-cy="column-collapse-sublink-Cars"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >Cars</a
-                            >
-                          </li>
-                        </ul>
-                      </li>
-                      <li role="none">
-                        <form
-                          action="https://www.google.co.uk/search"
-                          class="dcr-g8v7m4"
-                        >
-                          <label for="src-component-58424" class="dcr-0">
-                            <div class="dcr-19ilr9m">Search input</div>
-                          </label>
-                          <input
-                            type="text"
-                            id="src-component-58424"
-                            aria-required="true"
-                            aria-invalid="false"
-                            aria-describedby
-                            required
-                            name="q"
-                            placeholder="Search"
-                            data-link-name="nav2 : search"
-                            tabindex="-1"
-                            class="selectableMenuItem dcr-1xcf7cw"
-                          />
-                          <label class="dcr-0">
-                            <div class="dcr-19ilr9m">google-search</div>
-                            <div class="dcr-190ztmi">
-                              <svg
-                                width="30"
-                                viewBox="-3 -3 30 30"
-                                xmlns="http://www.w3.org/2000/svg"
-                                aria-hidden="true"
-                              >
-                                <path
-                                  fill-rule="evenodd"
-                                  clip-rule="evenodd"
-                                  d="M9.273 2c4.023 0 7.25 3.295 7.25 7.273a7.226 7.226 0 0 1-7.25 7.25C5.25 16.523 2 13.296 2 9.273 2 5.295 5.25 2 9.273 2Zm0 1.84A5.403 5.403 0 0 0 3.84 9.274c0 3 2.409 5.454 5.432 5.454 3 0 5.454-2.454 5.454-5.454 0-3.023-2.454-5.432-5.454-5.432Zm7.295 10.887L22 20.16 20.16 22l-5.433-5.432v-.932l.91-.909h.931Z"
-                                ></path>
-                              </svg>
-                              <span class="dcr-1p0hins">Search</span>
-                            </div>
-                          </label>
-                          <button
-                            type="submit"
-                            aria-live="polite"
-                            aria-label="Search with Google"
-                            data-link-name="nav2 : search : submit"
-                            tabindex="-1"
-                            class="dcr-a7qyd9"
-                          >
-                            <div class="src-button-space"></div>
-                            <svg
-                              width="30"
-                              viewBox="-3 -3 30 30"
-                              xmlns="http://www.w3.org/2000/svg"
-                              aria-hidden="true"
-                            >
-                              <path
-                                fill-rule="evenodd"
-                                clip-rule="evenodd"
-                                d="M1 12.956h18.274l-7.167 8.575.932.932L23 12.478v-.956l-9.96-9.985-.932.932 7.166 8.575H1v1.912Z"
-                              ></path>
-                            </svg>
-                          </button>
-                          <input
-                            type="hidden"
-                            name="as_sitesearch"
-                            value="www.theguardian.com"
-                          />
-                        </form>
-                        <div class="dcr-12vycz3"></div>
-                      </li>
-                      <ul role="menu" class="dcr-e1bf28">
-                        <li role="none" class="dcr-9ra8aa">
-                          <a
-                            href="https://support.theguardian.com?INTCMP=side_menu_support&amp;acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22side_menu_support%22%7D"
-                            role="menuitem"
-                            data-link-name="nav2 : secondary : Support us"
-                            data-cy="column-collapse-sublink-Support us"
-                            tabindex="-1"
-                            class="selectableMenuItem dcr-r07hem"
-                            >Support us</a
-                          >
-                        </li>
-                        <li role="none" class="dcr-9ra8aa">
-                          <a
-                            href="https://support.theguardian.com/subscribe?REFPVID=&amp;INTCMP=undefined&amp;acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentId%22%3A%22PrintSubscriptionsHeaderLink%22%2C%22componentType%22%3A%22ACQUISITIONS_HEADER%22%2C%22referrerPageviewId%22%3A%22%22%2C%22referrerUrl%22%3A%22%22%7D"
-                            role="menuitem"
-                            data-link-name="nav2 : secondary : Print subscriptions"
-                            data-cy="column-collapse-sublink-Print subscriptions"
-                            tabindex="-1"
-                            class="selectableMenuItem dcr-r07hem"
-                            >Print subscriptions</a
-                          >
-                        </li>
-                      </ul>
-                      <section class="dcr-e1bf28">
-                        <li role="none" class="dcr-1y4qg42">
-                          <script>
-                            document.addEventListener(
-                              'DOMContentLoaded',
-                              function () {
-                                var columnInput =
-                                  document.getElementById('UK-edition-button');
-
-                                if (!columnInput) return;
-                                // Sticky nav replaces the nav so element no longer exists for users in test.
-
-                                columnInput.addEventListener(
-                                  'keydown',
-                                  function (e) {
-                                    // keyCode: 13 => Enter key | keyCode: 32 => Space key
-                                    if (e.keyCode === 13 || e.keyCode === 32) {
-                                      e.preventDefault();
-                                      document
-                                        .getElementById(
-                                          'UK-edition-checkbox-input'
-                                        )
-                                        .click();
-                                    }
-                                  }
-                                );
-                              }
-                            );
-                          </script>
-                          <input
-                            type="checkbox"
-                            id="UK-edition-checkbox-input"
-                            tabindex="-1"
-                            aria-hidden="true"
-                            class="dcr-1acea34"
-                          />
-                          <label
-                            id="UK-edition-button"
-                            aria-label="Toggle UK edition"
-                            for="UK-edition-checkbox-input"
-                            aria-haspopup="true"
-                            aria-controls="uk-editionLinks"
-                            tabindex="-1"
-                            role="menuitem"
-                            data-cy="column-collapse-UK edition"
-                            data-link-name="nav2 : column-toggle-UK edition: show"
-                            class="selectableMenuItem dcr-1sks1z0"
-                            >UK edition</label
-                          >
-                          <ul
-                            role="menu"
-                            id="uk-editionLinks"
-                            data-cy="uk-editionLinks"
-                            class="dcr-b3zdlu"
-                          >
-                            <li role="none" class="dcr-4hq641">
-                              <a
-                                href="/preference/edition/us"
-                                role="menuitem"
-                                data-link-name="nav2 : secondary : US edition"
-                                data-cy="column-collapse-sublink-US edition"
-                                tabindex="-1"
-                                class="selectableMenuItem dcr-13wwvzl"
-                                >US edition</a
-                              >
-                            </li>
-                            <li role="none" class="dcr-4hq641">
-                              <a
-                                href="/preference/edition/au"
-                                role="menuitem"
-                                data-link-name="nav2 : secondary : Australia edition"
-                                data-cy="column-collapse-sublink-AU edition"
-                                tabindex="-1"
-                                class="selectableMenuItem dcr-13wwvzl"
-                                >Australia edition</a
-                              >
-                            </li>
-                            <li role="none" class="dcr-4hq641">
-                              <a
-                                href="/preference/edition/int"
-                                role="menuitem"
-                                data-link-name="nav2 : secondary : International edition"
-                                data-cy="column-collapse-sublink-International edition"
-                                tabindex="-1"
-                                class="selectableMenuItem dcr-13wwvzl"
-                                >International edition</a
-                              >
-                            </li>
-                          </ul>
-                        </li>
-                        <div class="dcr-12vycz3"></div>
-                      </section>
-                      <li role="none" class="dcr-jv36lp">
-                        <ul role="menu" id="moreLinks" class="dcr-17sb2rc">
-                          <li role="none" class="dcr-9ra8aa">
-                            <a
-                              href="https://jobs.theguardian.com"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : Search jobs"
-                              data-cy="column-collapse-sublink-Search jobs"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >Search jobs</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-9ra8aa">
-                            <a
-                              href="https://recruiters.theguardian.com/?utm_source=gdnwb&amp;utm_medium=navbar&amp;utm_campaign=Guardian_Navbar_Recruiters&amp;CMP_TU=trdmkt&amp;CMP_BUNIT=jobs"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : Hire with Guardian Jobs"
-                              data-cy="column-collapse-sublink-Hire with Guardian Jobs"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >Hire with Guardian Jobs</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-9ra8aa">
-                            <a
-                              href="https://holidays.theguardian.com?INTCMP=holidays_uk_web_newheader"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : Holidays"
-                              data-cy="column-collapse-sublink-Holidays"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >Holidays</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-9ra8aa">
-                            <a
-                              href="https://membership.theguardian.com/events?INTCMP=live_uk_header_dropdown"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : Live events"
-                              data-cy="column-collapse-sublink-Live events"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >Live events</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-9ra8aa">
-                            <a
-                              href="/guardian-masterclasses"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : Masterclasses"
-                              data-cy="column-collapse-sublink-Masterclasses"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >Masterclasses</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-9ra8aa">
-                            <a
-                              href="https://theguardian.newspapers.com"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : Digital Archive"
-                              data-cy="column-collapse-sublink-Digital Archive"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >Digital Archive</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-9ra8aa">
-                            <a
-                              href="/artanddesign/series/gnm-print-sales"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : Guardian Print Shop"
-                              data-cy="column-collapse-sublink-Guardian Print Shop"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >Guardian Print Shop</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-9ra8aa">
-                            <a
-                              href="https://patrons.theguardian.com/?INTCMP=header_patrons"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : Patrons"
-                              data-cy="column-collapse-sublink-Patrons"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >Patrons</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-9ra8aa">
-                            <a
-                              href="https://puzzles.theguardian.com/download"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : Guardian Puzzles app"
-                              data-cy="column-collapse-sublink-Guardian Puzzles app"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >Guardian Puzzles app</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-9ra8aa">
-                            <a
-                              href="https://licensing.theguardian.com/"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : Guardian Licensing"
-                              data-cy="column-collapse-sublink-Guardian Licensing"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >Guardian Licensing</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-4hq641">
-                            <a
-                              href="https://www.theguardian.com/mobile/2014/may/29/the-guardian-for-mobile-and-tablet"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : The Guardian app"
-                              data-cy="column-collapse-sublink-The Guardian app"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >The Guardian app</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-4hq641">
-                            <a
-                              href="/video"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : Video"
-                              data-cy="column-collapse-sublink-Video"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >Video</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-4hq641">
-                            <a
-                              href="/podcasts"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : Podcasts"
-                              data-cy="column-collapse-sublink-Podcasts"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >Podcasts</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-4hq641">
-                            <a
-                              href="/inpictures"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : Pictures"
-                              data-cy="column-collapse-sublink-Pictures"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >Pictures</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-4hq641">
-                            <a
-                              href="/email-newsletters"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : Newsletters"
-                              data-cy="column-collapse-sublink-Newsletters"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >Newsletters</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-4hq641">
-                            <a
-                              href="/theguardian"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : Today's paper"
-                              data-cy="column-collapse-sublink-Today's paper"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >Today's paper</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-4hq641">
-                            <a
-                              href="https://www.theguardian.com/membership"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : Inside the Guardian"
-                              data-cy="column-collapse-sublink-Inside the Guardian"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >Inside the Guardian</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-4hq641">
-                            <a
-                              href="/observer"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : The Observer"
-                              data-cy="column-collapse-sublink-The Observer"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >The Observer</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-4hq641">
-                            <a
-                              href="https://www.theguardian.com/weekly?INTCMP=gdnwb_mawns_editorial_gweekly_GW_TopNav_UK"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : Guardian Weekly"
-                              data-cy="column-collapse-sublink-Guardian Weekly"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >Guardian Weekly</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-4hq641">
-                            <a
-                              href="/crosswords"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : Crosswords"
-                              data-cy="column-collapse-sublink-Crosswords"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >Crosswords</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-4hq641">
-                            <a
-                              href="https://www.wordiply.com"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : Wordiply"
-                              data-cy="column-collapse-sublink-Wordiply"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >Wordiply</a
-                            >
-                          </li>
-                          <li role="none" class="dcr-4hq641">
-                            <a
-                              href="/theguardian/series/corrections-and-clarifications"
-                              role="menuitem"
-                              data-link-name="nav2 : secondary : Corrections"
-                              data-cy="column-collapse-sublink-Corrections"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                              >Corrections</a
-                            >
-                          </li>
-                        </ul>
-                      </li>
-                      <li role="none" class="dcr-vwltw3">
-                        <ul role="menu" class="dcr-17sb2rc">
-                          <li role="none" class="dcr-9ra8aa">
-                            <a
-                              data-link-name="nav2 : secondary : facebook"
-                              href="https://www.facebook.com/theguardian"
-                              role="menuitem"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                            >
-                              <svg
-                                width="32"
-                                height="32"
-                                viewBox="-2 -2 32 32"
-                                class="dcr-6sdrzu"
-                              >
-                                <path
-                                  d="M17.9 14h-3v8H12v-8h-2v-2.9h2V8.7C12 6.8 13.1 5 16 5c1.2 0 2 .1 2 .1v3h-1.8c-1 0-1.2.5-1.2 1.3v1.8h3l-.1 2.8z"
-                                ></path>
-                              </svg>
-                              Facebook
-                            </a>
-                          </li>
-                          <li role="none" class="dcr-9ra8aa">
-                            <a
-                              data-link-name="nav2 : secondary : twitter"
-                              href="https://twitter.com/guardian"
-                              role="menuitem"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-13wwvzl"
-                            >
-                              <svg
-                                width="32"
-                                height="32"
-                                viewBox="-2 -2 32 32"
-                                class="dcr-6sdrzu"
-                              >
-                                <path
-                                  d="M21.3 10.5v.5c0 4.7-3.5 10.1-9.9 10.1-2 0-3.8-.6-5.3-1.6.3 0 .6.1.8.1 1.6 0 3.1-.6 4.3-1.5-1.5 0-2.8-1-3.3-2.4.2 0 .4.1.7.1l.9-.1c-1.6-.3-2.8-1.8-2.8-3.5.5.3 1 .4 1.6.4-.9-.6-1.6-1.7-1.6-2.9 0-.6.2-1.3.5-1.8 1.7 2.1 4.3 3.6 7.2 3.7-.1-.3-.1-.5-.1-.8 0-2 1.6-3.5 3.5-3.5 1 0 1.9.4 2.5 1.1.8-.1 1.5-.4 2.2-.8-.3.8-.8 1.5-1.5 1.9.7-.1 1.4-.3 2-.5-.4.4-1 1-1.7 1.5z"
-                                ></path>
-                              </svg>
-                              Twitter
-                            </a>
-                          </li>
-                        </ul>
-                      </li>
-                      <li role="none" class="dcr-pt8pb9">
-                        <ul role="menu" class="dcr-4phbzi">
-                          <li class="dcr-nnfu1a">
-                            <a
-                              href="https://jobs.theguardian.com"
-                              role="menuitem"
-                              data-link-name="nav2 : brand extension : Search jobs"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-wzkd0n"
-                              >Search jobs</a
-                            >
-                          </li>
-                          <li class="dcr-nnfu1a">
-                            <a
-                              href="https://recruiters.theguardian.com/?utm_source=gdnwb&amp;utm_medium=navbar&amp;utm_campaign=Guardian_Navbar_Recruiters&amp;CMP_TU=trdmkt&amp;CMP_BUNIT=jobs"
-                              role="menuitem"
-                              data-link-name="nav2 : brand extension : Hire with Guardian Jobs"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-wzkd0n"
-                              >Hire with Guardian Jobs</a
-                            >
-                          </li>
-                          <li class="dcr-nnfu1a">
-                            <a
-                              href="https://holidays.theguardian.com?INTCMP=holidays_uk_web_newheader"
-                              role="menuitem"
-                              data-link-name="nav2 : brand extension : Holidays"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-wzkd0n"
-                              >Holidays</a
-                            >
-                          </li>
-                          <li class="dcr-nnfu1a">
-                            <a
-                              href="https://membership.theguardian.com/events?INTCMP=live_uk_header_dropdown"
-                              role="menuitem"
-                              data-link-name="nav2 : brand extension : Live events"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-wzkd0n"
-                              >Live events</a
-                            >
-                          </li>
-                          <li class="dcr-nnfu1a">
-                            <a
-                              href="/guardian-masterclasses"
-                              role="menuitem"
-                              data-link-name="nav2 : brand extension : Masterclasses"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-wzkd0n"
-                              >Masterclasses</a
-                            >
-                          </li>
-                          <li class="dcr-nnfu1a">
-                            <a
-                              href="https://theguardian.newspapers.com"
-                              role="menuitem"
-                              data-link-name="nav2 : brand extension : Digital Archive"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-wzkd0n"
-                              >Digital Archive</a
-                            >
-                          </li>
-                          <li class="dcr-nnfu1a">
-                            <a
-                              href="/artanddesign/series/gnm-print-sales"
-                              role="menuitem"
-                              data-link-name="nav2 : brand extension : Guardian Print Shop"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-wzkd0n"
-                              >Guardian Print Shop</a
-                            >
-                          </li>
-                          <li class="dcr-nnfu1a">
-                            <a
-                              href="https://patrons.theguardian.com/?INTCMP=header_patrons"
-                              role="menuitem"
-                              data-link-name="nav2 : brand extension : Patrons"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-wzkd0n"
-                              >Patrons</a
-                            >
-                          </li>
-                          <li class="dcr-nnfu1a">
-                            <a
-                              href="https://puzzles.theguardian.com/download"
-                              role="menuitem"
-                              data-link-name="nav2 : brand extension : Guardian Puzzles app"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-wzkd0n"
-                              >Guardian Puzzles app</a
-                            >
-                          </li>
-                          <li class="dcr-nnfu1a">
-                            <a
-                              href="https://licensing.theguardian.com/"
-                              role="menuitem"
-                              data-link-name="nav2 : brand extension : Guardian Licensing"
-                              tabindex="-1"
-                              class="selectableMenuItem dcr-wzkd0n"
-                              >Guardian Licensing</a
-                            >
-                          </li>
-                        </ul>
-                      </li>
-                    </ul>
+          <div class="dcr-1u9kji9"><span class="dcr-1bn3p0w">
+              <div class="top-banner-ad-container dcr-zzftu">
+                <div class="ad-slot-container dcr-fks95w">
+                  <div id="dfp-ad--top-above-nav" data-link-name="ad slot top-above-nav" data-name="top-above-nav"
+                    aria-hidden="true"
+                    class="js-ad-slot ad-slot ad-slot--top-above-nav ad-slot--mpu-banner-ad ad-slot--rendered dcr-12433rp">
                   </div>
                 </div>
               </div>
@@ -13313,290 +18635,1695 @@ https://workforus.theguardian.com/careers/product-engineering/
         >
           <div class="dcr-1w2x6ij">
             <ul data-testid="pillar-list" class="dcr-1ikbe4v">
-              <li class="dcr-1aeyz4o">
-                <a
-                  href="/"
-                  data-link-name="footer : primary : News"
-                  class="dcr-11rhxc6"
-                  >News</a
-                >
-              </li>
-              <li class="dcr-1aeyz4o">
-                <a
-                  href="/commentisfree"
-                  data-link-name="footer : primary : Opinion"
-                  class="dcr-yqz51q"
-                  >Opinion</a
-                >
-              </li>
-              <li class="dcr-1aeyz4o">
-                <a
-                  href="/sport"
-                  data-link-name="footer : primary : Sport"
-                  class="dcr-1dijbt5"
-                  >Sport</a
-                >
-              </li>
-              <li class="dcr-1aeyz4o">
-                <a
-                  href="/culture"
-                  data-link-name="footer : primary : Culture"
-                  class="dcr-qjynpy"
-                  >Culture</a
-                >
-              </li>
-              <li class="dcr-1aeyz4o">
-                <a
-                  href="/lifeandstyle"
-                  data-link-name="footer : primary : Lifestyle"
-                  class="dcr-1vrrbyb"
-                  >Lifestyle</a
-                >
-              </li>
+              <li class="dcr-1aeyz4o"><a id="navigation" href="/" data-link-name="nav2 : primary : News"
+                  class="dcr-h2gqsd">News</a></li>
+              <li class="dcr-1aeyz4o"><a href="/commentisfree" data-link-name="nav2 : primary : Opinion"
+                  class="dcr-c8vw16">Opinion</a></li>
+              <li class="dcr-1aeyz4o"><a href="/sport" data-link-name="nav2 : primary : Sport"
+                  class="dcr-a6bcsq">Sport</a></li>
+              <li class="dcr-1aeyz4o"><a href="/culture" data-link-name="nav2 : primary : Culture"
+                  class="dcr-1tabvac">Culture</a></li>
+              <li class="dcr-1aeyz4o"><a href="/lifeandstyle" data-link-name="nav2 : primary : Lifestyle"
+                  class="dcr-1t1n4fm">Lifestyle</a></li>
             </ul>
-          </div>
-          <div class="dcr-1xyi04h">
-            <div class="dcr-1wf840d">
-              <div>
-                Original reporting and incisive analysis, direct from the
-                Guardian every morning
+            <div id="expanded-menu-root"><label id="show-more-button" aria-label="Toggle main menu"
+                for="top-nav-input-checkbox" data-link-name="nav2 : veggie-burger: show" tabIndex="0" role="button"
+                data-cy="nav-show-more-button" class="dcr-1kuh7tf"><span class="dcr-1nvgr5i">Show</span><span
+                  class="dcr-a2u3ka">More<svg viewBox="-3 -3 30 30" xmlns="http://www.w3.org/2000/svg"
+                    aria-hidden="true">
+                    <path fill-rule="evenodd" clip-rule="evenodd"
+                      d="m1 7.224 10.498 10.498h1.004L23 7.224l-.98-.954L12 14.708 1.98 6.27 1 7.224Z"></path>
+                  </svg></span></label><label id="veggie-burger" aria-label="Toggle main menu"
+                for="top-nav-input-checkbox" data-link-name="nav2 : veggie-burger: show" tabIndex="0" role="button"
+                data-cy="veggie-burger" class="dcr-13vr4eh"><span class="dcr-1nvgr5i">Show More</span><span
+                  class="dcr-120u0k1"></span></label>
+              <div id="expanded-menu" class="dcr-mebke">
+                <div data-testid="expanded-menu" data-cy="expanded-menu" class="dcr-18m7gh9">
+                  <ul role="menubar" data-cy="nav-menu-columns" class="dcr-1kn7o79">
+                    <li role="none" class="dcr-1y4qg42">
+                      <script>document.addEventListener('DOMContentLoaded', function () {
+                          var columnInput = document.getElementById('News-button');
+
+                          if (!columnInput) return; // Sticky nav replaces the nav so element no longer exists for users in test.
+
+                          columnInput.addEventListener('keydown', function (e) {
+                            // keyCode: 13 => Enter key | keyCode: 32 => Space key
+                            if (e.keyCode === 13 || e.keyCode === 32) {
+                              e.preventDefault()
+                              document.getElementById('News-checkbox-input').click();
+                            }
+                          })
+                        })</script><input type="checkbox" id="News-checkbox-input" tabIndex="-1" aria-hidden="true"
+                        class="dcr-1acea34" /><label id="News-button" aria-label="Toggle News" for="News-checkbox-input"
+                        aria-haspopup="true" aria-controls="newsLinks" tabIndex="-1" role="menuitem"
+                        data-cy="column-collapse-News" data-link-name="nav2 : column-toggle-News: show"
+                        class="selectableMenuItem dcr-1fqnu7z">News</label>
+                      <ul role="menu" id="newsLinks" data-cy="newsLinks" class="dcr-nqw243">
+                        <li role="none" class="dcr-9ra8aa"><a href="/" role="menuitem"
+                            data-link-name="nav2 : secondary : View all News" data-cy="column-collapse-sublink-News"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">View all News</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/uk-news" role="menuitem"
+                            data-link-name="nav2 : secondary : UK news" data-cy="column-collapse-sublink-UK"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">UK news</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/world" role="menuitem"
+                            data-link-name="nav2 : secondary : World news" data-cy="column-collapse-sublink-World"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">World news</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/environment/climate-crisis" role="menuitem"
+                            data-link-name="nav2 : secondary : Climate crisis"
+                            data-cy="column-collapse-sublink-Climate crisis" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">Climate crisis</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/email-newsletters" role="menuitem"
+                            data-link-name="nav2 : secondary : Newsletters"
+                            data-cy="column-collapse-sublink-Newsletters" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">Newsletters</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/football" role="menuitem"
+                            data-link-name="nav2 : secondary : Football" data-cy="column-collapse-sublink-Football"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Football</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/world/coronavirus-outbreak" role="menuitem"
+                            data-link-name="nav2 : secondary : Coronavirus"
+                            data-cy="column-collapse-sublink-Coronavirus" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">Coronavirus</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/business" role="menuitem"
+                            data-link-name="nav2 : secondary : Business" data-cy="column-collapse-sublink-Business"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Business</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/environment" role="menuitem"
+                            data-link-name="nav2 : secondary : Environment"
+                            data-cy="column-collapse-sublink-Environment" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">Environment</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/politics" role="menuitem"
+                            data-link-name="nav2 : secondary : UK politics"
+                            data-cy="column-collapse-sublink-UK politics" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">UK politics</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/education" role="menuitem"
+                            data-link-name="nav2 : secondary : Education" data-cy="column-collapse-sublink-Education"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Education</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/society" role="menuitem"
+                            data-link-name="nav2 : secondary : Society" data-cy="column-collapse-sublink-Society"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Society</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/science" role="menuitem"
+                            data-link-name="nav2 : secondary : Science" data-cy="column-collapse-sublink-Science"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Science</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/technology" role="menuitem"
+                            data-link-name="nav2 : secondary : Tech" data-cy="column-collapse-sublink-Tech"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Tech</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/global-development" role="menuitem"
+                            data-link-name="nav2 : secondary : Global development"
+                            data-cy="column-collapse-sublink-Global development" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">Global development</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/obituaries" role="menuitem"
+                            data-link-name="nav2 : secondary : Obituaries" data-cy="column-collapse-sublink-Obituaries"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Obituaries</a></li>
+                      </ul>
+                      <div class="dcr-16d24hr"></div>
+                    </li>
+                    <li role="none" class="dcr-1y4qg42">
+                      <script>document.addEventListener('DOMContentLoaded', function () {
+                          var columnInput = document.getElementById('Opinion-button');
+
+                          if (!columnInput) return; // Sticky nav replaces the nav so element no longer exists for users in test.
+
+                          columnInput.addEventListener('keydown', function (e) {
+                            // keyCode: 13 => Enter key | keyCode: 32 => Space key
+                            if (e.keyCode === 13 || e.keyCode === 32) {
+                              e.preventDefault()
+                              document.getElementById('Opinion-checkbox-input').click();
+                            }
+                          })
+                        })</script><input type="checkbox" id="Opinion-checkbox-input" tabIndex="-1" aria-hidden="true"
+                        class="dcr-1acea34" /><label id="Opinion-button" aria-label="Toggle Opinion"
+                        for="Opinion-checkbox-input" aria-haspopup="true" aria-controls="opinionLinks" tabIndex="-1"
+                        role="menuitem" data-cy="column-collapse-Opinion"
+                        data-link-name="nav2 : column-toggle-Opinion: show"
+                        class="selectableMenuItem dcr-15vcq54">Opinion</label>
+                      <ul role="menu" id="opinionLinks" data-cy="opinionLinks" class="dcr-bu7bnv">
+                        <li role="none" class="dcr-9ra8aa"><a href="/commentisfree" role="menuitem"
+                            data-link-name="nav2 : secondary : View all Opinion"
+                            data-cy="column-collapse-sublink-Opinion" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">View all Opinion</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/profile/editorial" role="menuitem"
+                            data-link-name="nav2 : secondary : The Guardian view"
+                            data-cy="column-collapse-sublink-The Guardian view" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">The Guardian view</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/index/contributors" role="menuitem"
+                            data-link-name="nav2 : secondary : Columnists" data-cy="column-collapse-sublink-Columnists"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Columnists</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/cartoons/archive" role="menuitem"
+                            data-link-name="nav2 : secondary : Cartoons" data-cy="column-collapse-sublink-Cartoons"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Cartoons</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/type/video+tone/comment" role="menuitem"
+                            data-link-name="nav2 : secondary : Opinion videos"
+                            data-cy="column-collapse-sublink-Opinion videos" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">Opinion videos</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/tone/letters" role="menuitem"
+                            data-link-name="nav2 : secondary : Letters" data-cy="column-collapse-sublink-Letters"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Letters</a></li>
+                      </ul>
+                      <div class="dcr-1xxnrhn"></div>
+                    </li>
+                    <li role="none" class="dcr-1y4qg42">
+                      <script>document.addEventListener('DOMContentLoaded', function () {
+                          var columnInput = document.getElementById('Sport-button');
+
+                          if (!columnInput) return; // Sticky nav replaces the nav so element no longer exists for users in test.
+
+                          columnInput.addEventListener('keydown', function (e) {
+                            // keyCode: 13 => Enter key | keyCode: 32 => Space key
+                            if (e.keyCode === 13 || e.keyCode === 32) {
+                              e.preventDefault()
+                              document.getElementById('Sport-checkbox-input').click();
+                            }
+                          })
+                        })</script><input type="checkbox" id="Sport-checkbox-input" tabIndex="-1" aria-hidden="true"
+                        class="dcr-1acea34" /><label id="Sport-button" aria-label="Toggle Sport"
+                        for="Sport-checkbox-input" aria-haspopup="true" aria-controls="sportLinks" tabIndex="-1"
+                        role="menuitem" data-cy="column-collapse-Sport"
+                        data-link-name="nav2 : column-toggle-Sport: show"
+                        class="selectableMenuItem dcr-11zodys">Sport</label>
+                      <ul role="menu" id="sportLinks" data-cy="sportLinks" class="dcr-1efvfp0">
+                        <li role="none" class="dcr-9ra8aa"><a href="/sport" role="menuitem"
+                            data-link-name="nav2 : secondary : View all Sport" data-cy="column-collapse-sublink-Sport"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">View all Sport</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/football" role="menuitem"
+                            data-link-name="nav2 : secondary : Football" data-cy="column-collapse-sublink-Football"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Football</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/sport/cricket" role="menuitem"
+                            data-link-name="nav2 : secondary : Cricket" data-cy="column-collapse-sublink-Cricket"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Cricket</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/sport/rugby-union" role="menuitem"
+                            data-link-name="nav2 : secondary : Rugby union"
+                            data-cy="column-collapse-sublink-Rugby union" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">Rugby union</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/sport/tennis" role="menuitem"
+                            data-link-name="nav2 : secondary : Tennis" data-cy="column-collapse-sublink-Tennis"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Tennis</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/sport/cycling" role="menuitem"
+                            data-link-name="nav2 : secondary : Cycling" data-cy="column-collapse-sublink-Cycling"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Cycling</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/sport/formulaone" role="menuitem"
+                            data-link-name="nav2 : secondary : F1" data-cy="column-collapse-sublink-F1" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">F1</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/sport/golf" role="menuitem"
+                            data-link-name="nav2 : secondary : Golf" data-cy="column-collapse-sublink-Golf"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Golf</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/sport/boxing" role="menuitem"
+                            data-link-name="nav2 : secondary : Boxing" data-cy="column-collapse-sublink-Boxing"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Boxing</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/sport/rugbyleague" role="menuitem"
+                            data-link-name="nav2 : secondary : Rugby league"
+                            data-cy="column-collapse-sublink-Rugby league" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">Rugby league</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/sport/horse-racing" role="menuitem"
+                            data-link-name="nav2 : secondary : Racing" data-cy="column-collapse-sublink-Racing"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Racing</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/sport/us-sport" role="menuitem"
+                            data-link-name="nav2 : secondary : US sports" data-cy="column-collapse-sublink-US sports"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">US sports</a></li>
+                      </ul>
+                      <div class="dcr-xlajkp"></div>
+                    </li>
+                    <li role="none" class="dcr-1y4qg42">
+                      <script>document.addEventListener('DOMContentLoaded', function () {
+                          var columnInput = document.getElementById('Culture-button');
+
+                          if (!columnInput) return; // Sticky nav replaces the nav so element no longer exists for users in test.
+
+                          columnInput.addEventListener('keydown', function (e) {
+                            // keyCode: 13 => Enter key | keyCode: 32 => Space key
+                            if (e.keyCode === 13 || e.keyCode === 32) {
+                              e.preventDefault()
+                              document.getElementById('Culture-checkbox-input').click();
+                            }
+                          })
+                        })</script><input type="checkbox" id="Culture-checkbox-input" tabIndex="-1" aria-hidden="true"
+                        class="dcr-1acea34" /><label id="Culture-button" aria-label="Toggle Culture"
+                        for="Culture-checkbox-input" aria-haspopup="true" aria-controls="cultureLinks" tabIndex="-1"
+                        role="menuitem" data-cy="column-collapse-Culture"
+                        data-link-name="nav2 : column-toggle-Culture: show"
+                        class="selectableMenuItem dcr-hmp1vw">Culture</label>
+                      <ul role="menu" id="cultureLinks" data-cy="cultureLinks" class="dcr-1kltmkq">
+                        <li role="none" class="dcr-9ra8aa"><a href="/culture" role="menuitem"
+                            data-link-name="nav2 : secondary : View all Culture"
+                            data-cy="column-collapse-sublink-Culture" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">View all Culture</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/film" role="menuitem"
+                            data-link-name="nav2 : secondary : Film" data-cy="column-collapse-sublink-Film"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Film</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/music" role="menuitem"
+                            data-link-name="nav2 : secondary : Music" data-cy="column-collapse-sublink-Music"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Music</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/tv-and-radio" role="menuitem"
+                            data-link-name="nav2 : secondary : TV &amp; radio"
+                            data-cy="column-collapse-sublink-TV &amp; radio" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">TV &amp; radio</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/books" role="menuitem"
+                            data-link-name="nav2 : secondary : Books" data-cy="column-collapse-sublink-Books"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Books</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/artanddesign" role="menuitem"
+                            data-link-name="nav2 : secondary : Art &amp; design"
+                            data-cy="column-collapse-sublink-Art &amp; design" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">Art &amp; design</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/stage" role="menuitem"
+                            data-link-name="nav2 : secondary : Stage" data-cy="column-collapse-sublink-Stage"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Stage</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/games" role="menuitem"
+                            data-link-name="nav2 : secondary : Games" data-cy="column-collapse-sublink-Games"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Games</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/music/classicalmusicandopera" role="menuitem"
+                            data-link-name="nav2 : secondary : Classical" data-cy="column-collapse-sublink-Classical"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Classical</a></li>
+                      </ul>
+                      <div class="dcr-8lx8k9"></div>
+                    </li>
+                    <li role="none" class="dcr-1y4qg42">
+                      <script>document.addEventListener('DOMContentLoaded', function () {
+                          var columnInput = document.getElementById('Lifestyle-button');
+
+                          if (!columnInput) return; // Sticky nav replaces the nav so element no longer exists for users in test.
+
+                          columnInput.addEventListener('keydown', function (e) {
+                            // keyCode: 13 => Enter key | keyCode: 32 => Space key
+                            if (e.keyCode === 13 || e.keyCode === 32) {
+                              e.preventDefault()
+                              document.getElementById('Lifestyle-checkbox-input').click();
+                            }
+                          })
+                        })</script><input type="checkbox" id="Lifestyle-checkbox-input" tabIndex="-1" aria-hidden="true"
+                        class="dcr-1acea34" /><label id="Lifestyle-button" aria-label="Toggle Lifestyle"
+                        for="Lifestyle-checkbox-input" aria-haspopup="true" aria-controls="lifestyleLinks" tabIndex="-1"
+                        role="menuitem" data-cy="column-collapse-Lifestyle"
+                        data-link-name="nav2 : column-toggle-Lifestyle: show"
+                        class="selectableMenuItem dcr-19s2ze7">Lifestyle</label>
+                      <ul role="menu" id="lifestyleLinks" data-cy="lifestyleLinks" class="dcr-1ay3cld">
+                        <li role="none" class="dcr-9ra8aa"><a href="/lifeandstyle" role="menuitem"
+                            data-link-name="nav2 : secondary : View all Lifestyle"
+                            data-cy="column-collapse-sublink-Lifestyle" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">View all Lifestyle</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/fashion" role="menuitem"
+                            data-link-name="nav2 : secondary : Fashion" data-cy="column-collapse-sublink-Fashion"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Fashion</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/food" role="menuitem"
+                            data-link-name="nav2 : secondary : Food" data-cy="column-collapse-sublink-Food"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Food</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/tone/recipes" role="menuitem"
+                            data-link-name="nav2 : secondary : Recipes" data-cy="column-collapse-sublink-Recipes"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Recipes</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/travel" role="menuitem"
+                            data-link-name="nav2 : secondary : Travel" data-cy="column-collapse-sublink-Travel"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Travel</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/lifeandstyle/health-and-wellbeing" role="menuitem"
+                            data-link-name="nav2 : secondary : Health &amp; fitness"
+                            data-cy="column-collapse-sublink-Health &amp; fitness" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">Health &amp; fitness</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/lifeandstyle/women" role="menuitem"
+                            data-link-name="nav2 : secondary : Women" data-cy="column-collapse-sublink-Women"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Women</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/lifeandstyle/men" role="menuitem"
+                            data-link-name="nav2 : secondary : Men" data-cy="column-collapse-sublink-Men" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">Men</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/lifeandstyle/love-and-sex" role="menuitem"
+                            data-link-name="nav2 : secondary : Love &amp; sex"
+                            data-cy="column-collapse-sublink-Love &amp; sex" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">Love &amp; sex</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/fashion/beauty" role="menuitem"
+                            data-link-name="nav2 : secondary : Beauty" data-cy="column-collapse-sublink-Beauty"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Beauty</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/lifeandstyle/home-and-garden" role="menuitem"
+                            data-link-name="nav2 : secondary : Home &amp; garden"
+                            data-cy="column-collapse-sublink-Home &amp; garden" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">Home &amp; garden</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/money" role="menuitem"
+                            data-link-name="nav2 : secondary : Money" data-cy="column-collapse-sublink-Money"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Money</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/technology/motoring" role="menuitem"
+                            data-link-name="nav2 : secondary : Cars" data-cy="column-collapse-sublink-Cars"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Cars</a></li>
+                      </ul>
+                    </li>
+                    <li role="none">
+                      <form action="https://www.google.co.uk/search" class="dcr-g8v7m4"><label
+                          for="src-component-119422" class="dcr-0">
+                          <div class="dcr-19ilr9m">Search input </div>
+                        </label><input type="text" id="src-component-119422" aria-required="true" aria-invalid="false"
+                          aria-describedby required name="q" placeholder="Search" data-link-name="nav2 : search"
+                          tabIndex="-1" class="selectableMenuItem dcr-1xcf7cw" /><label class="dcr-0">
+                          <div class="dcr-19ilr9m">google-search </div>
+                          <div class="dcr-190ztmi"><svg width="30" viewBox="-3 -3 30 30"
+                              xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                              <path fill-rule="evenodd" clip-rule="evenodd"
+                                d="M9.273 2c4.023 0 7.25 3.295 7.25 7.273a7.226 7.226 0 0 1-7.25 7.25C5.25 16.523 2 13.296 2 9.273 2 5.295 5.25 2 9.273 2Zm0 1.84A5.403 5.403 0 0 0 3.84 9.274c0 3 2.409 5.454 5.432 5.454 3 0 5.454-2.454 5.454-5.454 0-3.023-2.454-5.432-5.454-5.432Zm7.295 10.887L22 20.16 20.16 22l-5.433-5.432v-.932l.91-.909h.931Z">
+                              </path>
+                            </svg><span class="dcr-1p0hins">Search</span></div>
+                        </label><button type="submit" aria-live="polite" aria-label="Search with Google"
+                          data-link-name="nav2 : search : submit" tabIndex="-1" class="dcr-a7qyd9">
+                          <div class="src-button-space"></div><svg width="30" viewBox="-3 -3 30 30"
+                            xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                            <path fill-rule="evenodd" clip-rule="evenodd"
+                              d="M1 12.956h18.274l-7.167 8.575.932.932L23 12.478v-.956l-9.96-9.985-.932.932 7.166 8.575H1v1.912Z">
+                            </path>
+                          </svg>
+                        </button><input type="hidden" name="as_sitesearch" value="www.theguardian.com" /></form>
+                      <div class="dcr-12vycz3"></div>
+                    </li>
+                    <ul role="menu" class="dcr-e1bf28">
+                      <li role="none" class="dcr-9ra8aa"><a
+                          href="https://support.theguardian.com?INTCMP=side_menu_support&amp;acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22side_menu_support%22%7D"
+                          role="menuitem" data-link-name="nav2 : secondary : Support us"
+                          data-cy="column-collapse-sublink-Support us" tabIndex="-1"
+                          class="selectableMenuItem dcr-r07hem">Support us</a></li>
+                      <li role="none" class="dcr-9ra8aa"><a
+                          href="https://support.theguardian.com/subscribe?REFPVID=&amp;INTCMP=undefined&amp;acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentId%22%3A%22PrintSubscriptionsHeaderLink%22%2C%22componentType%22%3A%22ACQUISITIONS_HEADER%22%2C%22referrerPageviewId%22%3A%22%22%2C%22referrerUrl%22%3A%22%22%7D"
+                          role="menuitem" data-link-name="nav2 : secondary : Print subscriptions"
+                          data-cy="column-collapse-sublink-Print subscriptions" tabIndex="-1"
+                          class="selectableMenuItem dcr-r07hem">Print subscriptions</a></li>
+                    </ul>
+                    <section class="dcr-e1bf28">
+                      <li role="none" class="dcr-1y4qg42">
+                        <script>document.addEventListener('DOMContentLoaded', function () {
+                            var columnInput = document.getElementById('UK-edition-button');
+
+                            if (!columnInput) return; // Sticky nav replaces the nav so element no longer exists for users in test.
+
+                            columnInput.addEventListener('keydown', function (e) {
+                              // keyCode: 13 => Enter key | keyCode: 32 => Space key
+                              if (e.keyCode === 13 || e.keyCode === 32) {
+                                e.preventDefault()
+                                document.getElementById('UK-edition-checkbox-input').click();
+                              }
+                            })
+                          })</script><input type="checkbox" id="UK-edition-checkbox-input" tabIndex="-1" aria-hidden="true"
+                          class="dcr-1acea34" /><label id="UK-edition-button" aria-label="Toggle UK edition"
+                          for="UK-edition-checkbox-input" aria-haspopup="true" aria-controls="uk-editionLinks"
+                          tabIndex="-1" role="menuitem" data-cy="column-collapse-UK edition"
+                          data-link-name="nav2 : column-toggle-UK edition: show"
+                          class="selectableMenuItem dcr-1sks1z0">UK edition</label>
+                        <ul role="menu" id="uk-editionLinks" data-cy="uk-editionLinks" class="dcr-b3zdlu">
+                          <li role="none" class="dcr-4hq641"><a href="/preference/edition/us" role="menuitem"
+                              data-link-name="nav2 : secondary : US edition"
+                              data-cy="column-collapse-sublink-US edition" tabIndex="-1"
+                              class="selectableMenuItem dcr-13wwvzl">US edition</a></li>
+                          <li role="none" class="dcr-4hq641"><a href="/preference/edition/au" role="menuitem"
+                              data-link-name="nav2 : secondary : Australia edition"
+                              data-cy="column-collapse-sublink-AU edition" tabIndex="-1"
+                              class="selectableMenuItem dcr-13wwvzl">Australia edition</a></li>
+                          <li role="none" class="dcr-4hq641"><a href="/preference/edition/int" role="menuitem"
+                              data-link-name="nav2 : secondary : International edition"
+                              data-cy="column-collapse-sublink-International edition" tabIndex="-1"
+                              class="selectableMenuItem dcr-13wwvzl">International edition</a></li>
+                        </ul>
+                      </li>
+                      <div class="dcr-12vycz3"></div>
+                    </section>
+                    <li role="none" class="dcr-jv36lp">
+                      <ul role="menu" id="moreLinks" class="dcr-17sb2rc">
+                        <li role="none" class="dcr-9ra8aa"><a href="https://jobs.theguardian.com" role="menuitem"
+                            data-link-name="nav2 : secondary : Search jobs"
+                            data-cy="column-collapse-sublink-Search jobs" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">Search jobs</a></li>
+                        <li role="none" class="dcr-9ra8aa"><a
+                            href="https://recruiters.theguardian.com/?utm_source=gdnwb&amp;utm_medium=navbar&amp;utm_campaign=Guardian_Navbar_Recruiters&amp;CMP_TU=trdmkt&amp;CMP_BUNIT=jobs"
+                            role="menuitem" data-link-name="nav2 : secondary : Hire with Guardian Jobs"
+                            data-cy="column-collapse-sublink-Hire with Guardian Jobs" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">Hire with Guardian Jobs</a></li>
+                        <li role="none" class="dcr-9ra8aa"><a
+                            href="https://holidays.theguardian.com?INTCMP=holidays_uk_web_newheader" role="menuitem"
+                            data-link-name="nav2 : secondary : Holidays" data-cy="column-collapse-sublink-Holidays"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Holidays</a></li>
+                        <li role="none" class="dcr-9ra8aa"><a
+                            href="https://membership.theguardian.com/events?INTCMP=live_uk_header_dropdown"
+                            role="menuitem" data-link-name="nav2 : secondary : Live events"
+                            data-cy="column-collapse-sublink-Live events" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">Live events</a></li>
+                        <li role="none" class="dcr-9ra8aa"><a href="/guardian-masterclasses" role="menuitem"
+                            data-link-name="nav2 : secondary : Masterclasses"
+                            data-cy="column-collapse-sublink-Masterclasses" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">Masterclasses</a></li>
+                        <li role="none" class="dcr-9ra8aa"><a href="https://theguardian.newspapers.com" role="menuitem"
+                            data-link-name="nav2 : secondary : Digital Archive"
+                            data-cy="column-collapse-sublink-Digital Archive" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">Digital Archive</a></li>
+                        <li role="none" class="dcr-9ra8aa"><a href="/artanddesign/series/gnm-print-sales"
+                            role="menuitem" data-link-name="nav2 : secondary : Guardian Print Shop"
+                            data-cy="column-collapse-sublink-Guardian Print Shop" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">Guardian Print Shop</a></li>
+                        <li role="none" class="dcr-9ra8aa"><a
+                            href="https://patrons.theguardian.com/?INTCMP=header_patrons" role="menuitem"
+                            data-link-name="nav2 : secondary : Patrons" data-cy="column-collapse-sublink-Patrons"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Patrons</a></li>
+                        <li role="none" class="dcr-9ra8aa"><a href="https://puzzles.theguardian.com/download"
+                            role="menuitem" data-link-name="nav2 : secondary : Guardian Puzzles app"
+                            data-cy="column-collapse-sublink-Guardian Puzzles app" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">Guardian Puzzles app</a></li>
+                        <li role="none" class="dcr-9ra8aa"><a href="https://licensing.theguardian.com/" role="menuitem"
+                            data-link-name="nav2 : secondary : Guardian Licensing"
+                            data-cy="column-collapse-sublink-Guardian Licensing" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">Guardian Licensing</a></li>
+                        <li role="none" class="dcr-4hq641"><a
+                            href="https://www.theguardian.com/mobile/2014/may/29/the-guardian-for-mobile-and-tablet"
+                            role="menuitem" data-link-name="nav2 : secondary : The Guardian app"
+                            data-cy="column-collapse-sublink-The Guardian app" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">The Guardian app</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/video" role="menuitem"
+                            data-link-name="nav2 : secondary : Video" data-cy="column-collapse-sublink-Video"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Video</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/podcasts" role="menuitem"
+                            data-link-name="nav2 : secondary : Podcasts" data-cy="column-collapse-sublink-Podcasts"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Podcasts</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/inpictures" role="menuitem"
+                            data-link-name="nav2 : secondary : Pictures" data-cy="column-collapse-sublink-Pictures"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Pictures</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/email-newsletters" role="menuitem"
+                            data-link-name="nav2 : secondary : Newsletters"
+                            data-cy="column-collapse-sublink-Newsletters" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">Newsletters</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/theguardian" role="menuitem"
+                            data-link-name="nav2 : secondary : Today's paper"
+                            data-cy="column-collapse-sublink-Today's paper" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">Today's paper</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="https://www.theguardian.com/membership"
+                            role="menuitem" data-link-name="nav2 : secondary : Inside the Guardian"
+                            data-cy="column-collapse-sublink-Inside the Guardian" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">Inside the Guardian</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/observer" role="menuitem"
+                            data-link-name="nav2 : secondary : The Observer"
+                            data-cy="column-collapse-sublink-The Observer" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">The Observer</a></li>
+                        <li role="none" class="dcr-4hq641"><a
+                            href="https://www.theguardian.com/weekly?INTCMP=gdnwb_mawns_editorial_gweekly_GW_TopNav_UK"
+                            role="menuitem" data-link-name="nav2 : secondary : Guardian Weekly"
+                            data-cy="column-collapse-sublink-Guardian Weekly" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">Guardian Weekly</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/crosswords" role="menuitem"
+                            data-link-name="nav2 : secondary : Crosswords" data-cy="column-collapse-sublink-Crosswords"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Crosswords</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="https://www.wordiply.com" role="menuitem"
+                            data-link-name="nav2 : secondary : Wordiply" data-cy="column-collapse-sublink-Wordiply"
+                            tabIndex="-1" class="selectableMenuItem dcr-13wwvzl">Wordiply</a></li>
+                        <li role="none" class="dcr-4hq641"><a href="/theguardian/series/corrections-and-clarifications"
+                            role="menuitem" data-link-name="nav2 : secondary : Corrections"
+                            data-cy="column-collapse-sublink-Corrections" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl">Corrections</a></li>
+                      </ul>
+                    </li>
+                    <li role="none" class="dcr-vwltw3">
+                      <ul role="menu" class="dcr-17sb2rc">
+                        <li role="none" class="dcr-9ra8aa"><a data-link-name="nav2 : secondary : facebook"
+                            href="https://www.facebook.com/theguardian" role="menuitem" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl"><svg width="32" height="32" viewBox="-2 -2 32 32"
+                              class="dcr-6sdrzu">
+                              <path
+                                d="M17.9 14h-3v8H12v-8h-2v-2.9h2V8.7C12 6.8 13.1 5 16 5c1.2 0 2 .1 2 .1v3h-1.8c-1 0-1.2.5-1.2 1.3v1.8h3l-.1 2.8z">
+                              </path>
+                            </svg>Facebook</a></li>
+                        <li role="none" class="dcr-9ra8aa"><a data-link-name="nav2 : secondary : twitter"
+                            href="https://twitter.com/guardian" role="menuitem" tabIndex="-1"
+                            class="selectableMenuItem dcr-13wwvzl"><svg width="32" height="32" viewBox="-2 -2 32 32"
+                              class="dcr-6sdrzu">
+                              <path
+                                d="M21.3 10.5v.5c0 4.7-3.5 10.1-9.9 10.1-2 0-3.8-.6-5.3-1.6.3 0 .6.1.8.1 1.6 0 3.1-.6 4.3-1.5-1.5 0-2.8-1-3.3-2.4.2 0 .4.1.7.1l.9-.1c-1.6-.3-2.8-1.8-2.8-3.5.5.3 1 .4 1.6.4-.9-.6-1.6-1.7-1.6-2.9 0-.6.2-1.3.5-1.8 1.7 2.1 4.3 3.6 7.2 3.7-.1-.3-.1-.5-.1-.8 0-2 1.6-3.5 3.5-3.5 1 0 1.9.4 2.5 1.1.8-.1 1.5-.4 2.2-.8-.3.8-.8 1.5-1.5 1.9.7-.1 1.4-.3 2-.5-.4.4-1 1-1.7 1.5z">
+                              </path>
+                            </svg>Twitter</a></li>
+                      </ul>
+                    </li>
+                    <li role="none" class="dcr-pt8pb9">
+                      <ul role="menu" class="dcr-4phbzi">
+                        <li class="dcr-nnfu1a"><a href="https://jobs.theguardian.com" role="menuitem"
+                            data-link-name="nav2 : brand extension : Search jobs" tabIndex="-1"
+                            class="selectableMenuItem dcr-wzkd0n">Search jobs</a></li>
+                        <li class="dcr-nnfu1a"><a
+                            href="https://recruiters.theguardian.com/?utm_source=gdnwb&amp;utm_medium=navbar&amp;utm_campaign=Guardian_Navbar_Recruiters&amp;CMP_TU=trdmkt&amp;CMP_BUNIT=jobs"
+                            role="menuitem" data-link-name="nav2 : brand extension : Hire with Guardian Jobs"
+                            tabIndex="-1" class="selectableMenuItem dcr-wzkd0n">Hire with Guardian Jobs</a></li>
+                        <li class="dcr-nnfu1a"><a
+                            href="https://holidays.theguardian.com?INTCMP=holidays_uk_web_newheader" role="menuitem"
+                            data-link-name="nav2 : brand extension : Holidays" tabIndex="-1"
+                            class="selectableMenuItem dcr-wzkd0n">Holidays</a></li>
+                        <li class="dcr-nnfu1a"><a
+                            href="https://membership.theguardian.com/events?INTCMP=live_uk_header_dropdown"
+                            role="menuitem" data-link-name="nav2 : brand extension : Live events" tabIndex="-1"
+                            class="selectableMenuItem dcr-wzkd0n">Live events</a></li>
+                        <li class="dcr-nnfu1a"><a href="/guardian-masterclasses" role="menuitem"
+                            data-link-name="nav2 : brand extension : Masterclasses" tabIndex="-1"
+                            class="selectableMenuItem dcr-wzkd0n">Masterclasses</a></li>
+                        <li class="dcr-nnfu1a"><a href="https://theguardian.newspapers.com" role="menuitem"
+                            data-link-name="nav2 : brand extension : Digital Archive" tabIndex="-1"
+                            class="selectableMenuItem dcr-wzkd0n">Digital Archive</a></li>
+                        <li class="dcr-nnfu1a"><a href="/artanddesign/series/gnm-print-sales" role="menuitem"
+                            data-link-name="nav2 : brand extension : Guardian Print Shop" tabIndex="-1"
+                            class="selectableMenuItem dcr-wzkd0n">Guardian Print Shop</a></li>
+                        <li class="dcr-nnfu1a"><a href="https://patrons.theguardian.com/?INTCMP=header_patrons"
+                            role="menuitem" data-link-name="nav2 : brand extension : Patrons" tabIndex="-1"
+                            class="selectableMenuItem dcr-wzkd0n">Patrons</a></li>
+                        <li class="dcr-nnfu1a"><a href="https://puzzles.theguardian.com/download" role="menuitem"
+                            data-link-name="nav2 : brand extension : Guardian Puzzles app" tabIndex="-1"
+                            class="selectableMenuItem dcr-wzkd0n">Guardian Puzzles app</a></li>
+                        <li class="dcr-nnfu1a"><a href="https://licensing.theguardian.com/" role="menuitem"
+                            data-link-name="nav2 : brand extension : Guardian Licensing" tabIndex="-1"
+                            class="selectableMenuItem dcr-wzkd0n">Guardian Licensing</a></li>
+                      </ul>
+                    </li>
+                  </ul>
+                </div>
               </div>
-              <a
-                href="https://www.theguardian.com/global/2022/sep/20/sign-up-for-the-first-edition-newsletter-our-free-news-email"
-                data-link-name="footer : morning-briefing"
-                class="dcr-1creg26"
-              >
-                Sign up for our email
-                <div class="src-button-space"></div>
-                <svg
-                  viewBox="-3 -3 30 30"
-                  xmlns="http://www.w3.org/2000/svg"
-                  aria-hidden="true"
-                >
-                  <path
-                    fill-rule="evenodd"
-                    clip-rule="evenodd"
-                    d="M1 12.956h18.274l-7.167 8.575.932.932L23 12.478v-.956l-9.96-9.985-.932.932 7.166 8.575H1v1.912Z"
-                  ></path>
-                </svg>
-              </a>
             </div>
-            <div class="dcr-ygowzy">
-              <ul>
-                <li>
-                  <a
-                    href="/about"
-                    data-link-name="uk : footer : about us"
-                    class="dcr-5hi9qv"
-                    >About us</a
-                  >
-                </li>
-                <li>
-                  <a
-                    href="/help"
-                    data-link-name="uk : footer : tech feedback"
-                    class="dcr-sts64"
-                    >Help</a
-                  >
-                </li>
-                <li>
-                  <a
-                    href="/info/complaints-and-corrections"
-                    data-link-name="complaints"
-                    class="dcr-5hi9qv"
-                    >Complaints &amp;corrections</a
-                  >
-                </li>
-                <li>
-                  <a
-                    href="https://www.theguardian.com/securedrop"
-                    data-link-name="securedrop"
-                    class="dcr-5hi9qv"
-                    >SecureDrop</a
-                  >
-                </li>
-                <li>
-                  <a
-                    href="https://workforus.theguardian.com"
-                    data-link-name="uk : footer : work for us"
-                    class="dcr-5hi9qv"
-                    >Work for us</a
-                  >
-                </li>
-                <li>
-                  <a
-                    href="/info/privacy"
-                    data-link-name="privacy"
-                    class="dcr-5hi9qv"
-                    >Privacy policy</a
-                  >
-                </li>
-                <li>
-                  <a
-                    href="/info/cookies"
-                    data-link-name="cookie"
-                    class="dcr-5hi9qv"
-                    >Cookie policy</a
-                  >
-                </li>
-                <li>
-                  <a
-                    href="/help/terms-of-service"
-                    data-link-name="terms"
-                    class="dcr-5hi9qv"
-                    >Terms &amp;conditions</a
-                  >
-                </li>
-                <li>
-                  <a
-                    href="/help/contact-us"
-                    data-link-name="uk : footer : contact us"
-                    class="dcr-5hi9qv"
-                    >Contact us</a
-                  >
-                </li>
-              </ul>
-              <ul>
-                <li>
-                  <a
-                    href="/index/subjects/a"
-                    data-link-name="uk : footer : all topics"
-                    class="dcr-5hi9qv"
-                    >All topics</a
-                  >
-                </li>
-                <li>
-                  <a
-                    href="/index/contributors"
-                    data-link-name="uk : footer : all contributors"
-                    class="dcr-5hi9qv"
-                    >All writers</a
-                  >
-                </li>
-                <li>
-                  <a
-                    href="https://uploads.guim.co.uk/2022/07/20/STL_Modern_Slavery_Statement_2022.pdf"
-                    data-link-name="uk : footer : modern slavery act statement"
-                    class="dcr-5hi9qv"
-                    >Modern Slavery Act</a
-                  >
-                </li>
-                <li>
-                  <a
-                    href="https://theguardian.newspapers.com"
-                    data-link-name="digital newspaper archive"
-                    class="dcr-5hi9qv"
-                    >Digital newspaper archive</a
-                  >
-                </li>
-                <li>
-                  <a
-                    href="https://www.facebook.com/theguardian"
-                    data-link-name="uk : footer : facebook"
-                    class="dcr-5hi9qv"
-                    >Facebook</a
-                  >
-                </li>
-                <li>
-                  <a
-                    href="https://www.youtube.com/user/TheGuardian"
-                    data-link-name="uk : footer : youtube"
-                    class="dcr-5hi9qv"
-                    >YouTube</a
-                  >
-                </li>
-                <li>
-                  <a
-                    href="https://www.instagram.com/guardian"
-                    data-link-name="uk : footer : instagram"
-                    class="dcr-5hi9qv"
-                    >Instagram</a
-                  >
-                </li>
-                <li>
-                  <a
-                    href="https://www.linkedin.com/company/theguardian"
-                    data-link-name="uk : footer : linkedin"
-                    class="dcr-5hi9qv"
-                    >LinkedIn</a
-                  >
-                </li>
-                <li>
-                  <a
-                    href="https://twitter.com/guardian"
-                    data-link-name="uk: footer : twitter"
-                    class="dcr-5hi9qv"
-                    >Twitter</a
-                  >
-                </li>
-                <li>
-                  <a
-                    href="/email-newsletters?INTCMP=DOTCOM_FOOTER_NEWSLETTER_UK"
-                    data-link-name="uk : footer : newsletters"
-                    class="dcr-5hi9qv"
-                    >Newsletters</a
-                  >
-                </li>
-              </ul>
-              <ul>
-                <li>
-                  <a
-                    href="https://advertising.theguardian.com"
-                    data-link-name="uk : footer : advertise with us"
-                    class="dcr-5hi9qv"
-                    >Advertise with us</a
-                  >
-                </li>
-                <li>
-                  <a
-                    href="/guardian-labs"
-                    data-link-name="uk : footer : guardian labs"
-                    class="dcr-5hi9qv"
-                    >Guardian Labs</a
-                  >
-                </li>
-                <li>
-                  <a
-                    href="https://jobs.theguardian.com"
-                    data-link-name="uk : footer : jobs"
-                    class="dcr-5hi9qv"
-                    >Search jobs</a
-                  >
-                </li>
-                <li>
-                  <a
-                    href="https://patrons.theguardian.com?INTCMP=footer_patrons"
-                    data-link-name="uk : footer : patrons"
-                    class="dcr-5hi9qv"
-                    >Patrons</a
-                  >
-                </li>
-              </ul>
-              <div class="dcr-1g9k069">
-                <gu-island
-                  name="ReaderRevenueLinks"
-                  deferUntil="visible"
-                  props='{"urls":{"contribute":"https://support.theguardian.com/contribute?INTCMP=header_support_contribute&amp;acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22header_support_contribute%22%7D","subscribe":"https://support.theguardian.com/subscribe?INTCMP=header_support_subscribe&amp;acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22header_support_subscribe%22%7D","support":"https://support.theguardian.com?INTCMP=header_support&amp;acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22header_support%22%7D","supporter":"https://support.theguardian.com/subscribe?INTCMP=header_supporter_cta&amp;acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22header_supporter_cta%22%7D"},"editionId":"UK","dataLinkNamePrefix":"footer : ","inHeader":false,"remoteHeader":false,"contributionsServiceUrl":"https://contributions.guardianapis.com"}'
-                  clientOnly
-                ></gu-island>
-              </div>
-            </div>
-            <div class="dcr-1xnlu54">
-              <a href="#top" class="dcr-1bljy3y">
-                <span class="dcr-4rr662">Back to top</span>
-                <span class="icon-container dcr-18yycfp">
-                  <i class="dcr-13lm9u3"></i>
-                </span>
-              </a>
-            </div>
-          </div>
-          <div class="dcr-1qbs42f">
-            © 2023 Guardian News &amp;Media Limited or its affiliated companies.
-            All rights reserved. (modern)
           </div>
         </div>
       </div>
-    </footer>
-    <!-- no recipe markup -->
-  </body>
+    </nav>
+    <aside class="dcr-1h92x0c">
+      <div class="dcr-188zz3t"><gu-island name="SubNav" deferUntil="idle"
+          props="{&quot;subNavSections&quot;:{&quot;links&quot;:[{&quot;title&quot;:&quot;UK&quot;,&quot;longTitle&quot;:&quot;UK news&quot;,&quot;url&quot;:&quot;/uk-news&quot;,&quot;children&quot;:[{&quot;title&quot;:&quot;UK politics&quot;,&quot;longTitle&quot;:&quot;UK politics&quot;,&quot;url&quot;:&quot;/politics&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Education&quot;,&quot;longTitle&quot;:&quot;Education&quot;,&quot;url&quot;:&quot;/education&quot;,&quot;children&quot;:[{&quot;title&quot;:&quot;Schools&quot;,&quot;longTitle&quot;:&quot;Schools&quot;,&quot;url&quot;:&quot;/education/schools&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Teachers&quot;,&quot;longTitle&quot;:&quot;Teachers&quot;,&quot;url&quot;:&quot;/teacher-network&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Universities&quot;,&quot;longTitle&quot;:&quot;Universities&quot;,&quot;url&quot;:&quot;/education/universities&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Students&quot;,&quot;longTitle&quot;:&quot;Students&quot;,&quot;url&quot;:&quot;/education/students&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false}],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Media&quot;,&quot;longTitle&quot;:&quot;Media&quot;,&quot;url&quot;:&quot;/media&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Society&quot;,&quot;longTitle&quot;:&quot;Society&quot;,&quot;url&quot;:&quot;/society&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Law&quot;,&quot;longTitle&quot;:&quot;Law&quot;,&quot;url&quot;:&quot;/law&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Scotland&quot;,&quot;longTitle&quot;:&quot;Scotland&quot;,&quot;url&quot;:&quot;/uk/scotland&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Wales&quot;,&quot;longTitle&quot;:&quot;Wales&quot;,&quot;url&quot;:&quot;/uk/wales&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Northern Ireland&quot;,&quot;longTitle&quot;:&quot;Northern Ireland&quot;,&quot;url&quot;:&quot;/uk/northernireland&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false}],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;World&quot;,&quot;longTitle&quot;:&quot;World news&quot;,&quot;url&quot;:&quot;/world&quot;,&quot;children&quot;:[{&quot;title&quot;:&quot;Europe&quot;,&quot;longTitle&quot;:&quot;Europe&quot;,&quot;url&quot;:&quot;/world/europe-news&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;US&quot;,&quot;longTitle&quot;:&quot;US news&quot;,&quot;url&quot;:&quot;/us-news&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Americas&quot;,&quot;longTitle&quot;:&quot;Americas&quot;,&quot;url&quot;:&quot;/world/americas&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Asia&quot;,&quot;longTitle&quot;:&quot;Asia&quot;,&quot;url&quot;:&quot;/world/asia&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Australia&quot;,&quot;longTitle&quot;:&quot;Australia news&quot;,&quot;url&quot;:&quot;/australia-news&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Middle East&quot;,&quot;longTitle&quot;:&quot;Middle East&quot;,&quot;url&quot;:&quot;/world/middleeast&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Africa&quot;,&quot;longTitle&quot;:&quot;Africa&quot;,&quot;url&quot;:&quot;/world/africa&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Inequality&quot;,&quot;longTitle&quot;:&quot;Inequality&quot;,&quot;url&quot;:&quot;/inequality&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Global development&quot;,&quot;longTitle&quot;:&quot;Global development&quot;,&quot;url&quot;:&quot;/global-development&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false}],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Climate crisis&quot;,&quot;longTitle&quot;:&quot;Climate crisis&quot;,&quot;url&quot;:&quot;/environment/climate-crisis&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Newsletters&quot;,&quot;longTitle&quot;:&quot;Newsletters&quot;,&quot;url&quot;:&quot;/email-newsletters&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Football&quot;,&quot;longTitle&quot;:&quot;Football&quot;,&quot;url&quot;:&quot;/football&quot;,&quot;children&quot;:[{&quot;title&quot;:&quot;Live scores&quot;,&quot;longTitle&quot;:&quot;football/live&quot;,&quot;url&quot;:&quot;/football/live&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Tables&quot;,&quot;longTitle&quot;:&quot;football/tables&quot;,&quot;url&quot;:&quot;/football/tables&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Fixtures&quot;,&quot;longTitle&quot;:&quot;football/fixtures&quot;,&quot;url&quot;:&quot;/football/fixtures&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Results&quot;,&quot;longTitle&quot;:&quot;football/results&quot;,&quot;url&quot;:&quot;/football/results&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Competitions&quot;,&quot;longTitle&quot;:&quot;football/competitions&quot;,&quot;url&quot;:&quot;/football/competitions&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Clubs&quot;,&quot;longTitle&quot;:&quot;football/teams&quot;,&quot;url&quot;:&quot;/football/teams&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false}],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Coronavirus&quot;,&quot;longTitle&quot;:&quot;Coronavirus&quot;,&quot;url&quot;:&quot;/world/coronavirus-outbreak&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Business&quot;,&quot;longTitle&quot;:&quot;Business&quot;,&quot;url&quot;:&quot;/business&quot;,&quot;children&quot;:[{&quot;title&quot;:&quot;Economics&quot;,&quot;longTitle&quot;:&quot;Economics&quot;,&quot;url&quot;:&quot;/business/economics&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Banking&quot;,&quot;longTitle&quot;:&quot;Banking&quot;,&quot;url&quot;:&quot;/business/banking&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Money&quot;,&quot;longTitle&quot;:&quot;Money&quot;,&quot;url&quot;:&quot;/money&quot;,&quot;children&quot;:[{&quot;title&quot;:&quot;Property&quot;,&quot;longTitle&quot;:&quot;Property&quot;,&quot;url&quot;:&quot;/money/property&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Pensions&quot;,&quot;longTitle&quot;:&quot;Pensions&quot;,&quot;url&quot;:&quot;/money/pensions&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Savings&quot;,&quot;longTitle&quot;:&quot;Savings&quot;,&quot;url&quot;:&quot;/money/savings&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Borrowing&quot;,&quot;longTitle&quot;:&quot;Borrowing&quot;,&quot;url&quot;:&quot;/money/debt&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Careers&quot;,&quot;longTitle&quot;:&quot;Careers&quot;,&quot;url&quot;:&quot;/money/work-and-careers&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false}],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Markets&quot;,&quot;longTitle&quot;:&quot;Markets&quot;,&quot;url&quot;:&quot;/business/stock-markets&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Project Syndicate&quot;,&quot;longTitle&quot;:&quot;Project Syndicate&quot;,&quot;url&quot;:&quot;/business/series/project-syndicate-economists&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;B2B&quot;,&quot;longTitle&quot;:&quot;B2B&quot;,&quot;url&quot;:&quot;/business-to-business&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Retail&quot;,&quot;longTitle&quot;:&quot;Retail&quot;,&quot;url&quot;:&quot;/business/retail&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false}],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Environment&quot;,&quot;longTitle&quot;:&quot;Environment&quot;,&quot;url&quot;:&quot;/environment&quot;,&quot;children&quot;:[{&quot;title&quot;:&quot;Climate crisis&quot;,&quot;longTitle&quot;:&quot;Climate crisis&quot;,&quot;url&quot;:&quot;/environment/climate-crisis&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Wildlife&quot;,&quot;longTitle&quot;:&quot;Wildlife&quot;,&quot;url&quot;:&quot;/environment/wildlife&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Energy&quot;,&quot;longTitle&quot;:&quot;Energy&quot;,&quot;url&quot;:&quot;/environment/energy&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Pollution&quot;,&quot;longTitle&quot;:&quot;Pollution&quot;,&quot;url&quot;:&quot;/environment/pollution&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false}],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;UK politics&quot;,&quot;longTitle&quot;:&quot;UK politics&quot;,&quot;url&quot;:&quot;/politics&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Education&quot;,&quot;longTitle&quot;:&quot;Education&quot;,&quot;url&quot;:&quot;/education&quot;,&quot;children&quot;:[{&quot;title&quot;:&quot;Schools&quot;,&quot;longTitle&quot;:&quot;Schools&quot;,&quot;url&quot;:&quot;/education/schools&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Teachers&quot;,&quot;longTitle&quot;:&quot;Teachers&quot;,&quot;url&quot;:&quot;/teacher-network&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Universities&quot;,&quot;longTitle&quot;:&quot;Universities&quot;,&quot;url&quot;:&quot;/education/universities&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Students&quot;,&quot;longTitle&quot;:&quot;Students&quot;,&quot;url&quot;:&quot;/education/students&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false}],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Society&quot;,&quot;longTitle&quot;:&quot;Society&quot;,&quot;url&quot;:&quot;/society&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Science&quot;,&quot;longTitle&quot;:&quot;Science&quot;,&quot;url&quot;:&quot;/science&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Tech&quot;,&quot;longTitle&quot;:&quot;Tech&quot;,&quot;url&quot;:&quot;/technology&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Global development&quot;,&quot;longTitle&quot;:&quot;Global development&quot;,&quot;url&quot;:&quot;/global-development&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Obituaries&quot;,&quot;longTitle&quot;:&quot;Obituaries&quot;,&quot;url&quot;:&quot;/obituaries&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false}]},&quot;currentNavLink&quot;:&quot;News&quot;,&quot;format&quot;:{&quot;display&quot;:0,&quot;design&quot;:0,&quot;theme&quot;:0}}">
+          <div data-print-layout="hide" data-cy="sub-nav" data-component="sub-nav" class="dcr-v6jxf0">
+            <ul role="list" class="dcr-1gt8egs">
+              <li><a data-src-focus-disabled="true" href="/uk-news" data-link-name="nav2 : subnav : uk-news"
+                  class="dcr-qo5392">UK</a></li>
+              <li><a data-src-focus-disabled="true" href="/world" data-link-name="nav2 : subnav : world"
+                  class="dcr-qo5392">World</a></li>
+              <li><a data-src-focus-disabled="true" href="/environment/climate-crisis"
+                  data-link-name="nav2 : subnav : environment/climate-crisis" class="dcr-qo5392">Climate crisis</a></li>
+              <li><a data-src-focus-disabled="true" href="/email-newsletters"
+                  data-link-name="nav2 : subnav : email-newsletters" class="dcr-qo5392">Newsletters</a></li>
+              <li><a data-src-focus-disabled="true" href="/football" data-link-name="nav2 : subnav : football"
+                  class="dcr-qo5392">Football</a></li>
+              <li><a data-src-focus-disabled="true" href="/world/coronavirus-outbreak"
+                  data-link-name="nav2 : subnav : world/coronavirus-outbreak" class="dcr-qo5392">Coronavirus</a></li>
+              <li><a data-src-focus-disabled="true" href="/business" data-link-name="nav2 : subnav : business"
+                  class="dcr-qo5392">Business</a></li>
+              <li><a data-src-focus-disabled="true" href="/environment" data-link-name="nav2 : subnav : environment"
+                  class="dcr-qo5392">Environment</a></li>
+              <li><a data-src-focus-disabled="true" href="/politics" data-link-name="nav2 : subnav : politics"
+                  class="dcr-qo5392">UK politics</a></li>
+              <li><a data-src-focus-disabled="true" href="/education" data-link-name="nav2 : subnav : education"
+                  class="dcr-qo5392">Education</a></li>
+              <li><a data-src-focus-disabled="true" href="/society" data-link-name="nav2 : subnav : society"
+                  class="dcr-qo5392">Society</a></li>
+              <li><a data-src-focus-disabled="true" href="/science" data-link-name="nav2 : subnav : science"
+                  class="dcr-qo5392">Science</a></li>
+              <li><a data-src-focus-disabled="true" href="/technology" data-link-name="nav2 : subnav : technology"
+                  class="dcr-qo5392">Tech</a></li>
+              <li><a data-src-focus-disabled="true" href="/global-development"
+                  data-link-name="nav2 : subnav : global-development" class="dcr-qo5392">Global development</a></li>
+              <li data-chromatic="ignore"><a data-src-focus-disabled="true" href="/obituaries"
+                  data-link-name="nav2 : subnav : obituaries" class="dcr-qo5392">Obituaries</a></li>
+            </ul>
+          </div>
+        </gu-island></div>
+    </aside>
+    <section class="dcr-1h92x0c">
+      <div class="dcr-188zz3t"><svg xmlns="http://www.w3.org/2000/svg" width="100%" height="13" viewBox="0 0 1300 13"
+          preserveAspectRatio="none" stroke="#DCDCDC" stroke-width="1" aria-hidden="true" focusable="false"
+          class="dcr-65xb9q">
+          <line x1="0" x2="1300" y1="0.5" y2="0.5"></line>
+          <line x1="0" x2="1300" y1="4.5" y2="4.5"></line>
+          <line x1="0" x2="1300" y1="8.5" y2="8.5"></line>
+          <line x1="0" x2="1300" y1="12.5" y2="12.5"></line>
+        </svg></div>
+    </section>
+  </div>
+  <main data-layout="FrontLayout" id="maincontent">
+    <section id="headlines" data-link-name="container-0 | headlines" data-component="headlines"
+      data-container-name="dynamic/fast" class="dcr-r91ehr">
+      <div class="dcr-em8d0v"></div>
+      <div class="dcr-1kx60rc"><span class="dcr-1n8hb96"></span>
+        <div class="dcr-15t9kli"><span class="dcr-1iz7gbk"></span>
+          <div class="dcr-1atljbz">
+            <h2 class="dcr-eubdc">Headlines</h2>
+          </div>
+        </div>
+      </div>
+      <div id="container-headlines" class="dcr-yyvovz">
+        <ul class="dcr-1mi5u71">
+          <li class="dcr-w3rkaf">
+            <div class="dcr-1p6anfw"><a href="/world/2023/jun/12/silvio-berlusconi-former-italian-prime-minister-dies"
+                data-link-name="news | group-2+ | card-@1" aria-label="Former Italian prime minister dies aged 86"
+                class="dcr-pkharf"></a>
+              <div class="dcr-1eb5jgw">
+                <div class="dcr-1pe3pea">
+                  <picture data-size="large" class="dcr-yosj9c">
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/755b8b2188ca614fda2a93366a91bacb4cc7b283/0_188_4096_2459/master/4096.jpg?width=700&amp;quality=45&amp;dpr=2&amp;s=none"
+                      media="(min-width: 980px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 980px) and (min-resolution: 120dpi)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/755b8b2188ca614fda2a93366a91bacb4cc7b283/0_188_4096_2459/master/4096.jpg?width=700&amp;quality=85&amp;dpr=1&amp;s=none"
+                      media="(min-width: 980px)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/755b8b2188ca614fda2a93366a91bacb4cc7b283/0_188_4096_2459/master/4096.jpg?width=500&amp;quality=45&amp;dpr=2&amp;s=none"
+                      media="(min-width: 740px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 740px) and (min-resolution: 120dpi)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/755b8b2188ca614fda2a93366a91bacb4cc7b283/0_188_4096_2459/master/4096.jpg?width=500&amp;quality=85&amp;dpr=1&amp;s=none"
+                      media="(min-width: 740px)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/755b8b2188ca614fda2a93366a91bacb4cc7b283/0_188_4096_2459/master/4096.jpg?width=480&amp;quality=45&amp;dpr=2&amp;s=none"
+                      media="(min-width: 480px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 480px) and (min-resolution: 120dpi)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/755b8b2188ca614fda2a93366a91bacb4cc7b283/0_188_4096_2459/master/4096.jpg?width=480&amp;quality=85&amp;dpr=1&amp;s=none"
+                      media="(min-width: 480px)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/755b8b2188ca614fda2a93366a91bacb4cc7b283/0_188_4096_2459/master/4096.jpg?width=360&amp;quality=45&amp;dpr=2&amp;s=none"
+                      media="(min-width: 320px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 320px) and (min-resolution: 120dpi)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/755b8b2188ca614fda2a93366a91bacb4cc7b283/0_188_4096_2459/master/4096.jpg?width=360&amp;quality=85&amp;dpr=1&amp;s=none"
+                      media="(min-width: 320px)" /><img alt
+                      src="https://i.guim.co.uk/img/media/755b8b2188ca614fda2a93366a91bacb4cc7b283/0_188_4096_2459/master/4096.jpg?width=360&amp;quality=85&amp;dpr=1&amp;s=none"
+                      class="dcr-evn1e9" />
+                  </picture>
+                  <div class="image-overlay"></div>
+                </div>
+                <div class="dcr-rrcudz">
+                  <div class="dcr-dbozpd">
+                    <h3 class="dcr-14gfmlq">
+                      <div class="dcr-1o7trcs">Silvio Berlusconi</div><span class="show-underline dcr-adlhb4">Former
+                        Italian prime minister dies aged 86</span>
+                    </h3>
+                  </div>
+                  <div>
+                    <div class="dcr-hcib8t">
+                      <div>Health of flamboyant media tycoon who led three Italian governments had deteriorated markedly
+                        in recent years</div>
+                    </div>
+                    <footer class="dcr-4xb9x1">
+                      <div class="dcr-17yg843"><span class="dcr-1hg1hdu"><span><time dateTime="2023-06-12T08:43:01.000Z"
+                              data-relativeformat="med">40m ago</time></span></span></div>
+                    </footer>
+                    <ul class="dcr-kz9nqe">
+                      <li class="dcr-z7lzm0">
+                        <h3 class="dcr-wi48h0"><a
+                            href="/world/2023/jun/12/berlusconi-death-legacy-loss-of-faith-in-italy-political-elite"
+                            class="dcr-os58m2">
+                            <div class="dcr-ect2dm">Berlusconi's legacy</div><span
+                              class="show-underline dcr-adlhb4">Bunga bunga and bling aside, he leaves behind a loss of
+                              faith in Italy’s political elite</span>
+                          </a></h3>
+                      </li>
+                      <li class="dcr-1hipxkh">
+                        <h3 class="dcr-wi48h0"><a href="/world/gallery/2011/feb/16/silvio-berlusconi-italy"
+                            class="dcr-os58m2">
+                            <div class="dcr-ect2dm">A life in pictures</div><span
+                              class="show-underline dcr-adlhb4">Silvio Berlusconi </span>
+                          </a></h3>
+                      </li>
+                    </ul>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </li>
+          <li class="dcr-1cgn3lv">
+            <div class="dcr-ruaspp"><a
+                href="/world/live/2023/jun/12/russia-ukraine-war-live-counteroffensive-seeing-first-localised-results-says-kyiv-icc-probe-of-kakhovka-dam-disaster-has-begun"
+                data-link-name="live | group-2 | card-@2"
+                aria-label="Russia-Ukraine war: heavy battles on frontline after Kyiv reports first gains in counteroffensive"
+                class="dcr-pkharf"></a>
+              <div class="dcr-17h8ziz">
+                <div class="dcr-1pb5o7w">
+                  <picture data-size="small" class="dcr-yosj9c">
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/02e6ade6186ac301c93fa6902c1a4f240680288d/166_0_4775_2866/master/4775.jpg?width=220&amp;quality=45&amp;dpr=2&amp;s=none"
+                      media="(min-width: 980px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 980px) and (min-resolution: 120dpi)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/02e6ade6186ac301c93fa6902c1a4f240680288d/166_0_4775_2866/master/4775.jpg?width=220&amp;quality=85&amp;dpr=1&amp;s=none"
+                      media="(min-width: 980px)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/02e6ade6186ac301c93fa6902c1a4f240680288d/166_0_4775_2866/master/4775.jpg?width=160&amp;quality=45&amp;dpr=2&amp;s=none"
+                      media="(min-width: 740px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 740px) and (min-resolution: 120dpi)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/02e6ade6186ac301c93fa6902c1a4f240680288d/166_0_4775_2866/master/4775.jpg?width=160&amp;quality=85&amp;dpr=1&amp;s=none"
+                      media="(min-width: 740px)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/02e6ade6186ac301c93fa6902c1a4f240680288d/166_0_4775_2866/master/4775.jpg?width=120&amp;quality=45&amp;dpr=2&amp;s=none"
+                      media="(min-width: 320px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 320px) and (min-resolution: 120dpi)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/02e6ade6186ac301c93fa6902c1a4f240680288d/166_0_4775_2866/master/4775.jpg?width=120&amp;quality=85&amp;dpr=1&amp;s=none"
+                      media="(min-width: 320px)" /><img alt
+                      src="https://i.guim.co.uk/img/media/02e6ade6186ac301c93fa6902c1a4f240680288d/166_0_4775_2866/master/4775.jpg?width=120&amp;quality=85&amp;dpr=1&amp;s=none"
+                      class="dcr-evn1e9" />
+                  </picture>
+                  <div class="image-overlay"></div>
+                </div>
+                <div class="dcr-1y2cu33">
+                  <div class="dcr-dbozpd">
+                    <h3 class="dcr-p1dvl6">
+                      <div class="dcr-16jv6hb"><span data-flashing-dot-hydrated="false" data-animate="false"
+                          class="dcr-5bdubr"></span>Live</div><span class="show-underline dcr-mfwrfv">Russia-Ukraine
+                        war: heavy battles on frontline after Kyiv reports first gains in counteroffensive</span>
+                    </h3>
+                  </div>
+                  <div>
+                    <footer class="dcr-4xb9x1">
+                      <div class="dcr-17yg843"><span class="dcr-1g99xyq"><span><time dateTime="2023-06-12T08:59:57.000Z"
+                              data-relativeformat="med">23m ago</time></span></span></div>
+                    </footer>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </li>
+        </ul>
+        <ul class="dcr-y4cf8a">
+          <li class="dcr-elbm7f">
+            <div class="dcr-ruaspp"><a
+                href="/politics/live/2023/jun/12/michael-gove-privileges-committee-boris-johnson-parliament-rishi-sunak-latest-politics-updates"
+                data-link-name="live | group-1 | card-@1"
+                aria-label="Rishi Sunak says Boris Johnson asked him to do something he ‘didn’t think was right’ with honours list"
+                class="dcr-pkharf"></a>
+              <div class="dcr-17h8ziz">
+                <div class="dcr-1pb5o7w">
+                  <picture data-size="small" class="dcr-yosj9c">
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/5439736b5e4704c12f4064ae687b91519bab054c/0_262_7868_4723/master/7868.jpg?width=220&amp;quality=45&amp;dpr=2&amp;s=none"
+                      media="(min-width: 980px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 980px) and (min-resolution: 120dpi)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/5439736b5e4704c12f4064ae687b91519bab054c/0_262_7868_4723/master/7868.jpg?width=220&amp;quality=85&amp;dpr=1&amp;s=none"
+                      media="(min-width: 980px)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/5439736b5e4704c12f4064ae687b91519bab054c/0_262_7868_4723/master/7868.jpg?width=160&amp;quality=45&amp;dpr=2&amp;s=none"
+                      media="(min-width: 740px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 740px) and (min-resolution: 120dpi)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/5439736b5e4704c12f4064ae687b91519bab054c/0_262_7868_4723/master/7868.jpg?width=160&amp;quality=85&amp;dpr=1&amp;s=none"
+                      media="(min-width: 740px)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/5439736b5e4704c12f4064ae687b91519bab054c/0_262_7868_4723/master/7868.jpg?width=120&amp;quality=45&amp;dpr=2&amp;s=none"
+                      media="(min-width: 320px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 320px) and (min-resolution: 120dpi)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/5439736b5e4704c12f4064ae687b91519bab054c/0_262_7868_4723/master/7868.jpg?width=120&amp;quality=85&amp;dpr=1&amp;s=none"
+                      media="(min-width: 320px)" /><img alt
+                      src="https://i.guim.co.uk/img/media/5439736b5e4704c12f4064ae687b91519bab054c/0_262_7868_4723/master/7868.jpg?width=120&amp;quality=85&amp;dpr=1&amp;s=none"
+                      class="dcr-evn1e9" />
+                  </picture>
+                  <div class="image-overlay"></div>
+                  <div class="dcr-1ysdk7i"><span class="dcr-kt9wlt"><svg viewBox="-3 -3 30 30"
+                        xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                        <path fill-rule="evenodd" clip-rule="evenodd"
+                          d="M20.075 12.35v-.7L4.475 5.2l-.575.45v12.7l.575.4 15.6-6.4Z"></path>
+                      </svg></span></div>
+                </div>
+                <div class="dcr-1y2cu33">
+                  <div class="dcr-dbozpd">
+                    <h3 class="dcr-p1dvl6">
+                      <div class="dcr-16jv6hb"><span data-flashing-dot-hydrated="false" data-animate="false"
+                          class="dcr-5bdubr"></span>Live</div><span class="show-underline dcr-mfwrfv">Rishi Sunak says
+                        Boris Johnson asked him to do something he ‘didn’t think was right’ with honours list</span>
+                    </h3>
+                  </div>
+                  <div>
+                    <footer class="dcr-4xb9x1">
+                      <div class="dcr-17yg843"><span class="dcr-1g99xyq"><span><time dateTime="2023-06-12T09:17:18.000Z"
+                              data-relativeformat="med">6m ago</time></span></span><a data-discussion-id="/p/z7t5e"
+                          data-format="{&quot;display&quot;:0,&quot;theme&quot;:0,&quot;design&quot;:10}"
+                          data-ignore="global-link-styling" data-link-name="Comment count"
+                          href="/politics/live/2023/jun/12/michael-gove-privileges-committee-boris-johnson-parliament-rishi-sunak-latest-politics-updates#comments"
+                          class="dcr-1xir693"></a></div>
+                    </footer>
+                  </div>
+                </div>
+              </div>
+              <ul class="dcr-kz9nqe">
+                <li class="dcr-1hipxkh">
+                  <h3 class="dcr-10b6thp"><a href="/politics/2023/jun/12/michael-gove-boris-johnson-conservatives-past"
+                      class="dcr-os58m2">
+                      <div class="dcr-cho92m">‘Life moves on’</div><span class="show-underline dcr-mfwrfv">Gove attempts
+                        to consign Boris Johnson to Conservatives’ past</span>
+                    </a></h3>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li class="dcr-1cgn3lv">
+            <div class="dcr-1p6anfw"><a href="/uk-news/2023/jun/12/three-britons-confirmed-dead-in-egypt-boat-fire"
+                data-link-name="news | group-1 | card-@2" aria-label="Three Britons confirmed dead after boat fire"
+                class="dcr-pkharf"></a>
+              <div class="dcr-17h8ziz">
+                <div class="dcr-1pb5o7w">
+                  <picture data-size="small" class="dcr-yosj9c">
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/0e64c599388a58d93d3391d14f67f5490e2c5cb7/0_10_3185_1911/master/3185.jpg?width=220&amp;quality=45&amp;dpr=2&amp;s=none"
+                      media="(min-width: 980px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 980px) and (min-resolution: 120dpi)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/0e64c599388a58d93d3391d14f67f5490e2c5cb7/0_10_3185_1911/master/3185.jpg?width=220&amp;quality=85&amp;dpr=1&amp;s=none"
+                      media="(min-width: 980px)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/0e64c599388a58d93d3391d14f67f5490e2c5cb7/0_10_3185_1911/master/3185.jpg?width=160&amp;quality=45&amp;dpr=2&amp;s=none"
+                      media="(min-width: 740px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 740px) and (min-resolution: 120dpi)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/0e64c599388a58d93d3391d14f67f5490e2c5cb7/0_10_3185_1911/master/3185.jpg?width=160&amp;quality=85&amp;dpr=1&amp;s=none"
+                      media="(min-width: 740px)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/0e64c599388a58d93d3391d14f67f5490e2c5cb7/0_10_3185_1911/master/3185.jpg?width=120&amp;quality=45&amp;dpr=2&amp;s=none"
+                      media="(min-width: 320px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 320px) and (min-resolution: 120dpi)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/0e64c599388a58d93d3391d14f67f5490e2c5cb7/0_10_3185_1911/master/3185.jpg?width=120&amp;quality=85&amp;dpr=1&amp;s=none"
+                      media="(min-width: 320px)" /><img alt
+                      src="https://i.guim.co.uk/img/media/0e64c599388a58d93d3391d14f67f5490e2c5cb7/0_10_3185_1911/master/3185.jpg?width=120&amp;quality=85&amp;dpr=1&amp;s=none"
+                      class="dcr-evn1e9" />
+                  </picture>
+                  <div class="image-overlay"></div>
+                </div>
+                <div class="dcr-1y2cu33">
+                  <div class="dcr-dbozpd">
+                    <h3 class="dcr-p1dvl6">
+                      <div class="dcr-1o7trcs">Egypt</div><span class="show-underline dcr-adlhb4">Three Britons
+                        confirmed dead after boat fire</span>
+                    </h3>
+                  </div>
+                  <div>
+                    <footer class="dcr-4xb9x1">
+                      <div class="dcr-17yg843"><span class="dcr-1hg1hdu"><span><time dateTime="2023-06-12T09:00:43.000Z"
+                              data-relativeformat="med">22m ago</time></span></span></div>
+                    </footer>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </li>
+          <li class="dcr-16fqzm2">
+            <ul class="dcr-1lcaowc">
+              <li class="dcr-avaain">
+                <div class="dcr-1p6anfw"><a
+                    href="/world/2023/jun/11/eleven-year-old-british-girl-shot-dead-in-her-garden-in-west-france"
+                    data-link-name="news | group-0 | card-@1"
+                    aria-label="Eleven-year-old British girl shot dead in family's garden" class="dcr-pkharf"></a>
+                  <div class="dcr-17h8ziz">
+                    <div class="dcr-1y2cu33">
+                      <div class="dcr-dbozpd">
+                        <h3 class="dcr-12hccii">
+                          <div class="dcr-1o7trcs">Brittany</div><span class="show-underline dcr-adlhb4">Eleven-year-old
+                            British girl shot dead in family's garden</span>
+                        </h3>
+                      </div>
+                      <div>
+                        <footer class="dcr-4xb9x1">
+                          <div class="dcr-17yg843"><span class="dcr-1hg1hdu"><span><time
+                                  dateTime="2023-06-11T22:27:25.000Z" data-relativeformat="med">11h
+                                  ago</time></span></span></div>
+                        </footer>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </li>
+              <li class="dcr-y8nd8l">
+                <div class="dcr-1p6anfw"><a
+                    href="/uk-news/2023/jun/12/chloe-mitchell-two-charged-over-and-disappearance-of-21-year-old"
+                    data-link-name="news | group-0 | card-@2"
+                    aria-label="Two charged over murder and disappearance of 21-year-old" class="dcr-pkharf"></a>
+                  <div class="dcr-17h8ziz">
+                    <div class="dcr-1y2cu33">
+                      <div class="dcr-dbozpd">
+                        <h3 class="dcr-12hccii">
+                          <div class="dcr-1o7trcs">Chloe Mitchell</div><span class="show-underline dcr-adlhb4">Two
+                            charged over murder and disappearance of 21-year-old</span>
+                        </h3>
+                      </div>
+                      <div>
+                        <footer class="dcr-4xb9x1">
+                          <div class="dcr-17yg843"><span class="dcr-1hg1hdu"><span><time
+                                  dateTime="2023-06-12T06:25:08.000Z" data-relativeformat="med">3h
+                                  ago</time></span></span></div>
+                        </footer>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </li>
+              <li class="dcr-avaain">
+                <div class="dcr-1pscgow"><a
+                    href="/stage/2023/jun/12/tony-awards-2023-leopoldstadt-and-kimberly-akimbo-win-big-in-historic-night-for-non-binary-actors"
+                    data-link-name="news | group-0 | card-@3"
+                    aria-label="Jodie Comer and Tom Stoppard lead big night for Britain" class="dcr-pkharf"></a>
+                  <div class="dcr-17h8ziz">
+                    <div class="dcr-1y2cu33">
+                      <div class="dcr-dbozpd">
+                        <h3 class="dcr-12hccii">
+                          <div class="dcr-1i3wv16">Tony awards 2023</div><span class="show-underline dcr-adlhb4">Jodie
+                            Comer and Tom Stoppard lead big night for Britain</span>
+                        </h3>
+                      </div>
+                      <div>
+                        <footer class="dcr-4xb9x1">
+                          <div class="dcr-17yg843"><span class="dcr-1hg1hdu"><span><time
+                                  dateTime="2023-06-12T04:18:45.000Z" data-relativeformat="med">5h
+                                  ago</time></span></span></div>
+                        </footer>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </li>
+              <li class="dcr-y8nd8l">
+                <div class="dcr-ruaspp"><a
+                    href="/business/live/2023/jun/12/bank-of-england-further-interest-rate-rises-fight-inflation-mortgage-london-tech-week-business-live"
+                    data-link-name="live | group-0 | card-@4"
+                    aria-label="Bank of England policymaker ‘cannot rule out’ further interest rate rises to fight inflation"
+                    class="dcr-pkharf"></a>
+                  <div class="dcr-17h8ziz">
+                    <div class="dcr-1y2cu33">
+                      <div class="dcr-dbozpd">
+                        <h3 class="dcr-12hccii">
+                          <div class="dcr-16jv6hb"><span data-flashing-dot-hydrated="false" data-animate="false"
+                              class="dcr-5bdubr"></span>Live</div><span class="show-underline dcr-mfwrfv">Bank of
+                            England policymaker ‘cannot rule out’ further interest rate rises to fight inflation</span>
+                        </h3>
+                      </div>
+                      <div>
+                        <footer class="dcr-4xb9x1">
+                          <div class="dcr-17yg843"><span class="dcr-1g99xyq"><span><time
+                                  dateTime="2023-06-12T09:18:45.000Z" data-relativeformat="med">4m
+                                  ago</time></span></span></div>
+                        </footer>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </li>
+              <li class="dcr-avaain">
+                <div class="dcr-15p4tz0"><a
+                    href="/money/2023/jun/12/older-people-hired-as-money-mules-by-gangs-as-cost-of-living-crisis-bites"
+                    data-link-name="news | group-0 | card-@5"
+                    aria-label="Older people recruited by gangs as cost of living crisis bites" class="dcr-pkharf"></a>
+                  <div class="dcr-17h8ziz">
+                    <div class="dcr-1y2cu33">
+                      <div class="dcr-dbozpd">
+                        <h3 class="dcr-12hccii">
+                          <div class="dcr-hhyfju">'Money mules'</div><span class="show-underline dcr-adlhb4">Older
+                            people recruited by gangs as cost of living crisis bites</span>
+                        </h3>
+                      </div>
+                      <div>
+                        <footer class="dcr-4xb9x1">
+                          <div class="dcr-17yg843"><span class="dcr-1hg1hdu"><span><time
+                                  dateTime="2023-06-12T08:00:14.000Z" data-relativeformat="med">1h
+                                  ago</time></span></span></div>
+                        </footer>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </li>
+              <li class="dcr-9e78hl">
+                <div class="dcr-1p6anfw"><a
+                    href="/media/2023/jun/12/channel-4-criticised-over-not-genuine-banksy-on-the-greatest-auction"
+                    data-link-name="news | group-0 | card-@6"
+                    aria-label="Channel 4 criticised over ‘not genuine Banksy’ on The Greatest Auction"
+                    class="dcr-pkharf"></a>
+                  <div class="dcr-17h8ziz">
+                    <div class="dcr-1y2cu33">
+                      <div class="dcr-dbozpd">
+                        <h3 class="dcr-12hccii">
+                          <div class="dcr-1o7trcs">Art</div><span class="show-underline dcr-adlhb4">Channel 4 criticised
+                            over ‘not genuine Banksy’ on The Greatest Auction</span>
+                        </h3>
+                      </div>
+                      <div>
+                        <footer class="dcr-4xb9x1">
+                          <div class="dcr-17yg843"><span class="dcr-1hg1hdu"><span><time
+                                  dateTime="2023-06-12T06:00:12.000Z" data-relativeformat="med">3h
+                                  ago</time></span></span></div>
+                        </footer>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </li>
+            </ul>
+          </li>
+        </ul>
+      </div>
+      <div class="dcr-glvxc9"></div>
+      <div class="dcr-rdw702"></div>
+    </section>
+    
+    <span class="dcr-12r3co1">
+      <div class="ad-slot-container dcr-1uz1ca8">
+        <div id="dfp-ad--inline0--mobile" data-link-name="ad slot inline0" data-name="inline0" aria-hidden="true"
+          class="js-ad-slot ad-slot ad-slot--inline0 ad-slot--container-inline ad-slot--mobile mobile-only ad-slot--rendered dcr-1r4i92e">
+        </div>
+      </div>
+    </span>
+
+    <div class="dcr-4mjixn">
+      <section data-link-name="container-1 | thrasher-preview" data-component="thrasher-preview" data-container-name="fixed/thrasher"
+        id="thrasher-preview" class="dcr-v339xn">
+        <div class="dcr-1ykr3rf">
+          <div class="dcr-tyd89o">
+            <!-- thrasher content sits in this div -->
+            <link rel="stylesheet" type="text/css" href="main.css" />
+            <div
+              id="thrasher__atom"
+              class="thrasher-inner thrasher-atom"
+              data-branch="thrashers/thrasher-atom"
+            >
+            <%= html %>
+            </div>
+          </div>
+          <div>
+            <script>
+              <%= js %>
+            </script>
+          </div>
+        </div>
+      </section>
+    </div>
+    
+    <section id="spotlight" data-link-name="container-2 | spotlight" data-component="spotlight"
+      data-container-name="dynamic/slow" class="dcr-r91ehr">
+      <div class="dcr-b25wgn"></div>
+      <div class="dcr-1kx60rc"><span class="dcr-1n8hb96"></span>
+        <div class="dcr-15t9kli"><span class="dcr-1iz7gbk"></span>
+          <div class="dcr-1atljbz">
+            <h2 class="dcr-eubdc">Spotlight</h2>
+          </div>
+        </div>
+      </div>
+      <div class="dcr-owfrse"><button data-link-name="Hide" data-show-hide-button="spotlight" aria-controls="spotlight"
+          aria-expanded="true" class="dcr-kfs8io">Hide</button></div>
+      <div id="container-spotlight" class="dcr-1lex7d6">
+        <ul class="dcr-1mi5u71">
+          <li class="dcr-w3rkaf">
+            <div class="dcr-1p6anfw"><a href="/world/2023/jun/12/colombia-plane-crash-how-four-siblings-survived-jungle"
+                data-link-name="feature | group-2+ | card-@1"
+                aria-label="How four siblings survived in Colombia’s perilous jungle" class="dcr-pkharf"></a>
+              <div class="dcr-1eb5jgw">
+                <div class="dcr-1pe3pea">
+                  <picture data-size="large" class="dcr-yosj9c">
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/29205209e8b896d60c908cf99823758644d389ec/0_922_3503_2102/master/3503.jpg?width=700&amp;quality=45&amp;dpr=2&amp;s=none"
+                      media="(min-width: 980px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 980px) and (min-resolution: 120dpi)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/29205209e8b896d60c908cf99823758644d389ec/0_922_3503_2102/master/3503.jpg?width=700&amp;quality=85&amp;dpr=1&amp;s=none"
+                      media="(min-width: 980px)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/29205209e8b896d60c908cf99823758644d389ec/0_922_3503_2102/master/3503.jpg?width=500&amp;quality=45&amp;dpr=2&amp;s=none"
+                      media="(min-width: 740px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 740px) and (min-resolution: 120dpi)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/29205209e8b896d60c908cf99823758644d389ec/0_922_3503_2102/master/3503.jpg?width=500&amp;quality=85&amp;dpr=1&amp;s=none"
+                      media="(min-width: 740px)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/29205209e8b896d60c908cf99823758644d389ec/0_922_3503_2102/master/3503.jpg?width=480&amp;quality=45&amp;dpr=2&amp;s=none"
+                      media="(min-width: 480px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 480px) and (min-resolution: 120dpi)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/29205209e8b896d60c908cf99823758644d389ec/0_922_3503_2102/master/3503.jpg?width=480&amp;quality=85&amp;dpr=1&amp;s=none"
+                      media="(min-width: 480px)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/29205209e8b896d60c908cf99823758644d389ec/0_922_3503_2102/master/3503.jpg?width=360&amp;quality=45&amp;dpr=2&amp;s=none"
+                      media="(min-width: 320px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 320px) and (min-resolution: 120dpi)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/29205209e8b896d60c908cf99823758644d389ec/0_922_3503_2102/master/3503.jpg?width=360&amp;quality=85&amp;dpr=1&amp;s=none"
+                      media="(min-width: 320px)" /><img alt
+                      src="https://i.guim.co.uk/img/media/29205209e8b896d60c908cf99823758644d389ec/0_922_3503_2102/master/3503.jpg?width=360&amp;quality=85&amp;dpr=1&amp;s=none"
+                      class="dcr-evn1e9" />
+                  </picture>
+                  <div class="image-overlay"></div>
+                </div>
+                <div class="dcr-rrcudz">
+                  <div class="dcr-dbozpd">
+                    <h3 class="dcr-14gfmlq">
+                      <div class="dcr-1o7trcs">Indigenous knowledge, bravery, vigilance</div><span
+                        class="show-underline dcr-adlhb4">How four siblings survived in Colombia’s perilous
+                        jungle</span>
+                    </h3>
+                  </div>
+                  <div>
+                    <div class="dcr-hcib8t">
+                      <div>Thirteen-year-old Lesly Mukutuy credited with using ancestral knowledge to help keep her
+                        younger siblings alive</div>
+                    </div>
+                    <footer class="dcr-4xb9x1">
+                      <div class="dcr-j8q3ty"></div>
+                    </footer>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </li>
+          <li class="dcr-1cgn3lv">
+            <div class="dcr-1p6anfw"><a
+                href="/society/ng-interactive/2023/jun/12/interactive-tool-that-shows-where-you-can-afford-to-buy-or-rent-home-great-britain"
+                data-link-name="news | group-2 | card-@2"
+                aria-label="Find out where you can afford to buy or rent in Great Britain" class="dcr-pkharf"></a>
+              <div class="dcr-17h8ziz">
+                <div class="dcr-1pb5o7w">
+                  <picture data-size="small" class="dcr-yosj9c">
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/f920ede96247ef10c3403f724f87bac6dbb6fddf/0_0_5000_3000/master/5000.jpg?width=220&amp;quality=45&amp;dpr=2&amp;s=none"
+                      media="(min-width: 980px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 980px) and (min-resolution: 120dpi)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/f920ede96247ef10c3403f724f87bac6dbb6fddf/0_0_5000_3000/master/5000.jpg?width=220&amp;quality=85&amp;dpr=1&amp;s=none"
+                      media="(min-width: 980px)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/f920ede96247ef10c3403f724f87bac6dbb6fddf/0_0_5000_3000/master/5000.jpg?width=160&amp;quality=45&amp;dpr=2&amp;s=none"
+                      media="(min-width: 740px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 740px) and (min-resolution: 120dpi)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/f920ede96247ef10c3403f724f87bac6dbb6fddf/0_0_5000_3000/master/5000.jpg?width=160&amp;quality=85&amp;dpr=1&amp;s=none"
+                      media="(min-width: 740px)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/f920ede96247ef10c3403f724f87bac6dbb6fddf/0_0_5000_3000/master/5000.jpg?width=120&amp;quality=45&amp;dpr=2&amp;s=none"
+                      media="(min-width: 320px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 320px) and (min-resolution: 120dpi)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/f920ede96247ef10c3403f724f87bac6dbb6fddf/0_0_5000_3000/master/5000.jpg?width=120&amp;quality=85&amp;dpr=1&amp;s=none"
+                      media="(min-width: 320px)" /><img alt
+                      src="https://i.guim.co.uk/img/media/f920ede96247ef10c3403f724f87bac6dbb6fddf/0_0_5000_3000/master/5000.jpg?width=120&amp;quality=85&amp;dpr=1&amp;s=none"
+                      class="dcr-evn1e9" />
+                  </picture>
+                  <div class="image-overlay"></div>
+                </div>
+                <div class="dcr-1y2cu33">
+                  <div class="dcr-dbozpd">
+                    <h3 class="dcr-p1dvl6">
+                      <div class="dcr-1o7trcs">Housing</div><span class="show-underline dcr-adlhb4">Find out where you
+                        can afford to buy or rent in Great Britain</span>
+                    </h3>
+                  </div>
+                  <div>
+                    <footer class="dcr-4xb9x1">
+                      <div class="dcr-j8q3ty"></div>
+                    </footer>
+                  </div>
+                </div>
+              </div>
+              <ul class="dcr-kz9nqe">
+                <li class="dcr-1hipxkh">
+                  <h3 class="dcr-wi48h0"><a
+                      href="/society/2023/jun/12/this-is-just-ruinous-the-britons-unable-to-afford-their-homes"
+                      class="dcr-os58m2">
+                      <div class="dcr-ect2dm">‘This is just ruinous’</div><span class="show-underline dcr-adlhb4">The
+                        Britons unable to afford their homes</span>
+                    </a></h3>
+                </li>
+              </ul>
+            </div>
+          </li>
+        </ul>
+        <ul class="dcr-lqxdi4">
+          <li class="dcr-1cgn3lv">
+            <div class="dcr-15p4tz0"><a
+                href="/lifeandstyle/2023/jun/12/a-new-start-after-60-living-moment-veena-torchia-vegan-cafe"
+                data-link-name="feature | group-1 | card-@2"
+                aria-label="I left Britain and opened a cafe in India. I’ve never been happier" class="dcr-pkharf"></a>
+              <div class="dcr-17h8ziz">
+                <div class="dcr-1pb5o7w">
+                  <picture data-size="small" class="dcr-yosj9c">
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/e0399a9fe74f073fe746eb9851c1c7e8ff5d9c6d/0_200_5250_3150/master/5250.jpg?width=220&amp;quality=45&amp;dpr=2&amp;s=none"
+                      media="(min-width: 980px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 980px) and (min-resolution: 120dpi)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/e0399a9fe74f073fe746eb9851c1c7e8ff5d9c6d/0_200_5250_3150/master/5250.jpg?width=220&amp;quality=85&amp;dpr=1&amp;s=none"
+                      media="(min-width: 980px)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/e0399a9fe74f073fe746eb9851c1c7e8ff5d9c6d/0_200_5250_3150/master/5250.jpg?width=160&amp;quality=45&amp;dpr=2&amp;s=none"
+                      media="(min-width: 740px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 740px) and (min-resolution: 120dpi)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/e0399a9fe74f073fe746eb9851c1c7e8ff5d9c6d/0_200_5250_3150/master/5250.jpg?width=160&amp;quality=85&amp;dpr=1&amp;s=none"
+                      media="(min-width: 740px)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/e0399a9fe74f073fe746eb9851c1c7e8ff5d9c6d/0_200_5250_3150/master/5250.jpg?width=120&amp;quality=45&amp;dpr=2&amp;s=none"
+                      media="(min-width: 320px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 320px) and (min-resolution: 120dpi)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/e0399a9fe74f073fe746eb9851c1c7e8ff5d9c6d/0_200_5250_3150/master/5250.jpg?width=120&amp;quality=85&amp;dpr=1&amp;s=none"
+                      media="(min-width: 320px)" /><img alt
+                      src="https://i.guim.co.uk/img/media/e0399a9fe74f073fe746eb9851c1c7e8ff5d9c6d/0_200_5250_3150/master/5250.jpg?width=120&amp;quality=85&amp;dpr=1&amp;s=none"
+                      class="dcr-evn1e9" />
+                  </picture>
+                  <div class="image-overlay"></div>
+                </div>
+                <div class="dcr-1y2cu33">
+                  <div class="dcr-dbozpd">
+                    <h3 class="dcr-p1dvl6">
+                      <div class="dcr-hhyfju">A new start after 60</div><span class="show-underline dcr-adlhb4">I left
+                        Britain and opened a cafe in India. I’ve never been happier</span>
+                    </h3>
+                  </div>
+                  <div>
+                    <div class="dcr-isu8nh">
+                      <div>Veena Torchia always felt like an outsider in London, but found peace when she and her
+                        husband moved to Rajasthan</div>
+                    </div>
+                    <footer class="dcr-4xb9x1">
+                      <div class="dcr-j8q3ty"></div>
+                    </footer>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </li>
+          <li class="dcr-1cgn3lv">
+            <div class="dcr-1p6anfw"><a
+                href="/science/2023/jun/12/the-pleasure-principle-is-a-little-bit-of-indulgence-the-secret-to-success"
+                data-link-name="feature | group-1 | card-@1"
+                aria-label="Is a little bit of indulgence the secret to success?" class="dcr-pkharf"></a>
+              <div class="dcr-17h8ziz">
+                <div class="dcr-1pb5o7w">
+                  <picture data-size="small" class="dcr-yosj9c">
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/dac60de2bbed6709c7884d84875b28fb1ac26810/0_0_5000_3000/master/5000.jpg?width=220&amp;quality=45&amp;dpr=2&amp;s=none"
+                      media="(min-width: 980px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 980px) and (min-resolution: 120dpi)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/dac60de2bbed6709c7884d84875b28fb1ac26810/0_0_5000_3000/master/5000.jpg?width=220&amp;quality=85&amp;dpr=1&amp;s=none"
+                      media="(min-width: 980px)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/dac60de2bbed6709c7884d84875b28fb1ac26810/0_0_5000_3000/master/5000.jpg?width=160&amp;quality=45&amp;dpr=2&amp;s=none"
+                      media="(min-width: 740px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 740px) and (min-resolution: 120dpi)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/dac60de2bbed6709c7884d84875b28fb1ac26810/0_0_5000_3000/master/5000.jpg?width=160&amp;quality=85&amp;dpr=1&amp;s=none"
+                      media="(min-width: 740px)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/dac60de2bbed6709c7884d84875b28fb1ac26810/0_0_5000_3000/master/5000.jpg?width=120&amp;quality=45&amp;dpr=2&amp;s=none"
+                      media="(min-width: 320px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 320px) and (min-resolution: 120dpi)" />
+                    <source
+                      srcSet="https://i.guim.co.uk/img/media/dac60de2bbed6709c7884d84875b28fb1ac26810/0_0_5000_3000/master/5000.jpg?width=120&amp;quality=85&amp;dpr=1&amp;s=none"
+                      media="(min-width: 320px)" /><img alt
+                      src="https://i.guim.co.uk/img/media/dac60de2bbed6709c7884d84875b28fb1ac26810/0_0_5000_3000/master/5000.jpg?width=120&amp;quality=85&amp;dpr=1&amp;s=none"
+                      class="dcr-evn1e9" />
+                  </picture>
+                  <div class="image-overlay"></div>
+                </div>
+                <div class="dcr-1y2cu33">
+                  <div class="dcr-dbozpd">
+                    <h3 class="dcr-p1dvl6">
+                      <div class="dcr-1o7trcs">The pleasure principle</div><span class="show-underline dcr-adlhb4">Is a
+                        little bit of indulgence the secret to success?</span>
+                    </h3>
+                  </div>
+                  <div>
+                    <div class="dcr-isu8nh">
+                      <div>The latest research shows delayed gratification is not always a guarantee of wellbeing –
+                        carefully planned moments of pleasure can be hugely beneficial</div>
+                    </div>
+                    <footer class="dcr-4xb9x1">
+                      <div class="dcr-j8q3ty"></div>
+                    </footer>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </li>
+          <li class="dcr-16fqzm2">
+            <ul class="dcr-y4cf8a">
+              <li class="dcr-1izbchs">
+                <div class="dcr-1pscgow"><a href="/culture/2023/jun/12/cultural-prescription-keeping-cool"
+                    data-link-name="news | group-0 | card-@1"
+                    aria-label="Music, books, stage and more to keep you cool in a heatwave" class="dcr-pkharf"></a>
+                  <div class="dcr-3tss6n">
+                    <div class="dcr-1e7l74i">
+                      <picture data-size="small" class="dcr-yosj9c">
+                        <source
+                          srcSet="https://i.guim.co.uk/img/media/500f47295383e46e0e4dc335330033497849f3c7/0_392_2717_1630/master/2717.jpg?width=220&amp;quality=45&amp;dpr=2&amp;s=none"
+                          media="(min-width: 980px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 980px) and (min-resolution: 120dpi)" />
+                        <source
+                          srcSet="https://i.guim.co.uk/img/media/500f47295383e46e0e4dc335330033497849f3c7/0_392_2717_1630/master/2717.jpg?width=220&amp;quality=85&amp;dpr=1&amp;s=none"
+                          media="(min-width: 980px)" />
+                        <source
+                          srcSet="https://i.guim.co.uk/img/media/500f47295383e46e0e4dc335330033497849f3c7/0_392_2717_1630/master/2717.jpg?width=160&amp;quality=45&amp;dpr=2&amp;s=none"
+                          media="(min-width: 740px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 740px) and (min-resolution: 120dpi)" />
+                        <source
+                          srcSet="https://i.guim.co.uk/img/media/500f47295383e46e0e4dc335330033497849f3c7/0_392_2717_1630/master/2717.jpg?width=160&amp;quality=85&amp;dpr=1&amp;s=none"
+                          media="(min-width: 740px)" />
+                        <source
+                          srcSet="https://i.guim.co.uk/img/media/500f47295383e46e0e4dc335330033497849f3c7/0_392_2717_1630/master/2717.jpg?width=120&amp;quality=45&amp;dpr=2&amp;s=none"
+                          media="(min-width: 320px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 320px) and (min-resolution: 120dpi)" />
+                        <source
+                          srcSet="https://i.guim.co.uk/img/media/500f47295383e46e0e4dc335330033497849f3c7/0_392_2717_1630/master/2717.jpg?width=120&amp;quality=85&amp;dpr=1&amp;s=none"
+                          media="(min-width: 320px)" /><img alt
+                          src="https://i.guim.co.uk/img/media/500f47295383e46e0e4dc335330033497849f3c7/0_392_2717_1630/master/2717.jpg?width=120&amp;quality=85&amp;dpr=1&amp;s=none"
+                          class="dcr-evn1e9" />
+                      </picture>
+                      <div class="image-overlay"></div>
+                    </div>
+                    <div class="dcr-awenke">
+                      <div class="dcr-dbozpd">
+                        <h3 class="dcr-12hccii">
+                          <div class="dcr-1i3wv16">Hot in here</div><span class="show-underline dcr-adlhb4">Music,
+                            books, stage and more to keep you cool in a heatwave</span>
+                        </h3>
+                      </div>
+                      <div>
+                        <footer class="dcr-4xb9x1">
+                          <div class="dcr-j8q3ty"><a data-discussion-id="/p/z48eg"
+                              data-format="{&quot;display&quot;:0,&quot;theme&quot;:3,&quot;design&quot;:0}"
+                              data-ignore="global-link-styling" data-link-name="Comment count"
+                              href="/culture/2023/jun/12/cultural-prescription-keeping-cool#comments"
+                              class="dcr-1xir693"></a></div>
+                        </footer>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </li>
+              <li class="dcr-1izbchs">
+                <div class="dcr-1p6anfw"><a
+                    href="/society/2023/jun/12/its-been-called-a-vitality-meter-what-your-grip-says-about-your-health-and-how-you-can-improve-it"
+                    data-link-name="feature | group-0 | card-@2"
+                    aria-label="What your grip says about your health – and how you can improve it"
+                    class="dcr-pkharf"></a>
+                  <div class="dcr-3tss6n">
+                    <div class="dcr-1e7l74i">
+                      <picture data-size="small" class="dcr-yosj9c">
+                        <source
+                          srcSet="https://i.guim.co.uk/img/media/9d9b11f9c6804565a5a198712d76c4c2020968af/0_226_5760_3456/master/5760.jpg?width=220&amp;quality=45&amp;dpr=2&amp;s=none"
+                          media="(min-width: 980px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 980px) and (min-resolution: 120dpi)" />
+                        <source
+                          srcSet="https://i.guim.co.uk/img/media/9d9b11f9c6804565a5a198712d76c4c2020968af/0_226_5760_3456/master/5760.jpg?width=220&amp;quality=85&amp;dpr=1&amp;s=none"
+                          media="(min-width: 980px)" />
+                        <source
+                          srcSet="https://i.guim.co.uk/img/media/9d9b11f9c6804565a5a198712d76c4c2020968af/0_226_5760_3456/master/5760.jpg?width=160&amp;quality=45&amp;dpr=2&amp;s=none"
+                          media="(min-width: 740px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 740px) and (min-resolution: 120dpi)" />
+                        <source
+                          srcSet="https://i.guim.co.uk/img/media/9d9b11f9c6804565a5a198712d76c4c2020968af/0_226_5760_3456/master/5760.jpg?width=160&amp;quality=85&amp;dpr=1&amp;s=none"
+                          media="(min-width: 740px)" />
+                        <source
+                          srcSet="https://i.guim.co.uk/img/media/9d9b11f9c6804565a5a198712d76c4c2020968af/0_226_5760_3456/master/5760.jpg?width=120&amp;quality=45&amp;dpr=2&amp;s=none"
+                          media="(min-width: 320px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 320px) and (min-resolution: 120dpi)" />
+                        <source
+                          srcSet="https://i.guim.co.uk/img/media/9d9b11f9c6804565a5a198712d76c4c2020968af/0_226_5760_3456/master/5760.jpg?width=120&amp;quality=85&amp;dpr=1&amp;s=none"
+                          media="(min-width: 320px)" /><img alt
+                          src="https://i.guim.co.uk/img/media/9d9b11f9c6804565a5a198712d76c4c2020968af/0_226_5760_3456/master/5760.jpg?width=120&amp;quality=85&amp;dpr=1&amp;s=none"
+                          class="dcr-evn1e9" />
+                      </picture>
+                      <div class="image-overlay"></div>
+                    </div>
+                    <div class="dcr-awenke">
+                      <div class="dcr-dbozpd">
+                        <h3 class="dcr-12hccii">
+                          <div class="dcr-1o7trcs">‘Vitality meter!’</div><span class="show-underline dcr-adlhb4">What
+                            your grip says about your health – and how you can improve it</span>
+                        </h3>
+                      </div>
+                      <div>
+                        <footer class="dcr-4xb9x1">
+                          <div class="dcr-j8q3ty"><a data-discussion-id="/p/nqk3j"
+                              data-format="{&quot;display&quot;:0,&quot;theme&quot;:0,&quot;design&quot;:9}"
+                              data-ignore="global-link-styling" data-link-name="Comment count"
+                              href="/society/2023/jun/12/its-been-called-a-vitality-meter-what-your-grip-says-about-your-health-and-how-you-can-improve-it#comments"
+                              class="dcr-1xir693"></a></div>
+                        </footer>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </li>
+              <li class="dcr-1izbchs">
+                <div class="dcr-1pscgow"><a
+                    href="/tv-and-radio/2023/jun/12/bridgerton-queen-charlotte-race-black-fantasies-king-george"
+                    data-link-name="feature | group-0 | card-@3"
+                    aria-label="The real problem with the show’s Black fantasy" class="dcr-pkharf"></a>
+                  <div class="dcr-3tss6n">
+                    <div class="dcr-1e7l74i">
+                      <picture data-size="small" class="dcr-yosj9c">
+                        <source
+                          srcSet="https://i.guim.co.uk/img/media/57c9c90435f72ccfbedf6196082d5c867c0531a0/721_213_2378_1427/master/2378.jpg?width=220&amp;quality=45&amp;dpr=2&amp;s=none"
+                          media="(min-width: 980px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 980px) and (min-resolution: 120dpi)" />
+                        <source
+                          srcSet="https://i.guim.co.uk/img/media/57c9c90435f72ccfbedf6196082d5c867c0531a0/721_213_2378_1427/master/2378.jpg?width=220&amp;quality=85&amp;dpr=1&amp;s=none"
+                          media="(min-width: 980px)" />
+                        <source
+                          srcSet="https://i.guim.co.uk/img/media/57c9c90435f72ccfbedf6196082d5c867c0531a0/721_213_2378_1427/master/2378.jpg?width=160&amp;quality=45&amp;dpr=2&amp;s=none"
+                          media="(min-width: 740px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 740px) and (min-resolution: 120dpi)" />
+                        <source
+                          srcSet="https://i.guim.co.uk/img/media/57c9c90435f72ccfbedf6196082d5c867c0531a0/721_213_2378_1427/master/2378.jpg?width=160&amp;quality=85&amp;dpr=1&amp;s=none"
+                          media="(min-width: 740px)" />
+                        <source
+                          srcSet="https://i.guim.co.uk/img/media/57c9c90435f72ccfbedf6196082d5c867c0531a0/721_213_2378_1427/master/2378.jpg?width=120&amp;quality=45&amp;dpr=2&amp;s=none"
+                          media="(min-width: 320px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 320px) and (min-resolution: 120dpi)" />
+                        <source
+                          srcSet="https://i.guim.co.uk/img/media/57c9c90435f72ccfbedf6196082d5c867c0531a0/721_213_2378_1427/master/2378.jpg?width=120&amp;quality=85&amp;dpr=1&amp;s=none"
+                          media="(min-width: 320px)" /><img alt
+                          src="https://i.guim.co.uk/img/media/57c9c90435f72ccfbedf6196082d5c867c0531a0/721_213_2378_1427/master/2378.jpg?width=120&amp;quality=85&amp;dpr=1&amp;s=none"
+                          class="dcr-evn1e9" />
+                      </picture>
+                      <div class="image-overlay"></div>
+                    </div>
+                    <div class="dcr-awenke">
+                      <div class="dcr-dbozpd">
+                        <h3 class="dcr-12hccii">
+                          <div class="dcr-1i3wv16">‘Why is Bridgerton’s race twisting acceptable?’</div><span
+                            class="show-underline dcr-adlhb4">The real problem with the show’s Black fantasy</span>
+                        </h3>
+                      </div>
+                      <div>
+                        <footer class="dcr-4xb9x1">
+                          <div class="dcr-j8q3ty"></div>
+                        </footer>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </li>
+              <li class="dcr-1izbchs">
+                <div class="dcr-15p4tz0"><a
+                    href="/travel/2023/jun/12/britains-10-most-popular-walks-according-to-the-os-map-app"
+                    data-link-name="feature | group-0 | card-@4" aria-label="According to the OS map app"
+                    class="dcr-pkharf"></a>
+                  <div class="dcr-3tss6n">
+                    <div class="dcr-1e7l74i">
+                      <picture data-size="small" class="dcr-yosj9c">
+                        <source
+                          srcSet="https://i.guim.co.uk/img/media/306da98048c8b1be4863dae13541082005b7b16b/0_161_4816_2890/master/4816.jpg?width=220&amp;quality=45&amp;dpr=2&amp;s=none"
+                          media="(min-width: 980px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 980px) and (min-resolution: 120dpi)" />
+                        <source
+                          srcSet="https://i.guim.co.uk/img/media/306da98048c8b1be4863dae13541082005b7b16b/0_161_4816_2890/master/4816.jpg?width=220&amp;quality=85&amp;dpr=1&amp;s=none"
+                          media="(min-width: 980px)" />
+                        <source
+                          srcSet="https://i.guim.co.uk/img/media/306da98048c8b1be4863dae13541082005b7b16b/0_161_4816_2890/master/4816.jpg?width=160&amp;quality=45&amp;dpr=2&amp;s=none"
+                          media="(min-width: 740px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 740px) and (min-resolution: 120dpi)" />
+                        <source
+                          srcSet="https://i.guim.co.uk/img/media/306da98048c8b1be4863dae13541082005b7b16b/0_161_4816_2890/master/4816.jpg?width=160&amp;quality=85&amp;dpr=1&amp;s=none"
+                          media="(min-width: 740px)" />
+                        <source
+                          srcSet="https://i.guim.co.uk/img/media/306da98048c8b1be4863dae13541082005b7b16b/0_161_4816_2890/master/4816.jpg?width=120&amp;quality=45&amp;dpr=2&amp;s=none"
+                          media="(min-width: 320px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: 320px) and (min-resolution: 120dpi)" />
+                        <source
+                          srcSet="https://i.guim.co.uk/img/media/306da98048c8b1be4863dae13541082005b7b16b/0_161_4816_2890/master/4816.jpg?width=120&amp;quality=85&amp;dpr=1&amp;s=none"
+                          media="(min-width: 320px)" /><img alt
+                          src="https://i.guim.co.uk/img/media/306da98048c8b1be4863dae13541082005b7b16b/0_161_4816_2890/master/4816.jpg?width=120&amp;quality=85&amp;dpr=1&amp;s=none"
+                          class="dcr-evn1e9" />
+                      </picture>
+                      <div class="image-overlay"></div>
+                    </div>
+                    <div class="dcr-awenke">
+                      <div class="dcr-dbozpd">
+                        <h3 class="dcr-12hccii">
+                          <div class="dcr-hhyfju">Britain’s 10 most popular walks</div><span
+                            class="show-underline dcr-adlhb4">According to the OS map app</span>
+                        </h3>
+                      </div>
+                      <div>
+                        <footer class="dcr-4xb9x1">
+                          <div class="dcr-j8q3ty"></div>
+                        </footer>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </li>
+            </ul>
+          </li>
+        </ul>
+      </div>
+      <div class="dcr-glvxc9"></div>
+      <div class="dcr-rdw702">
+        <ul class="dcr-1mbvac">
+          <li><a href="/crosswords"><svg viewBox="0, 0, 106, 106" width="106px" height="106px">
+                <rect x="0" y="0" fill="#000000" width="106" height="106"></rect>
+                <rect x="16" y="61" width="14" height="14" fill="#ffffff"></rect>
+                <rect x="61" y="1" width="14" height="14" fill="#ffffff"></rect>
+                <rect x="91" y="46" width="14" height="14" fill="#ffffff"></rect>
+                <rect x="1" y="61" width="14" height="14" fill="#ffffff"></rect>
+                <rect x="61" y="31" width="14" height="14" fill="#ffffff"></rect>
+                <rect x="46" y="91" width="14" height="14" fill="#ffffff"></rect>
+                <rect x="1" y="46" width="14" height="14" fill="#ffffff"></rect>
+                <rect x="76" y="1" width="14" height="14" fill="#ffffff"></rect>
+                <rect x="61" y="46" width="14" height="14" fill="#ffffff"></rect>
+                <rect x="46" y="31" width="14" height="14" fill="#ffffff"></rect>
+                <rect x="31" y="91" width="14" height="14" fill="#ffffff"></rect>
+                <rect x="31" y="46" width="14" height="14" fill="#ffffff"></rect>
+                <rect x="76" y="61" width="14" height="14" fill="#ffffff"></rect>
+                <rect x="1" y="76" width="14" height="14" fill="#ffffff"></rect>
+                <rect x="91" y="31" width="14" height="14" fill="#ffffff"></rect>
+                <rect x="31" y="31" width="14" height="14" fill="#ffffff"></rect>
+                <rect x="1" y="31" width="14" height="14" fill="#ffffff"></rect>
+                <rect x="31" y="61" width="14" height="14" fill="#ffffff"></rect>
+                <rect x="31" y="16" width="14" height="14" fill="#ffffff"></rect>
+                <rect x="61" y="16" width="14" height="14" fill="#ffffff"></rect>
+                <rect x="91" y="76" width="14" height="14" fill="#ffffff"></rect>
+                <rect x="91" y="16" width="14" height="14" fill="#ffffff"></rect>
+                <rect x="16" y="91" width="14" height="14" fill="#ffffff"></rect>
+                <rect x="61" y="91" width="14" height="14" fill="#ffffff"></rect>
+                <rect x="91" y="1" width="14" height="14" fill="#ffffff"></rect>
+                <rect x="1" y="91" width="14" height="14" fill="#ffffff"></rect>
+                <rect x="46" y="61" width="14" height="14" fill="#ffffff"></rect>
+                <rect x="76" y="91" width="14" height="14" fill="#ffffff"></rect>
+                <rect x="31" y="1" width="14" height="14" fill="#ffffff"></rect>
+                <rect x="91" y="61" width="14" height="14" fill="#ffffff"></rect>
+                <rect x="46" y="1" width="14" height="14" fill="#ffffff"></rect>
+                <rect x="1" y="16" width="14" height="14" fill="#ffffff"></rect>
+                <rect x="16" y="31" width="14" height="14" fill="#ffffff"></rect>
+                <rect x="61" y="61" width="14" height="14" fill="#ffffff"></rect>
+                <rect x="61" y="76" width="14" height="14" fill="#ffffff"></rect>
+                <rect x="91" y="91" width="14" height="14" fill="#ffffff"></rect>
+              </svg></a></li>
+          <li class="dcr-109rq7o"><a subdued href="/crosswords" class="dcr-3tlap1">Crosswords</a></li>
+        </ul>
+      </div>
+    </section>
+  </main>
+  <section class="dcr-v339xn">
+    <div class="dcr-1v397f0">
+      <div data-link-name="keywords" class="dcr-1hy529c"><svg xmlns="http://www.w3.org/2000/svg" width="100%"
+          height="13" viewBox="0 0 1300 13" preserveAspectRatio="none" stroke="#DCDCDC" stroke-width="1"
+          aria-hidden="true" focusable="false" class="dcr-kammsl">
+          <line x1="0" x2="1300" y1="0.5" y2="0.5"></line>
+          <line x1="0" x2="1300" y1="4.5" y2="4.5"></line>
+          <line x1="0" x2="1300" y1="8.5" y2="8.5"></line>
+          <line x1="0" x2="1300" y1="12.5" y2="12.5"></line>
+        </svg>
+        <div class="dcr-c4kygy">Topics</div><a href="https://www.theguardian.com/world/europe-news"
+          data-link-name="keyword: /world/europe-news" class="dcr-91lgpk">Europe</a><a
+          href="https://www.theguardian.com/world/ukraine" data-link-name="keyword: /world/ukraine"
+          class="dcr-91lgpk">Ukraine</a><a href="https://www.theguardian.com/politics/boris-johnson"
+          data-link-name="keyword: /politics/boris-johnson" class="dcr-91lgpk">Boris Johnson</a><a
+          href="https://www.theguardian.com/politics/conservatives" data-link-name="keyword: /politics/conservatives"
+          class="dcr-91lgpk">Conservatives</a><a href="https://www.theguardian.com/society/health"
+          data-link-name="keyword: /society/health" class="dcr-91lgpk">Health</a>
+      </div>
+    </div>
+  </section>
+  <aside class="dcr-nosp2s">
+    <div class="dcr-1ykr3rf">
+      <div class="ad-slot-container dcr-10hq5cq">
+        <div id="dfp-ad--merchandising" data-link-name="ad slot merchandising" data-name="merchandising"
+          aria-hidden="true" class="js-ad-slot ad-slot ad-slot--merchandising dcr-5zzwsk"></div>
+      </div>
+    </div>
+  </aside>
+  <aside class="dcr-v339xn">
+    <div class="dcr-188zz3t"><gu-island name="SubNav" deferUntil="visible"
+        props="{&quot;subNavSections&quot;:{&quot;links&quot;:[{&quot;title&quot;:&quot;UK&quot;,&quot;longTitle&quot;:&quot;UK news&quot;,&quot;url&quot;:&quot;/uk-news&quot;,&quot;children&quot;:[{&quot;title&quot;:&quot;UK politics&quot;,&quot;longTitle&quot;:&quot;UK politics&quot;,&quot;url&quot;:&quot;/politics&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Education&quot;,&quot;longTitle&quot;:&quot;Education&quot;,&quot;url&quot;:&quot;/education&quot;,&quot;children&quot;:[{&quot;title&quot;:&quot;Schools&quot;,&quot;longTitle&quot;:&quot;Schools&quot;,&quot;url&quot;:&quot;/education/schools&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Teachers&quot;,&quot;longTitle&quot;:&quot;Teachers&quot;,&quot;url&quot;:&quot;/teacher-network&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Universities&quot;,&quot;longTitle&quot;:&quot;Universities&quot;,&quot;url&quot;:&quot;/education/universities&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Students&quot;,&quot;longTitle&quot;:&quot;Students&quot;,&quot;url&quot;:&quot;/education/students&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false}],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Media&quot;,&quot;longTitle&quot;:&quot;Media&quot;,&quot;url&quot;:&quot;/media&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Society&quot;,&quot;longTitle&quot;:&quot;Society&quot;,&quot;url&quot;:&quot;/society&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Law&quot;,&quot;longTitle&quot;:&quot;Law&quot;,&quot;url&quot;:&quot;/law&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Scotland&quot;,&quot;longTitle&quot;:&quot;Scotland&quot;,&quot;url&quot;:&quot;/uk/scotland&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Wales&quot;,&quot;longTitle&quot;:&quot;Wales&quot;,&quot;url&quot;:&quot;/uk/wales&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Northern Ireland&quot;,&quot;longTitle&quot;:&quot;Northern Ireland&quot;,&quot;url&quot;:&quot;/uk/northernireland&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false}],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;World&quot;,&quot;longTitle&quot;:&quot;World news&quot;,&quot;url&quot;:&quot;/world&quot;,&quot;children&quot;:[{&quot;title&quot;:&quot;Europe&quot;,&quot;longTitle&quot;:&quot;Europe&quot;,&quot;url&quot;:&quot;/world/europe-news&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;US&quot;,&quot;longTitle&quot;:&quot;US news&quot;,&quot;url&quot;:&quot;/us-news&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Americas&quot;,&quot;longTitle&quot;:&quot;Americas&quot;,&quot;url&quot;:&quot;/world/americas&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Asia&quot;,&quot;longTitle&quot;:&quot;Asia&quot;,&quot;url&quot;:&quot;/world/asia&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Australia&quot;,&quot;longTitle&quot;:&quot;Australia news&quot;,&quot;url&quot;:&quot;/australia-news&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Middle East&quot;,&quot;longTitle&quot;:&quot;Middle East&quot;,&quot;url&quot;:&quot;/world/middleeast&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Africa&quot;,&quot;longTitle&quot;:&quot;Africa&quot;,&quot;url&quot;:&quot;/world/africa&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Inequality&quot;,&quot;longTitle&quot;:&quot;Inequality&quot;,&quot;url&quot;:&quot;/inequality&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Global development&quot;,&quot;longTitle&quot;:&quot;Global development&quot;,&quot;url&quot;:&quot;/global-development&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false}],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Climate crisis&quot;,&quot;longTitle&quot;:&quot;Climate crisis&quot;,&quot;url&quot;:&quot;/environment/climate-crisis&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Newsletters&quot;,&quot;longTitle&quot;:&quot;Newsletters&quot;,&quot;url&quot;:&quot;/email-newsletters&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Football&quot;,&quot;longTitle&quot;:&quot;Football&quot;,&quot;url&quot;:&quot;/football&quot;,&quot;children&quot;:[{&quot;title&quot;:&quot;Live scores&quot;,&quot;longTitle&quot;:&quot;football/live&quot;,&quot;url&quot;:&quot;/football/live&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Tables&quot;,&quot;longTitle&quot;:&quot;football/tables&quot;,&quot;url&quot;:&quot;/football/tables&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Fixtures&quot;,&quot;longTitle&quot;:&quot;football/fixtures&quot;,&quot;url&quot;:&quot;/football/fixtures&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Results&quot;,&quot;longTitle&quot;:&quot;football/results&quot;,&quot;url&quot;:&quot;/football/results&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Competitions&quot;,&quot;longTitle&quot;:&quot;football/competitions&quot;,&quot;url&quot;:&quot;/football/competitions&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Clubs&quot;,&quot;longTitle&quot;:&quot;football/teams&quot;,&quot;url&quot;:&quot;/football/teams&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false}],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Coronavirus&quot;,&quot;longTitle&quot;:&quot;Coronavirus&quot;,&quot;url&quot;:&quot;/world/coronavirus-outbreak&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Business&quot;,&quot;longTitle&quot;:&quot;Business&quot;,&quot;url&quot;:&quot;/business&quot;,&quot;children&quot;:[{&quot;title&quot;:&quot;Economics&quot;,&quot;longTitle&quot;:&quot;Economics&quot;,&quot;url&quot;:&quot;/business/economics&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Banking&quot;,&quot;longTitle&quot;:&quot;Banking&quot;,&quot;url&quot;:&quot;/business/banking&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Money&quot;,&quot;longTitle&quot;:&quot;Money&quot;,&quot;url&quot;:&quot;/money&quot;,&quot;children&quot;:[{&quot;title&quot;:&quot;Property&quot;,&quot;longTitle&quot;:&quot;Property&quot;,&quot;url&quot;:&quot;/money/property&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Pensions&quot;,&quot;longTitle&quot;:&quot;Pensions&quot;,&quot;url&quot;:&quot;/money/pensions&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Savings&quot;,&quot;longTitle&quot;:&quot;Savings&quot;,&quot;url&quot;:&quot;/money/savings&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Borrowing&quot;,&quot;longTitle&quot;:&quot;Borrowing&quot;,&quot;url&quot;:&quot;/money/debt&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Careers&quot;,&quot;longTitle&quot;:&quot;Careers&quot;,&quot;url&quot;:&quot;/money/work-and-careers&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false}],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Markets&quot;,&quot;longTitle&quot;:&quot;Markets&quot;,&quot;url&quot;:&quot;/business/stock-markets&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Project Syndicate&quot;,&quot;longTitle&quot;:&quot;Project Syndicate&quot;,&quot;url&quot;:&quot;/business/series/project-syndicate-economists&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;B2B&quot;,&quot;longTitle&quot;:&quot;B2B&quot;,&quot;url&quot;:&quot;/business-to-business&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Retail&quot;,&quot;longTitle&quot;:&quot;Retail&quot;,&quot;url&quot;:&quot;/business/retail&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false}],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Environment&quot;,&quot;longTitle&quot;:&quot;Environment&quot;,&quot;url&quot;:&quot;/environment&quot;,&quot;children&quot;:[{&quot;title&quot;:&quot;Climate crisis&quot;,&quot;longTitle&quot;:&quot;Climate crisis&quot;,&quot;url&quot;:&quot;/environment/climate-crisis&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Wildlife&quot;,&quot;longTitle&quot;:&quot;Wildlife&quot;,&quot;url&quot;:&quot;/environment/wildlife&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Energy&quot;,&quot;longTitle&quot;:&quot;Energy&quot;,&quot;url&quot;:&quot;/environment/energy&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Pollution&quot;,&quot;longTitle&quot;:&quot;Pollution&quot;,&quot;url&quot;:&quot;/environment/pollution&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false}],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;UK politics&quot;,&quot;longTitle&quot;:&quot;UK politics&quot;,&quot;url&quot;:&quot;/politics&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Education&quot;,&quot;longTitle&quot;:&quot;Education&quot;,&quot;url&quot;:&quot;/education&quot;,&quot;children&quot;:[{&quot;title&quot;:&quot;Schools&quot;,&quot;longTitle&quot;:&quot;Schools&quot;,&quot;url&quot;:&quot;/education/schools&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Teachers&quot;,&quot;longTitle&quot;:&quot;Teachers&quot;,&quot;url&quot;:&quot;/teacher-network&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Universities&quot;,&quot;longTitle&quot;:&quot;Universities&quot;,&quot;url&quot;:&quot;/education/universities&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Students&quot;,&quot;longTitle&quot;:&quot;Students&quot;,&quot;url&quot;:&quot;/education/students&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false}],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Society&quot;,&quot;longTitle&quot;:&quot;Society&quot;,&quot;url&quot;:&quot;/society&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Science&quot;,&quot;longTitle&quot;:&quot;Science&quot;,&quot;url&quot;:&quot;/science&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Tech&quot;,&quot;longTitle&quot;:&quot;Tech&quot;,&quot;url&quot;:&quot;/technology&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Global development&quot;,&quot;longTitle&quot;:&quot;Global development&quot;,&quot;url&quot;:&quot;/global-development&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false},{&quot;title&quot;:&quot;Obituaries&quot;,&quot;longTitle&quot;:&quot;Obituaries&quot;,&quot;url&quot;:&quot;/obituaries&quot;,&quot;children&quot;:[],&quot;mobileOnly&quot;:false}]},&quot;currentNavLink&quot;:&quot;News&quot;,&quot;format&quot;:{&quot;display&quot;:0,&quot;design&quot;:0,&quot;theme&quot;:0}}">
+        <div data-print-layout="hide" data-cy="sub-nav" data-component="sub-nav" class="dcr-v6jxf0">
+          <ul role="list" class="dcr-1gt8egs">
+            <li><a data-src-focus-disabled="true" href="/uk-news" data-link-name="nav2 : subnav : uk-news"
+                class="dcr-qo5392">UK</a></li>
+            <li><a data-src-focus-disabled="true" href="/world" data-link-name="nav2 : subnav : world"
+                class="dcr-qo5392">World</a></li>
+            <li><a data-src-focus-disabled="true" href="/environment/climate-crisis"
+                data-link-name="nav2 : subnav : environment/climate-crisis" class="dcr-qo5392">Climate crisis</a></li>
+            <li><a data-src-focus-disabled="true" href="/email-newsletters"
+                data-link-name="nav2 : subnav : email-newsletters" class="dcr-qo5392">Newsletters</a></li>
+            <li><a data-src-focus-disabled="true" href="/football" data-link-name="nav2 : subnav : football"
+                class="dcr-qo5392">Football</a></li>
+            <li><a data-src-focus-disabled="true" href="/world/coronavirus-outbreak"
+                data-link-name="nav2 : subnav : world/coronavirus-outbreak" class="dcr-qo5392">Coronavirus</a></li>
+            <li><a data-src-focus-disabled="true" href="/business" data-link-name="nav2 : subnav : business"
+                class="dcr-qo5392">Business</a></li>
+            <li><a data-src-focus-disabled="true" href="/environment" data-link-name="nav2 : subnav : environment"
+                class="dcr-qo5392">Environment</a></li>
+            <li><a data-src-focus-disabled="true" href="/politics" data-link-name="nav2 : subnav : politics"
+                class="dcr-qo5392">UK politics</a></li>
+            <li><a data-src-focus-disabled="true" href="/education" data-link-name="nav2 : subnav : education"
+                class="dcr-qo5392">Education</a></li>
+            <li><a data-src-focus-disabled="true" href="/society" data-link-name="nav2 : subnav : society"
+                class="dcr-qo5392">Society</a></li>
+            <li><a data-src-focus-disabled="true" href="/science" data-link-name="nav2 : subnav : science"
+                class="dcr-qo5392">Science</a></li>
+            <li><a data-src-focus-disabled="true" href="/technology" data-link-name="nav2 : subnav : technology"
+                class="dcr-qo5392">Tech</a></li>
+            <li><a data-src-focus-disabled="true" href="/global-development"
+                data-link-name="nav2 : subnav : global-development" class="dcr-qo5392">Global development</a></li>
+            <li data-chromatic="ignore"><a data-src-focus-disabled="true" href="/obituaries"
+                data-link-name="nav2 : subnav : obituaries" class="dcr-qo5392">Obituaries</a></li>
+          </ul>
+        </div>
+      </gu-island></div>
+  </aside>
+  <footer class="dcr-1uyetce">
+    <div class="dcr-1ykr3rf">
+      <div data-print-layout="hide" data-link-name="footer" data-component="footer" class="dcr-10rqwzg">
+        <div class="dcr-1w2x6ij">
+          <ul data-testid="pillar-list" class="dcr-1ikbe4v">
+            <li class="dcr-1aeyz4o"><a href="/" data-link-name="footer : primary : News" class="dcr-11rhxc6">News</a>
+            </li>
+            <li class="dcr-1aeyz4o"><a href="/commentisfree" data-link-name="footer : primary : Opinion"
+                class="dcr-yqz51q">Opinion</a></li>
+            <li class="dcr-1aeyz4o"><a href="/sport" data-link-name="footer : primary : Sport"
+                class="dcr-1dijbt5">Sport</a></li>
+            <li class="dcr-1aeyz4o"><a href="/culture" data-link-name="footer : primary : Culture"
+                class="dcr-qjynpy">Culture</a></li>
+            <li class="dcr-1aeyz4o"><a href="/lifeandstyle" data-link-name="footer : primary : Lifestyle"
+                class="dcr-1vrrbyb">Lifestyle</a></li>
+          </ul>
+        </div>
+        <div class="dcr-1xyi04h">
+          <div class="dcr-1wf840d">
+            <div>Original reporting and incisive analysis, direct from the Guardian every morning</div><a
+              href="https://www.theguardian.com/global/2022/sep/20/sign-up-for-the-first-edition-newsletter-our-free-news-email"
+              data-link-name="footer : morning-briefing" class="dcr-1creg26">Sign up for our email<div
+                class="src-button-space"></div><svg viewBox="-3 -3 30 30" xmlns="http://www.w3.org/2000/svg"
+                aria-hidden="true">
+                <path fill-rule="evenodd" clip-rule="evenodd"
+                  d="M1 12.956h18.274l-7.167 8.575.932.932L23 12.478v-.956l-9.96-9.985-.932.932 7.166 8.575H1v1.912Z">
+                </path>
+              </svg></a>
+          </div>
+          <div class="dcr-ygowzy">
+            <ul>
+              <li><a href="/about" data-link-name="uk : footer : about us" class="dcr-5hi9qv">About us</a></li>
+              <li><a href="/help" data-link-name="uk : footer : tech feedback" class="dcr-sts64">Help</a></li>
+              <li><a href="/info/complaints-and-corrections" data-link-name="complaints" class="dcr-5hi9qv">Complaints
+                  &amp; corrections</a></li>
+              <li><a href="https://www.theguardian.com/securedrop" data-link-name="securedrop"
+                  class="dcr-5hi9qv">SecureDrop</a></li>
+              <li><a href="https://workforus.theguardian.com" data-link-name="uk : footer : work for us"
+                  class="dcr-5hi9qv">Work for us</a></li>
+              <li><a href="/info/privacy" data-link-name="privacy" class="dcr-5hi9qv">Privacy policy</a></li>
+              <li><a href="/info/cookies" data-link-name="cookie" class="dcr-5hi9qv">Cookie policy</a></li>
+              <li><a href="/help/terms-of-service" data-link-name="terms" class="dcr-5hi9qv">Terms &amp; conditions</a>
+              </li>
+              <li><a href="/help/contact-us" data-link-name="uk : footer : contact us" class="dcr-5hi9qv">Contact us</a>
+              </li>
+            </ul>
+            <ul>
+              <li><a href="/index/subjects/a" data-link-name="uk : footer : all topics" class="dcr-5hi9qv">All
+                  topics</a></li>
+              <li><a href="/index/contributors" data-link-name="uk : footer : all contributors" class="dcr-5hi9qv">All
+                  writers</a></li>
+              <li><a href="https://uploads.guim.co.uk/2022/07/20/STL_Modern_Slavery_Statement_2022.pdf"
+                  data-link-name="uk : footer : modern slavery act statement" class="dcr-5hi9qv">Modern Slavery Act</a>
+              </li>
+              <li><a href="https://theguardian.newspapers.com" data-link-name="digital newspaper archive"
+                  class="dcr-5hi9qv">Digital newspaper archive</a></li>
+              <li><a href="https://www.facebook.com/theguardian" data-link-name="uk : footer : facebook"
+                  class="dcr-5hi9qv">Facebook</a></li>
+              <li><a href="https://www.youtube.com/user/TheGuardian" data-link-name="uk : footer : youtube"
+                  class="dcr-5hi9qv">YouTube</a></li>
+              <li><a href="https://www.instagram.com/guardian" data-link-name="uk : footer : instagram"
+                  class="dcr-5hi9qv">Instagram</a></li>
+              <li><a href="https://www.linkedin.com/company/theguardian" data-link-name="uk : footer : linkedin"
+                  class="dcr-5hi9qv">LinkedIn</a></li>
+              <li><a href="https://twitter.com/guardian" data-link-name="uk: footer : twitter"
+                  class="dcr-5hi9qv">Twitter</a></li>
+              <li><a href="/email-newsletters?INTCMP=DOTCOM_FOOTER_NEWSLETTER_UK"
+                  data-link-name="uk : footer : newsletters" class="dcr-5hi9qv">Newsletters</a></li>
+            </ul>
+            <ul>
+              <li><a href="https://advertising.theguardian.com" data-link-name="uk : footer : advertise with us"
+                  class="dcr-5hi9qv">Advertise with us</a></li>
+              <li><a href="/guardian-labs" data-link-name="uk : footer : guardian labs" class="dcr-5hi9qv">Guardian
+                  Labs</a></li>
+              <li><a href="https://jobs.theguardian.com" data-link-name="uk : footer : jobs" class="dcr-5hi9qv">Search
+                  jobs</a></li>
+              <li><a href="https://patrons.theguardian.com?INTCMP=footer_patrons" data-link-name="uk : footer : patrons"
+                  class="dcr-5hi9qv">Patrons</a></li>
+            </ul>
+            <div class="dcr-1g9k069"><gu-island name="ReaderRevenueLinks" deferUntil="visible"
+                props="{&quot;urls&quot;:{&quot;contribute&quot;:&quot;https://support.theguardian.com/contribute?INTCMP=header_support_contribute&amp;acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22header_support_contribute%22%7D&quot;,&quot;subscribe&quot;:&quot;https://support.theguardian.com/subscribe?INTCMP=header_support_subscribe&amp;acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22header_support_subscribe%22%7D&quot;,&quot;support&quot;:&quot;https://support.theguardian.com?INTCMP=header_support&amp;acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22header_support%22%7D&quot;,&quot;supporter&quot;:&quot;https://support.theguardian.com/subscribe?INTCMP=header_supporter_cta&amp;acquisitionData=%7B%22source%22:%22GUARDIAN_WEB%22,%22componentType%22:%22ACQUISITIONS_HEADER%22,%22componentId%22:%22header_supporter_cta%22%7D&quot;},&quot;editionId&quot;:&quot;UK&quot;,&quot;dataLinkNamePrefix&quot;:&quot;footer : &quot;,&quot;inHeader&quot;:false,&quot;remoteHeader&quot;:false,&quot;contributionsServiceUrl&quot;:&quot;https://contributions.guardianapis.com&quot;}"
+                clientOnly></gu-island></div>
+          </div>
+          <div class="dcr-1xnlu54"><a href="#top" class="dcr-1bljy3y"><span class="dcr-4rr662">Back to top</span><span
+                class="icon-container dcr-18yycfp"><i class="dcr-13lm9u3"></i></span></a></div>
+        </div>
+        <div class="dcr-1qbs42f">© 2023 Guardian News &amp; Media Limited or its affiliated companies. All rights
+          reserved. (modern)</div>
+      </div>
+    </div>
+  </footer>
+  <!-- no recipe markup -->
+</body>
+
 </html>

--- a/harness/index.html
+++ b/harness/index.html
@@ -133,9 +133,11 @@
     <div class="atoms">
         <h2>Thrasher containers</h2>
         <a href="./front-football-header.html">Web: football weekly front</a>
+        <a href="./front-uk.html">Frontend: UK front</a>
+        <a href="./dcr-front-uk.html">DCR: UK front</a>
         <a href="./front-football.html">Web: football front</a>
+        <a href="./dcr-front-football.html">DCR: Football front</a>
         <a href="./webview.html">Android front webview</a>
-
         <h2>Snaps</h2>
         <a href="./interactive.html">Interactive</a>
         <a href="./immersive.html">Immersive interactive</a>

--- a/shared/css/_football.scss
+++ b/shared/css/_football.scss
@@ -153,6 +153,7 @@ $textColor: #121212;
             border-radius:17px;
             transition:color 0.3s ease-in-out, background-color 0.3s ease-in-out;
             margin-right:4px;
+            color:inherit;
             &:hover {
                 background-color:#ffffff;
                 text-decoration: none;


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

**! Note: I could not test or deploy this as there are problems with gulp**

## What does this change?

Explicitly inherits text colour on the buttons for the thrasher, preventing them defaulting to the default browser link colour

## How to test

Add the thrasher to a front on code e.g. https://m.code.dev-theguardian.com/football and compare results using the `?dcr` query param
