### PR TITLE
Thrashers/multi newsletter 1  set27

### DIFF
--- a/atoms/set-27/client/css/main.scss
+++ b/atoms/set-27/client/css/main.scss
@@ -1,0 +1,11 @@
+@import "_mq";
+@import "_fonts";
+@import "_palette";
+@import "_app-fonts";
+@import "_mixins";
+
+
+$thrasherId: thrasher__multi-newsletter-27;
+@import "../../../../multi-thrasher-shared/css/basics";
+@import "../../../../multi-thrasher-shared/css/newsletter-card";
+@import "../../../../multi-thrasher-shared/css/thrasher";

--- a/atoms/set-27/client/js/app.js
+++ b/atoms/set-27/client/js/app.js
@@ -1,0 +1,144 @@
+function trackLoad() {
+  window.guardian.ophan.record({
+    component: "thrasher : multi-newsletter-1 : load",
+    value: 1,
+  });
+}
+window.trackLoad = trackLoad;
+
+function initCardSections() {
+  var thrashersWithCardSections = [
+    ...document.querySelectorAll('[data-role="multi-thrasher-with-cards"]'),
+  ];
+
+  thrashersWithCardSections.forEach(function (thrasher) {
+    if (thrasher.getAttribute("data-card-section-initialised") === "true") {
+      return;
+    }
+    var lastScrollCheckTime = 0;
+    var lastButtonClickTime = 0
+    var cardHolder = thrasher.querySelector(
+      '[data-role="multi-thrasher-card-holder"]'
+    );
+
+    if (!cardHolder) {
+      return;
+    }
+
+    var leftButtons = [
+      ...thrasher.querySelectorAll(
+        '[data-role="multi-thrasher-scroll-left-button"]'
+      ),
+    ];
+    var rightButtons = [
+      ...thrasher.querySelectorAll(
+        '[data-role="multi-thrasher-scroll-right-button"]'
+      ),
+    ];
+
+    function getScrollDistance() {
+      return cardHolder.children[0].offsetWidth + 20;
+    }
+
+    function setDisabled(intendedPosition) {
+      if (intendedPosition <= 0) {
+        leftButtons.forEach(function (button) {
+          button.setAttribute("disabled", "true");
+        });
+      } else {
+        leftButtons.forEach(function (button) {
+          button.removeAttribute("disabled");
+        });
+      }
+
+      if (intendedPosition + cardHolder.offsetWidth >= cardHolder.scrollWidth) {
+        rightButtons.forEach(function (button) {
+          button.setAttribute("disabled", "true");
+        });
+      } else {
+        rightButtons.forEach(function (button) {
+          button.removeAttribute("disabled");
+        });
+      }
+    }
+    function scrollLeft() {
+      var intendedPosition = cardHolder.scrollLeft - getScrollDistance();
+      lastButtonClickTime = Date.now()
+      cardHolder.scrollTo({
+        left: intendedPosition,
+        top: 0,
+        behavior: "smooth",
+      });
+      setDisabled(intendedPosition);
+    }
+    function scrollRight() {
+      var intendedPosition = cardHolder.scrollLeft + getScrollDistance();
+      lastButtonClickTime = Date.now()
+      cardHolder.scrollTo({
+        left: intendedPosition,
+        top: 0,
+        behavior: "smooth",
+      });
+      setDisabled(intendedPosition);
+    }
+
+    function throttledSetDisabled(event) {
+      var now = Date.now();
+      var sinceLastCheck = now - lastScrollCheckTime
+      var sinceLastButtonClick = now - lastButtonClickTime
+
+      if (sinceLastCheck > 100 && sinceLastButtonClick > 2000) {
+        lastScrollCheckTime = now;
+        window.setTimeout(function() {
+          setDisabled(cardHolder.scrollLeft)
+        }, 100)
+      }
+    }
+
+    window.addEventListener("resize", function () {
+      setDisabled(cardHolder.scrollLeft);
+    });
+    leftButtons.forEach(function (button) {
+      button.addEventListener("click", scrollLeft);
+    });
+    rightButtons.forEach(function (button) {
+      button.addEventListener("click", scrollRight);
+    });
+    cardHolder.addEventListener("scroll", throttledSetDisabled);
+    setDisabled(0);
+    thrasher.setAttribute("data-card-section-initialised", "true");
+  });
+}
+
+function invertColorOnIframeResultPages(event) {
+  if (!event.data.subject || event.data.subject !== "emailEmbedPageLoaded") {
+    return;
+  }
+  if (!event.data.path || typeof event.data.path !== "string") {
+    return;
+  }
+  if (
+    !event.data.path.startsWith("/email/error") &&
+    !event.data.path.startsWith("/email/success")
+  ) {
+    return;
+  }
+  if (event.origin !== window.origin) {
+    console.warn('emailEmbedPageLoaded received from wrong origin:', event.origin)
+    return;
+  }
+  var iframesOnDarkBackgrounds = [
+    ...document.querySelectorAll(
+      ".newsletter-card__iframe-wrapper iframe.invert-colors"
+    ),
+  ];
+
+  iframesOnDarkBackgrounds.forEach(function (iframe) {
+    if (iframe.contentWindow === event.source) {
+      iframe.style.filter = "invert(1)";
+    }
+  });
+}
+
+window.addEventListener("message", invertColorOnIframeResultPages, false);
+initCardSections();

--- a/atoms/set-27/client/js/main.js
+++ b/atoms/set-27/client/js/main.js
@@ -1,0 +1,34 @@
+var el = document.createElement('script');
+el.src = '<%= atomPath %>/app.js';
+document.body.appendChild(el);
+
+if (window.resize) {
+  const html = document.querySelector('html')
+  const body = document.querySelector('body')
+
+  html.style.overflow = 'hidden'
+  html.style.margin = '0px'
+  html.style.padding = '0px'
+
+  body.style.overflow = 'hidden'
+  body.style.margin = '0px'
+  body.style.padding = '0px'
+}
+
+if (
+  window.frameElement &&
+  window.frameElement.classList.contains("interactive-atom-fence")
+) {
+  var embedhtml = document.querySelector("html");
+  var embedbody = document.querySelector("body");
+  embedbody.classList.add("ge-liveblog");
+  embedhtml.style.overflow = "hidden";
+  embedhtml.style.padding = "0";
+  embedhtml.style.margin = "0";
+  embedbody.style.overflow = "hidden";
+  embedbody.style.padding = "0";
+  embedbody.style.margin = "0";
+  setTimeout(() => {
+    window.resize();
+  }, 100);
+}

--- a/atoms/set-27/info.csv
+++ b/atoms/set-27/info.csv
@@ -1,0 +1,1 @@
+Morning Mail,Afternoon Update,Five Great Reads

--- a/atoms/set-27/server/render.js
+++ b/atoms/set-27/server/render.js
@@ -1,0 +1,5 @@
+import mainHTML from "./atoms/set-27/server/templates/main.html!text"
+
+export async function render() {
+    return mainHTML;
+} 

--- a/atoms/set-27/server/templates/main.html
+++ b/atoms/set-27/server/templates/main.html
@@ -1,0 +1,282 @@
+<!-- thrasher content sits in this div -->
+<div
+  id="thrasher__multi-newsletter-27"
+  class="thrasher-inner multi-thrasher"
+  data-branch="thrashers/multi-newsletter-1"
+>
+  <main class="multi-thrasher__layout" data-role="multi-thrasher-with-cards">
+    <aside class="multi-thrasher__aside">
+      <img
+        class="multi-thrasher__aside-image"
+        src="<%= path %>/the-guardian-newsletters.png"
+        alt="The Guardian Newsletters logo"
+        height="22.3"
+        width="150"
+      />
+      <a
+        class="multi-thrasher__aside-link"
+        href="https://www.theguardian.com/email-newsletters"
+        >Explore all newsletters</a
+      >
+    </aside>
+
+    <div class="multi-thrasher__inner">
+      <section class="multi-thrasher__section multi-thrasher__section--cards">
+        <div
+          class="multi-thrasher__card-holder"
+          data-role="multi-thrasher-card-holder"
+        >
+          <!-- swift notes -->
+          <article
+            class="newsletter-card"
+            style="background-color: #eb322f; color: #fff"
+          >
+            <h2 class="newsletter-card__title">Swift Notes</h2>
+
+            <div class="newsletter-card__inner">
+              <img
+                class="newsletter-card__image"
+                src="<%= path %>/swift-notes-square.jpg"
+                alt="Swift notes newsletter image"
+                height="100"
+                width="100"
+              />
+              <div class="newsletter-card__content">
+                <div class="newsletter-card__frequency-block">
+                  <svg
+                    width="25"
+                    height="25"
+                    viewBox="0 0 25 25"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <rect width="25" height="25" rx="12.5" fill="#FFE500" />
+                    <path
+                      fill-rule="evenodd"
+                      clip-rule="evenodd"
+                      d="M16.8077 6H8.19231V9.69231H6.69781L5.73077 10.7376L11.8553 15.6154H13.1447L19.2692 10.7376L18.3022 9.69231H16.8077V6ZM15.5769 9.69231V9.07692H9.42308V9.69231H15.5769ZM15.5769 7.23077H9.42308V7.84615H15.5769V7.23077ZM5.73077 18.0769V12.2308L11.8553 16.5385H13.1447L19.2692 12.2308V18.0769L18.3022 19H6.69781L5.73077 18.0769ZM9.42308 10.9231H15.5769V11.5385H9.42308V10.9231Z"
+                      fill="#121212"
+                    />
+                  </svg>
+                  <span> Weekly </span>
+                </div>
+                <p class="newsletter-card__description">
+                  Your ticket to Taylor-world – new music, the UK leg of the
+                  Eras tour, her influence on the football field and the US
+                  presidential elections
+                </p>
+              </div>
+            </div>
+
+            <div class="newsletter-card__iframe-wrapper element-embed">
+              <iframe
+                src="https://www.theguardian.com/email/form/thrasher/swift-notes"
+                height="60"
+                data-form-title="Sign up for Swift Notes"
+                data-form-description="Your ticket to Taylor-world – new music, the UK leg of the Eras tour, her influence on the football field and the US presidential elections"
+                data-form-campaign-code="swiftnotes_email"
+                scrolling="no"
+                seamless=""
+                frameborder="0"
+                class="iframed--overflow-hidden email-sub__iframe js-email-sub__iframe js-email-sub__iframe--article invert-colors"
+                data-form-success-desc="Subscription confirmed. We&#x27;ll send you Swift Notes weekly"
+                title="Sign up for Swift Notes"
+              ></iframe>
+            </div>
+          </article>
+
+          <!-- Well Actually -->
+          <article
+            class="newsletter-card"
+            style="background-color: #7DB8EA; color: #fff"
+          >
+            <h2 class="newsletter-card__title">Well Actually</h2>
+
+            <div class="newsletter-card__inner">
+              <img
+                class="newsletter-card__image"
+                src="https://uploads.guim.co.uk/2024/03/07/wellness-square.png"
+                alt="Well Actually newsletter image"
+                height="100"
+                width="100"
+              />
+              <div class="newsletter-card__content">
+                <div class="newsletter-card__frequency-block">
+                  <svg
+                    width="25"
+                    height="25"
+                    viewBox="0 0 25 25"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <rect width="25" height="25" rx="12.5" fill="#FFE500" />
+                    <path
+                      fill-rule="evenodd"
+                      clip-rule="evenodd"
+                      d="M16.8077 6H8.19231V9.69231H6.69781L5.73077 10.7376L11.8553 15.6154H13.1447L19.2692 10.7376L18.3022 9.69231H16.8077V6ZM15.5769 9.69231V9.07692H9.42308V9.69231H15.5769ZM15.5769 7.23077H9.42308V7.84615H15.5769V7.23077ZM5.73077 18.0769V12.2308L11.8553 16.5385H13.1447L19.2692 12.2308V18.0769L18.3022 19H6.69781L5.73077 18.0769ZM9.42308 10.9231H15.5769V11.5385H9.42308V10.9231Z"
+                      fill="#121212"
+                    />
+                  </svg>
+                  <span> Weekly </span>
+                </div>
+                <p class="newsletter-card__description">
+                  Practical advice, expert insights and answers to your questions about how to live a good life
+                </p>
+              </div>
+            </div>
+
+            <div class="newsletter-card__iframe-wrapper element-embed">
+              <iframe
+                src="https://www.theguardian.com/email/form/thrasher/6039"
+                height="60"
+                data-form-title="Sign up for Well Actually"
+                data-form-description="Practical advice, expert insights and answers to your questions about how to live a good life"
+                data-form-campaign-code="wellactually_email"
+                scrolling="no"
+                seamless=""
+                frameborder="0"
+                class="iframed--overflow-hidden email-sub__iframe js-email-sub__iframe js-email-sub__iframe--article"
+                data-form-success-desc="Subscription confirmed. We&#x27;ll send you Well Actually weekly"
+                title="Sign up for Well Actually: A free weekly newsletter about health and wellness"
+              ></iframe>
+            </div>
+          </article>
+
+          <!-- Trump on Trial -->
+          <article
+            class="newsletter-card"
+            style="background-color: #660505; color: #fff"
+          >
+            <h2 class="newsletter-card__title">Trump on Trial</h2>
+
+            <div class="newsletter-card__inner">
+              <img
+                class="newsletter-card__image"
+                src="https://uploads.guim.co.uk/2024/01/05/Trump_Court_Newsletter_v2_SQUARE.jpg"
+                alt="The Trump on trail newsletter image"
+                height="100"
+                width="100"
+              />
+              <div class="newsletter-card__content">
+                <div class="newsletter-card__frequency-block">
+                  <svg
+                    width="25"
+                    height="25"
+                    viewBox="0 0 25 25"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <rect width="25" height="25" rx="12.5" fill="#FFE500" />
+                    <path
+                      fill-rule="evenodd"
+                      clip-rule="evenodd"
+                      d="M16.8077 6H8.19231V9.69231H6.69781L5.73077 10.7376L11.8553 15.6154H13.1447L19.2692 10.7376L18.3022 9.69231H16.8077V6ZM15.5769 9.69231V9.07692H9.42308V9.69231H15.5769ZM15.5769 7.23077H9.42308V7.84615H15.5769V7.23077ZM5.73077 18.0769V12.2308L11.8553 16.5385H13.1447L19.2692 12.2308V18.0769L18.3022 19H6.69781L5.73077 18.0769ZM9.42308 10.9231H15.5769V11.5385H9.42308V10.9231Z"
+                      fill="#121212"
+                    />
+                  </svg>
+                  <span> Daily during trials </span>
+                </div>
+                <p class="newsletter-card__description">
+                  Get all the latest updates from court as Trump faces several
+                  criminal cases, starting later this year.
+                </p>
+              </div>
+            </div>
+
+            <div class="newsletter-card__iframe-wrapper element-embed">
+              <iframe
+                src="https://www.theguardian.com/email/form/thrasher/6032"
+                height="60"
+                data-form-title="Sign up for Trump on Trial"
+                data-form-description="Get all the latest updates from court as Trump faces several criminal cases, starting later this year."
+                data-form-campaign-code="trumpontrial_email"
+                scrolling="no"
+                seamless=""
+                frameborder="0"
+                class="iframed--overflow-hidden email-sub__iframe js-email-sub__iframe js-email-sub__iframe--article"
+                data-form-success-desc="Subscription confirmed. We&#x27;ll send you Trump on Trial daily during trials"
+                title="Sign up for Trump on Trial"
+              ></iframe>
+            </div>
+          </article>
+        </div>
+        <button
+          data-role="multi-thrasher-scroll-left-button"
+          aria-label="scroll newsletters left"
+          class="multi-thrasher__scroll-button multi-thrasher__scroll-button--left-desktop"
+        >
+          <svg
+            width="18"
+            height="18"
+            viewBox="0 0 18 18"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              fill-rule="evenodd"
+              clip-rule="evenodd"
+              d="M12.541 0.75L4.6875 8.60355V9.39645L12.541 17.25L13.2773 16.5326L6.9907 9L13.2773 1.46739L12.541 0.75Z"
+              fill="white"
+            />
+          </svg>
+        </button>
+        <button
+          data-role="multi-thrasher-scroll-right-button"
+          aria-label="scroll newsletters right"
+          class="multi-thrasher__scroll-button multi-thrasher__scroll-button--right-desktop"
+        >
+          <svg
+            width="10"
+            height="18"
+            viewBox="0 0 10 18"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              fill-rule="evenodd"
+              clip-rule="evenodd"
+              d="M1.42377 0.75L0.6875 1.46739L6.97411 9L0.6875 16.5326L1.42377 17.25L9.27732 9.39645V8.60355L1.42377 0.75Z"
+              fill="white"
+            />
+          </svg>
+        </button>
+      </section>
+      <section class="multi-thrasher__section multi-thrasher__section--privacy">
+        <aside class="multi-thrasher__privacy">
+          <p>
+            <b>Privacy Notice:</b> Newsletters may contain info about charities,
+            online ads, and content funded by outside parties. For more
+            information click here for
+            <a target="_blank" href="/help/privacy-policy">our privacy policy</a
+            >. <br />We operate Google reCAPTCHA to protect our website and the
+            <a
+              href="https://policies.google.com/privacy"
+              target="_blank"
+              aria-label="google's privacy policy"
+              >Google Privacy Policy</a
+            >
+            and
+            <a
+              href="https://policies.google.com/terms"
+              target="_blank"
+              aria-label="google's terms of service"
+              >Terms of Service</a
+            >
+            apply.
+          </p>
+        </aside>
+      </section>
+      <section
+        class="multi-thrasher__section multi-thrasher__section--mobile-footer"
+      >
+        <img
+          class="multi-thrasher__footer-image"
+          src="<%= path %>/the-guardian-newsletters.png"
+          alt="The Guardian Newsletters logo"
+          height="22.3"
+          width="70"
+        />
+      </section>
+    </div>
+  </main>
+</div>

--- a/atoms/set-27/server/templates/main.html
+++ b/atoms/set-27/server/templates/main.html
@@ -26,18 +26,134 @@
           class="multi-thrasher__card-holder"
           data-role="multi-thrasher-card-holder"
         >
-          <!-- swift notes -->
+          <!-- Morning Mail -->
           <article
             class="newsletter-card"
-            style="background-color: #eb322f; color: #fff"
+            style="background-color: #c1d8fc; color: #000"
           >
-            <h2 class="newsletter-card__title">Swift Notes</h2>
+            <h2 class="newsletter-card__title">Morning Mail</h2>
 
             <div class="newsletter-card__inner">
               <img
                 class="newsletter-card__image"
-                src="<%= path %>/swift-notes-square.jpg"
-                alt="Swift notes newsletter image"
+                src="<%= path %>/morning-mail-square.png"
+                alt="Morning Mail newsletter image"
+                height="100"
+                width="100"
+              />
+              <div class="newsletter-card__content">
+                <div class="newsletter-card__frequency-block">
+                  <svg
+                    width="25"
+                    height="25"
+                    viewBox="0 0 25 25"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <rect width="25" height="25" rx="12.5" fill="#FFE500" />
+                    <path
+                      fill-rule="evenodd"
+                      clip-rule="evenodd"
+                      d="M16.8077 6H8.19231V9.69231H6.69781L5.73077 10.7376L11.8553 15.6154H13.1447L19.2692 10.7376L18.3022 9.69231H16.8077V6ZM15.5769 9.69231V9.07692H9.42308V9.69231H15.5769ZM15.5769 7.23077H9.42308V7.84615H15.5769V7.23077ZM5.73077 18.0769V12.2308L11.8553 16.5385H13.1447L19.2692 12.2308V18.0769L18.3022 19H6.69781L5.73077 18.0769ZM9.42308 10.9231H15.5769V11.5385H9.42308V10.9231Z"
+                      fill="#121212"
+                    />
+                  </svg>
+                  <span> Every weekday </span>
+                </div>
+                <p class="newsletter-card__description">
+                  Start your day with a breakdown of the key stories and why
+                  they matter
+                </p>
+              </div>
+            </div>
+
+            <div class="newsletter-card__iframe-wrapper element-embed">
+              <iframe
+                src="https://www.theguardian.com/email/form/thrasher/4148"
+                height="60"
+                data-form-title="Sign up for Morning Mail"
+                data-form-description="Start your day with a breakdown of the key stories and why they matter"
+                data-form-campaign-code="morningmailau_email"
+                scrolling="no"
+                seamless=""
+                frameborder="0"
+                class="iframed--overflow-hidden email-sub__iframe js-email-sub__iframe js-email-sub__iframe--article"
+                data-form-success-desc="We&#x27;ll send you Guardian Australia's Morning Mail every weekday"
+                title="Sign up for Moring Mail"
+              ></iframe>
+            </div>
+          </article>
+
+          <!-- Afternoon Update-->
+          <article
+            class="newsletter-card"
+            style="background-color: #f9b376; color: #000"
+          >
+            <h2 class="newsletter-card__title">Afternoon Update</h2>
+
+            <div class="newsletter-card__inner">
+              <img
+                class="newsletter-card__image"
+                src="<%= path %>/afternoon-update-square.png"
+                alt="Afternoon Update newsletter image"
+                height="100"
+                width="100"
+              />
+              <div class="newsletter-card__content">
+                <div class="newsletter-card__frequency-block">
+                  <svg
+                    width="25"
+                    height="25"
+                    viewBox="0 0 25 25"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <rect width="25" height="25" rx="12.5" fill="#FFE500" />
+                    <path
+                      fill-rule="evenodd"
+                      clip-rule="evenodd"
+                      d="M16.8077 6H8.19231V9.69231H6.69781L5.73077 10.7376L11.8553 15.6154H13.1447L19.2692 10.7376L18.3022 9.69231H16.8077V6ZM15.5769 9.69231V9.07692H9.42308V9.69231H15.5769ZM15.5769 7.23077H9.42308V7.84615H15.5769V7.23077ZM5.73077 18.0769V12.2308L11.8553 16.5385H13.1447L19.2692 12.2308V18.0769L18.3022 19H6.69781L5.73077 18.0769ZM9.42308 10.9231H15.5769V11.5385H9.42308V10.9231Z"
+                      fill="#121212"
+                    />
+                  </svg>
+                  <span> Every weekday </span>
+                </div>
+                <p class="newsletter-card__description">
+                  Finish your day with a three-minute roundup of the stories
+                  that matter
+                </p>
+              </div>
+            </div>
+
+            <div class="newsletter-card__iframe-wrapper element-embed">
+              <iframe
+                src="https://www.theguardian.com/email/form/thrasher/6023"
+                height="60"
+                data-form-title="Sign up for Afternoon Update"
+                data-form-description="Finish your day with a three-minute roundup of the stories that matter"
+                data-form-campaign-code="afternoonupdateau_email "
+                scrolling="no"
+                seamless=""
+                frameborder="0"
+                class="iframed--overflow-hidden email-sub__iframe js-email-sub__iframe js-email-sub__iframe--article"
+                data-form-success-desc="We&#x27;ll send you Afternoon Update every weekday"
+                title="Sign up for Afternoon Update"
+              ></iframe>
+            </div>
+          </article>
+
+          <!-- Five Great Reads -->
+          <article
+            class="newsletter-card"
+            style="background-color: #fec8d3; color: #000"
+          >
+            <h2 class="newsletter-card__title">Five Great Reads</h2>
+
+            <div class="newsletter-card__inner">
+              <img
+                class="newsletter-card__image"
+                src="<%= path %>/five-great-reads-square-new.png"
+                alt="Five Great Reads newsletter image"
                 height="100"
                 width="100"
               />
@@ -61,141 +177,25 @@
                   <span> Weekly </span>
                 </div>
                 <p class="newsletter-card__description">
-                  Your ticket to Taylor-world – new music, the UK leg of the
-                  Eras tour, her influence on the football field and the US
-                  presidential elections
+                  Enjoy the weekend with five essential, immersive reads from
+                  across the world
                 </p>
               </div>
             </div>
 
             <div class="newsletter-card__iframe-wrapper element-embed">
               <iframe
-                src="https://www.theguardian.com/email/form/thrasher/swift-notes"
+                src="https://www.theguardian.com/email/form/thrasher/6019"
                 height="60"
-                data-form-title="Sign up for Swift Notes"
-                data-form-description="Your ticket to Taylor-world – new music, the UK leg of the Eras tour, her influence on the football field and the US presidential elections"
-                data-form-campaign-code="swiftnotes_email"
-                scrolling="no"
-                seamless=""
-                frameborder="0"
-                class="iframed--overflow-hidden email-sub__iframe js-email-sub__iframe js-email-sub__iframe--article invert-colors"
-                data-form-success-desc="Subscription confirmed. We&#x27;ll send you Swift Notes weekly"
-                title="Sign up for Swift Notes"
-              ></iframe>
-            </div>
-          </article>
-
-          <!-- Well Actually -->
-          <article
-            class="newsletter-card"
-            style="background-color: #7DB8EA; color: #fff"
-          >
-            <h2 class="newsletter-card__title">Well Actually</h2>
-
-            <div class="newsletter-card__inner">
-              <img
-                class="newsletter-card__image"
-                src="https://uploads.guim.co.uk/2024/03/07/wellness-square.png"
-                alt="Well Actually newsletter image"
-                height="100"
-                width="100"
-              />
-              <div class="newsletter-card__content">
-                <div class="newsletter-card__frequency-block">
-                  <svg
-                    width="25"
-                    height="25"
-                    viewBox="0 0 25 25"
-                    fill="none"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <rect width="25" height="25" rx="12.5" fill="#FFE500" />
-                    <path
-                      fill-rule="evenodd"
-                      clip-rule="evenodd"
-                      d="M16.8077 6H8.19231V9.69231H6.69781L5.73077 10.7376L11.8553 15.6154H13.1447L19.2692 10.7376L18.3022 9.69231H16.8077V6ZM15.5769 9.69231V9.07692H9.42308V9.69231H15.5769ZM15.5769 7.23077H9.42308V7.84615H15.5769V7.23077ZM5.73077 18.0769V12.2308L11.8553 16.5385H13.1447L19.2692 12.2308V18.0769L18.3022 19H6.69781L5.73077 18.0769ZM9.42308 10.9231H15.5769V11.5385H9.42308V10.9231Z"
-                      fill="#121212"
-                    />
-                  </svg>
-                  <span> Weekly </span>
-                </div>
-                <p class="newsletter-card__description">
-                  Practical advice, expert insights and answers to your questions about how to live a good life
-                </p>
-              </div>
-            </div>
-
-            <div class="newsletter-card__iframe-wrapper element-embed">
-              <iframe
-                src="https://www.theguardian.com/email/form/thrasher/6039"
-                height="60"
-                data-form-title="Sign up for Well Actually"
-                data-form-description="Practical advice, expert insights and answers to your questions about how to live a good life"
-                data-form-campaign-code="wellactually_email"
+                data-form-title="Sign up for Five Great Reads"
+                data-form-description="Enjoy the weekend with five essential, immersive reads from across the world"
+                data-form-campaign-code="fivegreatrules_email "
                 scrolling="no"
                 seamless=""
                 frameborder="0"
                 class="iframed--overflow-hidden email-sub__iframe js-email-sub__iframe js-email-sub__iframe--article"
-                data-form-success-desc="Subscription confirmed. We&#x27;ll send you Well Actually weekly"
-                title="Sign up for Well Actually: A free weekly newsletter about health and wellness"
-              ></iframe>
-            </div>
-          </article>
-
-          <!-- Trump on Trial -->
-          <article
-            class="newsletter-card"
-            style="background-color: #660505; color: #fff"
-          >
-            <h2 class="newsletter-card__title">Trump on Trial</h2>
-
-            <div class="newsletter-card__inner">
-              <img
-                class="newsletter-card__image"
-                src="https://uploads.guim.co.uk/2024/01/05/Trump_Court_Newsletter_v2_SQUARE.jpg"
-                alt="The Trump on trail newsletter image"
-                height="100"
-                width="100"
-              />
-              <div class="newsletter-card__content">
-                <div class="newsletter-card__frequency-block">
-                  <svg
-                    width="25"
-                    height="25"
-                    viewBox="0 0 25 25"
-                    fill="none"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <rect width="25" height="25" rx="12.5" fill="#FFE500" />
-                    <path
-                      fill-rule="evenodd"
-                      clip-rule="evenodd"
-                      d="M16.8077 6H8.19231V9.69231H6.69781L5.73077 10.7376L11.8553 15.6154H13.1447L19.2692 10.7376L18.3022 9.69231H16.8077V6ZM15.5769 9.69231V9.07692H9.42308V9.69231H15.5769ZM15.5769 7.23077H9.42308V7.84615H15.5769V7.23077ZM5.73077 18.0769V12.2308L11.8553 16.5385H13.1447L19.2692 12.2308V18.0769L18.3022 19H6.69781L5.73077 18.0769ZM9.42308 10.9231H15.5769V11.5385H9.42308V10.9231Z"
-                      fill="#121212"
-                    />
-                  </svg>
-                  <span> Daily during trials </span>
-                </div>
-                <p class="newsletter-card__description">
-                  Get all the latest updates from court as Trump faces several
-                  criminal cases, starting later this year.
-                </p>
-              </div>
-            </div>
-
-            <div class="newsletter-card__iframe-wrapper element-embed">
-              <iframe
-                src="https://www.theguardian.com/email/form/thrasher/6032"
-                height="60"
-                data-form-title="Sign up for Trump on Trial"
-                data-form-description="Get all the latest updates from court as Trump faces several criminal cases, starting later this year."
-                data-form-campaign-code="trumpontrial_email"
-                scrolling="no"
-                seamless=""
-                frameborder="0"
-                class="iframed--overflow-hidden email-sub__iframe js-email-sub__iframe js-email-sub__iframe--article"
-                data-form-success-desc="Subscription confirmed. We&#x27;ll send you Trump on Trial daily during trials"
-                title="Sign up for Trump on Trial"
+                data-form-success-desc="We&#x27;ll send you Five Great Reads every week"
+                title="Sign up for Five Great Reads"
               ></iframe>
             </div>
           </article>

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -259,8 +259,14 @@ const upload = () => {
 
 const getAtoms = () => (fs.readdirSync(".build")).filter(n => n !== "assets" && n !== "index.html")
 
-const url = (cb) => {
+const sortBySetNumber = (nameA, nameB) => {
+  if (nameA.startsWith("set-") && nameB.startsWith("set-")) {
+    return Number(nameA.substring(4)) < Number(nameB.substring(4)) ? -1:1
+  }
+  return nameA < nameB ? -1:1
+}
 
+const url = (cb) => {
   const readInfoFile = (atomName) => {
     const path = `./atoms/${atomName}/info.csv`
     try {
@@ -271,7 +277,7 @@ const url = (cb) => {
     }
   }
 
-  const atoms = getAtoms();
+  const atoms = getAtoms().sort(sortBySetNumber);
 
   atoms.forEach(atom => {
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
fixes a niggle in `gulp url` to sort the atoms in numerical order.

adds set 27 - Morning Mail,Afternoon Update,Five Great Reads


## Images
<img width="1391" alt="Screenshot 2024-04-11 at 16 58 32" src="https://github.com/guardian/interactive-atom-thrasher-template/assets/30567854/bee6c1b2-fac8-45a5-a2ae-e86c3fe41d8c">


