### PR TITLE
Fix Wordiply thrasher on apps

### DIFF
--- a/atoms/default/client/css/main.scss
+++ b/atoms/default/client/css/main.scss
@@ -543,7 +543,7 @@ $tertiary: #f1c8e0;
     padding: 0;
     margin: 0;
     .secret-podcast-2022 {
-      height: 100%;
+      position: absolute;
     }
     .secret-podcast-2022__copy__button__caption {
       margin-bottom: 4px;


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

The Wordiply thrasher doesn't display correctly on the Android app - the background is cut off so the "Play" button appears to partly hang outside the thrasher.

The thrasher background colour is applied to parent container. The child container with the contents, including the button is placed with `float: left`.

This change is to replace the height style on the parent container with an absolute position instead.

## How to test

Not sure. There are some instructions here: https://github.com/guardian/interactive-atom-thrasher-template?tab=readme-ov-file#apps-compatibility

I tested the live thrasher by making the changes in chrome dev tools inspector.

## How can we measure success?

The thrasher displays correctly on the Android app

## Have we considered potential risks?

No, but we should also test on iOS - the changed CSS applies to both (it's currently broken on both too).

## Images

| Before | After |
|--------|--------|
| ![wordiply-before](https://github.com/guardian/interactive-atom-thrasher-template/assets/79363218/470a1c21-c968-4e24-905c-45f496e2cc4b) | ![Screenshot_20240528_170022](https://github.com/guardian/interactive-atom-thrasher-template/assets/79363218/7c5e1929-8d4e-4358-bd0b-d5416d9eb4b3) |

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
