### PR TITLE
change image on sets 11, 12, and 13 for the whats-on relaunch

### DIFF
--- a/atoms/set-11/server/templates/main.html
+++ b/atoms/set-11/server/templates/main.html
@@ -19,7 +19,7 @@
                         <h2 class="newsletter-card__title">What's On</h2>
                     
                         <div class="newsletter-card__inner">
-                            <img class="newsletter-card__image" src="<%= path %>/whats-on-square.png" alt="What's On newsletter image" height="100" width="100">
+                            <img class="newsletter-card__image" src="https://uploads.guim.co.uk/2024/08/14/whats-on-square-new.png" alt="What's On newsletter image" height="100" width="100">
                             <div class="newsletter-card__content">
                                 <div class="newsletter-card__frequency-block">
                                     <svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/atoms/set-12/server/templates/main.html
+++ b/atoms/set-12/server/templates/main.html
@@ -19,7 +19,7 @@
                         <h2 class="newsletter-card__title">What's On</h2>
                     
                         <div class="newsletter-card__inner">
-                            <img class="newsletter-card__image" src="<%= path %>/whats-on-square.png" alt="What's On newsletter image" height="100" width="100">
+                            <img class="newsletter-card__image" src="https://uploads.guim.co.uk/2024/08/14/whats-on-square-new.png" alt="What's On newsletter image" height="100" width="100">
                             <div class="newsletter-card__content">
                                 <div class="newsletter-card__frequency-block">
                                     <svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/atoms/set-13/server/templates/main.html
+++ b/atoms/set-13/server/templates/main.html
@@ -51,7 +51,7 @@
                         <h2 class="newsletter-card__title">What's On</h2>
                     
                         <div class="newsletter-card__inner">
-                            <img class="newsletter-card__image" src="<%= path %>/whats-on-square.png" alt="What's On newsletter image" height="100" width="100">
+                            <img class="newsletter-card__image" src="https://uploads.guim.co.uk/2024/08/14/whats-on-square-new.png" alt="What's On newsletter image" height="100" width="100">
                             <div class="newsletter-card__content">
                                 <div class="newsletter-card__frequency-block">
                                     <svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
## What does this change?

Updates the image used in triples for what'on.

Sets 11, 12 and 13

## How to test

Run the project and have a look

## How can we measure success?

With great care, and, by looking at the images

## Have we considered potential risks?

Always

## Images

<img width="1223" alt="Screenshot 2024-08-14 at 10 48 52" src="https://github.com/user-attachments/assets/4467281f-228b-4467-b2f7-674f430a00e8">

